### PR TITLE
Lots of additions and improvements to detector state page

### DIFF
--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -246,11 +246,15 @@ def translate_caen_trigger(trig_source_mask,trig_out_mask):
     ret["software_trigger"] = [(trig_source_mask & 1<<31) > 0, (trig_out_mask & 1<< 31 )> 0]
     return ret
 
+
 @app.template_filter('caen_human_readable')
 def caen_human_readable_filter(caen):
     ret = {}
     try:
         ret['post_trigger'] = caen['post_trigger']
+        ret['enabled_channels'] = \
+            map(lambda x: (1 << x & caen['channel_mask']) > 0, range(8))
+
         ret.update(translate_caen_front_panel_io_control(caen['front_panel_io_control']))
         ret.update(translate_caen_acquisition_control(caen['front_panel_io_control']))
         ret.update(translate_caen_channel_configuaration(caen['channel_configuration']))

--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -251,7 +251,7 @@ def translate_caen_trigger(trig_source_mask,trig_out_mask):
 def caen_human_readable_filter(caen):
     ret = {}
     try:
-        ret['post_trigger'] = caen['post_trigger']
+        ret['post_trigger'] = caen['post_trigger']*4
         ret['enabled_channels'] = \
             map(lambda x: (1 << x & caen['channel_mask']) > 0, range(8))
 

--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -21,7 +21,7 @@ def get_latest_trigger_scans():
     conn.close()
 
     if result is None:
-	return None
+        return None
 
     keys = result.keys()
     rows = result.fetchall()
@@ -64,7 +64,7 @@ def get_trigger_scan_for_run(run):
     return dict(zip(names,results))
 def get_detector_control_state(key):
     return fetch_from_table_with_key('detector_control',key)
-    
+
 def get_caen_state(key):
     return fetch_from_table_with_key('caen',key)
 
@@ -174,6 +174,7 @@ def translate_mtca_dacs(dacs):
     ret["OWLE HI"] = dacs[9]
     #Not bothering with the spares (for now) (or ever probably)
     return ret;
+
 @app.template_filter('mtc_human_readable')
 def mtc_human_readable_filter(mtc):
     ret = {}

--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -88,6 +88,8 @@ def get_fec_state(key):
 def get_run_state(run):
     return fetch_from_table_with_key('run_state',run,key_name='run')
 
+
+
 def translate_trigger_mask(maskVal):
     trigger_bit_to_string = [
                                 (0 ,"NHIT100LO"),

--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -313,6 +313,8 @@ def fec_human_readable_filter(fec):
         ret['MB_ID'] = '0x%x' % fec['mbid']
         ret['sequencers'] = translate_fec_disable_mask(fec['disable_mask'])
         ret['num_sequencers'] = len(filter(None,ret['sequencers']))
+        ret['vbal_0'] = fec['vbal_0']
+        ret['vbal_1'] = fec['vbal_1']
     except Exception as e:
         print "FEC translation error : %s" % e
         return False

--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -259,7 +259,16 @@ def caen_human_readable_filter(caen):
         ret.update(translate_caen_acquisition_control(caen['front_panel_io_control']))
         ret.update(translate_caen_channel_configuaration(caen['channel_configuration']))
         ret['buffer_organization'] = hex(caen["buffer_organization"])
-        ret.update(translate_caen_trigger(caen["trigger_mask"],caen["trigger_out_mask"]))
+        ret.update(translate_caen_trigger(caen["trigger_mask"], caen["trigger_out_mask"]))
+
+        # channel_dacs was added to the DB later than everything else.
+        # So a number of runs don't have channel_offset info.
+        # Therefore it's afforded special treatment
+        try:
+            ret['channel_offsets'] = [x/2**16-1.0 for x in caen['channel_dacs']]
+        except TypeError:
+            ret['channel_offsets'] = 0
+
     except Exception as e:
         print "CAEN translation error: %s" % e
         return False

--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -344,15 +344,20 @@ def trigger_scan_string_translate(name):
         return name
     return (name[:index+1]+" "+name[index+1:]).upper()
 
+
 @app.template_filter('trigger_scan_human_readable')
 def trigger_scan_human_readable(trigger_scan):
     if trigger_scan is None:
         return False
     res = {}
-    for name,obj in trigger_scan.iteritems():
-        name = trigger_scan_string_translate(name)
-        vals = False
-        if(obj):
-            vals = (obj['baseline'],obj['adc_per_nhit'])
-        res[name] = vals
+    try:
+        for name, obj in trigger_scan.iteritems():
+            name = trigger_scan_string_translate(name)
+            vals = False
+            if(obj):
+                vals = (obj['baseline'], obj['adc_per_nhit'])
+            res[name] = vals
+    except Exception as e:
+        print "trigger scan translation error: %s" % e
+        return False
     return res

--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -346,6 +346,8 @@ def trigger_scan_string_translate(name):
 
 @app.template_filter('trigger_scan_human_readable')
 def trigger_scan_human_readable(trigger_scan):
+    if trigger_scan is None:
+        return False
     res = {}
     for name,obj in trigger_scan.iteritems():
         name = trigger_scan_string_translate(name)

--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -88,8 +88,6 @@ def get_fec_state(key):
 def get_run_state(run):
     return fetch_from_table_with_key('run_state',run,key_name='run')
 
-
-
 def translate_trigger_mask(maskVal):
     trigger_bit_to_string = [
                                 (0 ,"NHIT100LO"),

--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -18,6 +18,8 @@ def get_latest_trigger_scans():
 
     result = conn.execute("select distinct on (name) * from trigger_scan order by name, key desc")
 
+    conn.close()
+
     if result is None:
 	return None
 
@@ -35,13 +37,13 @@ def fetch_from_table_with_key(table_name, key, key_name='key'):
     command = "SELECT * FROM %s WHERE %s = %s" % (table_name, key_name, key)
     res =  conn.execute(command)
 
+    conn.close()
     try:
         values = zip(res.keys(),res.fetchone())
     except TypeError:
         # Chances are this failed b/c the SELECT command didn't find anything
         raise ValueError("%s %s is not valid...probably" % (key_name, key))
 
-    conn.close()
 
     return dict(values)
 

--- a/minard/static/css/detector_state.css
+++ b/minard/static/css/detector_state.css
@@ -6,17 +6,6 @@
     fill:green;
     background-color:green
 }
-tr.on{
-    color:green;
-    font-weight:bold;
-    fill:initial;
-    background-color:initial
-}
-tr.off{
-    fill:initial;
-    background-color:initial
-
-}
 .off{
     fill:grey;
     background-color:grey;

--- a/minard/static/css/detector_state.css
+++ b/minard/static/css/detector_state.css
@@ -1,6 +1,12 @@
+.unknown{
+    fill:#e0e0e0;
+    background-color:#e0e0e0;
+}
 .on{
     fill:green;
+    background-color:green
 }
 .off{
-    fill:red;
+    fill:grey;
+    background-color:grey;
 }

--- a/minard/static/css/detector_state.css
+++ b/minard/static/css/detector_state.css
@@ -6,6 +6,17 @@
     fill:green;
     background-color:green
 }
+tr.on{
+    color:green;
+    font-weight:bold;
+    fill:initial;
+    background-color:initial
+}
+tr.off{
+    fill:initial;
+    background-color:initial
+
+}
 .off{
     fill:grey;
     background-color:grey;

--- a/minard/static/css/detector_state.css
+++ b/minard/static/css/detector_state.css
@@ -1,18 +1,6 @@
-.crate_mask circle{
-    opacity:0.75;
-}
-.crate_mask circle.on{
+.on{
     fill:green;
 }
-.crate_mask circle.off{
-    fill:grey;
-}
-.rack_mask circle{
-    opacity:0.75;
-}
-.rack_mask circle.on{
-
-}
-.rack_mask circle.off{
-    fill:grey;
+.off{
+    fill:red;
 }

--- a/minard/static/js/crate.js
+++ b/minard/static/js/crate.js
@@ -135,8 +135,6 @@ function crate_view() {
                     return 'background-color:' + scale(+v);
         }};}
         function stylingFunction(node,data) {
-                console.log(attribute);
-                console.log(node);
                 node.attr(attribute,coloringFunction(data));
         }
 
@@ -152,7 +150,7 @@ function crate_view() {
         }
         return stylingFunction;
     }
-    stylingFunction = MakeStylingFunction();
+    var stylingFunction = MakeStylingFunction();
 
     function chart(selection) {
         selection.each(function(data) {
@@ -187,8 +185,8 @@ function crate_view() {
 
         var td = tr2.selectAll('td')
             .data(function(d) { return d; }, function(d) { return d; })
-            .enter().append('td')
-            .attr('style','background-color:#e0e0e0');
+            .enter().append('td');
+//.attr('style','background-color:#e0e0e0');
 
         var select = d3.select(this).selectAll('#crate-view div table tr td')
 
@@ -233,8 +231,8 @@ function crate_view() {
     }
 
     chart.stylingFunction = function(value) {
-        if(!arguments.length) return coloringFunction;
-        coloringFunction = value;
+        if(!arguments.length) {return stylingFunction;}
+        stylingFunction = value;
         return chart;
     }
 

--- a/minard/static/js/crate.js
+++ b/minard/static/js/crate.js
@@ -123,15 +123,36 @@ function crate_view() {
 
     var scale = d3.scale.threshold().domain([100]).range(['#bababa','#ca0020']);
 
-    var coloringFunction = function(data) {
-        return function(k, i) {
-            var v = data[k];
-            if (v === null || typeof v === 'undefined' || v === 0) {
-                return 'background-color:#e0e0e0';
-            }
-            else {
-                return 'background-color:' + scale(+v);
-    }};}
+    function MakeStylingFunction(){
+        var attribute = 'style';
+        var coloringFunction = function(data) {
+            return function(k, i) {
+                var v = data[k];
+                if (v === null || typeof v === 'undefined' || v === 0) {
+                    return 'background-color:#e0e0e0';
+                }
+                else {
+                    return 'background-color:' + scale(+v);
+        }};}
+        function stylingFunction(node,data) {
+                console.log(attribute);
+                console.log(node);
+                node.attr(attribute,coloringFunction(data));
+        }
+
+        stylingFunction.attribute = function(value) {
+            if(!arguments.length) return attribute;
+            attribute = value;
+            return stylingFunction;
+        }
+        stylingFunction.coloringFunction = function(value) {
+            if(!arguments.length) return coloringFunction;
+            coloringFunction = value;
+            return stylingFunction;
+        }
+        return stylingFunction;
+    }
+    stylingFunction = MakeStylingFunction();
 
     function chart(selection) {
         selection.each(function(data) {
@@ -171,8 +192,9 @@ function crate_view() {
 
         var select = d3.select(this).selectAll('#crate-view div table tr td')
 
-        select.attr('style',coloringFunction(data));
+        stylingFunction(select,data);
     });}
+
     chart.height = function(value) {
         if (!arguments.length) return height;
         height = value;
@@ -209,7 +231,8 @@ function crate_view() {
         scale = d3.scale.threshold().domain([threshold]).range(['#bababa','#ca0020']);
         return chart;
     }
-    chart.coloringFunction = function(value) {
+
+    chart.stylingFunction = function(value) {
         if(!arguments.length) return coloringFunction;
         coloringFunction = value;
         return chart;

--- a/minard/static/js/crate.js
+++ b/minard/static/js/crate.js
@@ -121,6 +121,8 @@ function crate_view() {
 
     var caption = true;
 
+    var hover_text = false;
+
     var scale = d3.scale.threshold().domain([100]).range(['#bababa','#ca0020']);
 
     function MakeStylingFunction(){
@@ -173,7 +175,6 @@ function crate_view() {
             .attr("id", function(d, i) { return "crate" + i;})
           .append('table')
             .attr('style','padding:2px;border-collapse:separate;border-spacing:1px')
-            .attr('title', function(d, i) { return 'Crate ' + i; });
 
         if (caption) {
             tr1.insert('caption').text(function(d, i) { return i; })
@@ -186,7 +187,17 @@ function crate_view() {
         var td = tr2.selectAll('td')
             .data(function(d) { return d; }, function(d) { return d; })
             .enter().append('td');
-//.attr('style','background-color:#e0e0e0');
+        if(hover_text){
+            if(typeof hover_text === "function"){
+                td.attr('title',hover_text(data));
+            }
+            else{
+                td.attr('title',hover_text);
+            }
+        }
+        else{
+            tr1.attr('title', function(d, i) { return 'Crate ' + i; });
+        }
 
         var select = d3.select(this).selectAll('#crate-view div table tr td')
 
@@ -233,6 +244,12 @@ function crate_view() {
     chart.stylingFunction = function(value) {
         if(!arguments.length) {return stylingFunction;}
         stylingFunction = value;
+        return chart;
+    }
+
+    chart.hover_text = function(value) {
+        if(!arguments.length) {return hover_text;}
+        hover_text = value;
         return chart;
     }
 

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -20,20 +20,31 @@ function display_binary_crate_view(key,crates_data,sizeinfo,node)
 }
 function display_continuous_crate_view(key,crates_data,sizeinfo,node)
 {
+    // This function draws a crate view at the given node and returns
+    // a function that will re-draw view for different colors.
+    //
     // For now this just assumes a linear scale from 0-255.
     // May have to generalize at some point.
-    var scale = d3.scale.linear().domain([0,255]).range(['#6666ff','#ffcc00']);
-    var coloringFunc = function(data) {
-        return function(k, i) {
-            var v = data[k];
-            if (v === null || typeof v === 'undefined') {
-                return 'background-color:#e0e0e0';
-            }
-            else {
+    function draw_continous_crate_view(color_scale){
+        var scale = d3.scale.linear().domain([0,255]).range(color_scale);
+        var coloringFunc = function(data) {
+            return function(k, i) {
+                var v = data[k];
+                if (v === null || typeof v === 'undefined') {
+                    return 'background-color:#e0e0e0';
+                }
+                else {
 
-                return 'background-color:' + scale(+v);
-    }};}
-    display_crate_view(key,crates_data,sizeinfo,node,{'attrib':'style','func':coloringFunc});
+                    return 'background-color:' + scale(+v);
+        }};}
+        return display_crate_view(key,crates_data,sizeinfo,node,{'attrib':'style','func':coloringFunc});
+    }
+    crate_node = draw_continous_crate_view(colorbrewer['BuPu'][3]);
+    function redraw(color_scale){
+        node.select("#crate").remove()
+        draw_continous_crate_view(color_scale)
+    }
+    return redraw
 }
 function display_crate_view(key,crates_data,sizeinfo,node,styling)
 {
@@ -151,7 +162,6 @@ function display_triggers(node,wordlist) {
 
 function display_ped_delay(node,delay) {
     node.append("h3").text("Pedestal Delay = "+ delay.toString() +"ns");
-
 };
 
 function display_lockout_width(node,lockout) {

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -26,7 +26,7 @@ function display_binary_crate_view(key,crates_data,sizeinfo,node)
     return function(d,i) {
         v = data[d];
         if(v == null){
-            return "Unknown";
+            return "Unknown/Crate Off";
         }
         else if(v ==0){
             return "off";
@@ -141,7 +141,7 @@ function display_continuous_crate_view(key,crates_data,sizeinfo,color_scale,node
         return function(d,i) {
             v = data[d];
             if(v == null){
-                return "Unknown";
+                return "Unknown/Crate Off";
             }
             return v;
         }};

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -314,7 +314,11 @@ function display_caen(node,caen_info) {
     var size_info = {};
     size_info['width'] = node.node().parentElement.parentElement.parentElement.clientWidth;
     size_info['height'] = 25;
-    display_bit_mask(caen_info.enabled_channels,node,"Enabled Channels" ,size_info);
+    channel_text = function(d,i){
+        str = "Channel "+i+": ";
+        return str +(d ? "enabled" : "disabled");
+    }
+    display_bit_mask(caen_info.enabled_channels,node,"Enabled Channels" ,size_info,channel_text);
     node.append('h4').text("Acquisition Mode = "+caen_info.acquisition_mode);
     node.append('h4').text("Trigger Logic Levels = "+caen_info.trigger_voltage_level);
     node.append('h4').text("Number of Post Trigger Samples = "+ caen_info.post_trigger);

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -555,8 +555,13 @@ function display_mtc(node,mtc_data){
     var size_info ={};
     size_info['width']= node.node().parentElement.parentElement.clientWidth
     size_info['height']= 25;
-    display_bit_mask(mtc_data.gt_crates,node,"GT",size_info);
-    display_bit_mask(mtc_data.ped_crates,node,"PED",size_info);
+    mtcd_mask_text_factory = function(name) {
+        return function(d,i) {
+            return "Sending "+name+" signal to crate "+i+": "+(d ? "enabled" : "disabled");
+        }
+    }
+    display_bit_mask(mtc_data.gt_crates,node,"GT",size_info,mtcd_mask_text_factory("GT"));
+    display_bit_mask(mtc_data.ped_crates,node,"PED",size_info,mtcd_mask_text_factory("PED"));
 
     node.append('h3')
         .text("MTCA Relays")
@@ -564,13 +569,18 @@ function display_mtc(node,mtc_data){
         .attr('class',"col-xs-12")
         .append('hr');
 
-    display_bit_mask(mtc_data.N100_crates,node,"N100",size_info);
-    display_bit_mask(mtc_data.N20_crates,node,"N20",size_info);
-    display_bit_mask(mtc_data.ESUMHI_crates,node,"ESUM HI",size_info);
-    display_bit_mask(mtc_data.ESUMLO_crates,node,"ESUM LO",size_info);
-    display_bit_mask(mtc_data.OWLELO_crates,node,"OWLE LO",size_info);
-    display_bit_mask(mtc_data.OWLEHI_crates,node,"OWLE HI",size_info);
-    display_bit_mask(mtc_data.OWLN_crates,node,"OWLN",size_info);
+    mtca_relay_text_factory = function(name){
+        return function(d,i){
+            return "Summing "+name+" from crate "+i+": "+(d ? "enabled" : "disabled");
+        }
+    }
+    display_bit_mask(mtc_data.N100_crates,node,"N100",size_info,mtca_relay_text_factory("N100"));
+    display_bit_mask(mtc_data.N20_crates,node,"N20",size_info,mtca_relay_text_factory("N100"));
+    display_bit_mask(mtc_data.ESUMHI_crates,node,"ESUM HI",size_info,mtca_relay_text_factory("ESUM HI"));
+    display_bit_mask(mtc_data.ESUMLO_crates,node,"ESUM LO",size_info,mtca_relay_text_factory("ESUM LO"));
+    display_bit_mask(mtc_data.OWLELO_crates,node,"OWLE LO",size_info,mtca_relay_text_factory("OWLE LO"));
+    display_bit_mask(mtc_data.OWLEHI_crates,node,"OWLE HI",size_info,mtca_relay_text_factory("OWLE HI"));
+    display_bit_mask(mtc_data.OWLN_crates,node,"OWLN",size_info,mtca_relay_text_factory("OWLN"));
 }
 
 function display_mtca_thresholds(node,dacs,trigger_scan,enabled_dacs){

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -361,22 +361,58 @@ function display_dictionary_as_list(node,dict,title) {
         .text(function(d) { return d+' = '+dict[d].toString();});
 
 }
-function display_mtca_thresholds(node,dacs,trigger_scan){
 
-    function dac_to_volts(value) { return (10.0/4096)*value - 5.0; }
-    volt_dict = {}
-    for(var key in dacs) {
-        var dac_count = dacs[key];
-        volt_dict[key] = dac_to_volts(dac_count).toFixed(2)+"V";
-        if(trigger_scan[key]) {
-            var baseline = trigger_scan[key][0];
-            var adc_to_nhit = trigger_scan[key][1];
-            var nhits = (dac_count - baseline)*adc_to_nhit;
-            volt_dict[key] += " = "+nhits.toFixed(1)+" NHit";
+function get_enabled_dacs(dacs,gt_mask)
+{
+    console.log(dacs);
+    console.log(gt_mask);
+    keys = Object.keys(dacs)
+    new_dict = {};
+    for(var i=0;i<keys.length;i++)
+    {
+        if(gt_mask.includes(keys[i].replace(' ','')))
+        {
+            new_dict[keys[i]] = dacs[keys[i]];
         }
     }
+    console.log(new_dict);
+    return new_dict;
+}
+function display_mtca_thresholds(node,dacs,trigger_scan){
+    function dac_to_volts(value) { return (10.0/4096)*value - 5.0; }
+    volt_dict = {}
 
-    display_dictionary_as_list(node,volt_dict,'MTCA Thresholds');
+    table = node.append('table').attr('class','table')
+    head = table.append('thead').append('tr')
+    head.append('th').text('Name')
+    head.append('th').text('Volts')
+    head.append('th').text('NHits')
+
+    keys = Object.keys(dacs)
+    table.append('tbody')
+        .selectAll('tr')
+        .data(keys)
+        .enter()
+        .append('tr')
+        .selectAll('td')
+        .data( function(key,i) {
+            dac_count = dacs[key];
+            volts = dac_to_volts(dac_count).toFixed(2);
+            nHit = '-';
+            if(trigger_scan[key])
+            {
+                baseline = trigger_scan[key][0];
+                adc_to_nhit = trigger_scan[key][1];
+                nHit = (dac_count - baseline)*adc_to_nhit;
+                nHit = nHit.toFixed(0)
+            }
+            return [key,volts,nHit];
+        })
+        .enter()
+        .append('td')
+        .text( function(row,i) {
+            return row;
+        });
 }
 function display_crate_mask(mask,dom_node,title,size_info) {
     var width = size_info.width;

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -488,7 +488,10 @@ function get_enabled_dacs(dacs,gt_mask)
     new_dict = {};
     for(var i=0;i<keys.length;i++)
     {
-        if(gt_mask.includes(keys[i].replace(' ','')))
+        if(gt_mask.includes(
+                keys[i].replace(' ','')
+                .replace('N100','NHIT100')
+                .replace('N20',"NHIT20")))
         {
             new_dict[keys[i]] = dacs[keys[i]];
         }

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -364,8 +364,6 @@ function display_dictionary_as_list(node,dict,title) {
 
 function get_enabled_dacs(dacs,gt_mask)
 {
-    console.log(dacs);
-    console.log(gt_mask);
     keys = Object.keys(dacs)
     new_dict = {};
     for(var i=0;i<keys.length;i++)
@@ -375,7 +373,6 @@ function get_enabled_dacs(dacs,gt_mask)
             new_dict[keys[i]] = dacs[keys[i]];
         }
     }
-    console.log(new_dict);
     return new_dict;
 }
 function display_mtca_thresholds(node,dacs,trigger_scan){
@@ -566,7 +563,7 @@ function create_color_picker(node,title,class_name) {
             .attr("cy",10)
             .attr("r",8)
             .attr("fill",color)
-            .on("click",change_colors );
+            .on("click",change_colors);
     }
 
         title_node.append('p').text(title)

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -515,7 +515,7 @@ function display_mtca_thresholds(node,dacs,trigger_scan,enabled_dacs){
             { return ""; }
             if(enabled_dacs && enabled_dacs[key])
             { return 'on'; }
-            return '';
+            return 'off';
         })
         .selectAll('td')
         .data( function(key,i) {
@@ -651,7 +651,9 @@ function crate() {
     var width = 780;
     var height = 80;
 
-    function my(){ }
+    function my(){
+
+    }
     my.width = function(value) {
         if(!arguments.length) {
             return width;
@@ -669,11 +671,9 @@ function crate() {
     return my;
 }
 function change_colors(class_name,color) {
-    crate_elements = d3.selectAll("td."+class_name)
-    text_elements = d3.selectAll("tr."+class_name)
-    other_elements = d3.selectAll("."+class_name+":not(tr):not(td)")
-    crate_elements.attr("style","background-color:"+color)
-    other_elements.attr("style","fill:"+color);
-    text_elements = d3.selectAll("tr."+class_name);
-    text_elements.attr("style","color:"+color);
+    var cols = document.getElementsByClassName(class_name);
+    for(i=0;i<cols.length;i++) {
+        cols[i].style.fill = color;
+        cols[i].style['background-color'] = color;
+    }
 }

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -515,7 +515,7 @@ function display_mtca_thresholds(node,dacs,trigger_scan,enabled_dacs){
             { return ""; }
             if(enabled_dacs && enabled_dacs[key])
             { return 'on'; }
-            return 'off';
+            return '';
         })
         .selectAll('td')
         .data( function(key,i) {
@@ -651,9 +651,7 @@ function crate() {
     var width = 780;
     var height = 80;
 
-    function my(){
-
-    }
+    function my(){ }
     my.width = function(value) {
         if(!arguments.length) {
             return width;
@@ -671,9 +669,11 @@ function crate() {
     return my;
 }
 function change_colors(class_name,color) {
-    var cols = document.getElementsByClassName(class_name);
-    for(i=0;i<cols.length;i++) {
-        cols[i].style.fill = color;
-        cols[i].style['background-color'] = color;
-    }
+    crate_elements = d3.selectAll("td."+class_name)
+    text_elements = d3.selectAll("tr."+class_name)
+    other_elements = d3.selectAll("."+class_name+":not(tr):not(td)")
+    crate_elements.attr("style","background-color:"+color)
+    other_elements.attr("style","fill:"+color);
+    text_elements = d3.selectAll("tr."+class_name);
+    text_elements.attr("style","color:"+color);
 }

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -514,8 +514,8 @@ function display_mtca_thresholds(node,dacs,trigger_scan,enabled_dacs){
             if(!enabled_dacs)
             { return ""; }
             if(enabled_dacs && enabled_dacs[key])
-            { return 'on'; }
-            return 'off';
+            { return 'success'; }
+            return '';
         })
         .selectAll('td')
         .data( function(key,i) {

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -613,6 +613,7 @@ function display_mtca_thresholds(node,dacs,trigger_scan,enabled_dacs){
     function dac_to_volts(value) { return (10.0/4096)*value - 5.0; }
     volt_dict = {}
 
+    node.append("h3").text("Thresholds");
     table = node.append('table').attr('class','table')
     head = table.append('thead').append('tr')
     head.append('th').text('Name')

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -201,6 +201,7 @@ function get_crates_in_rack(irack) {
     }
     return  [crates_below,crates_below+1];
 }
+
 function num_crates_on(det_cont_info) {
     var count = 0;
     if(det_cont_info['iboot'] == 0)
@@ -218,8 +219,8 @@ function num_crates_on(det_cont_info) {
         }
     }
     return count;
-
 }
+
 function display_detector_control(detector_control_info) {
     var det_cont = d3.select("#detector_control");
     var bounds = det_cont.node().parentElement.parentElement.clientWidth
@@ -229,34 +230,54 @@ function display_detector_control(detector_control_info) {
     radius = step_size/4.0;
     var xpos_func = function(d,i) { return step_size+i*step_size; }
     var ypos_func = function(d,i) { return height/2.0; }
+
     var svg = det_cont.append("svg")
         .attr("width",width)
         .attr("height",height)
         .attr("viewBox","0 0 "+width.toString()+" "+height.toString())
         .attr("class","rack_mask");
+
     var arr = [];
     arr.push(["T",detector_control_info["timing_rack"]]);
     for(var i=1;i<12;i++) {
         arr.push([i.toString(),detector_control_info["rack"+i.toString()]]);
     }
-    svg.selectAll('circle')
+    nodes = svg.append('g').selectAll('circle')
         .data(arr)
         .enter()
-        .append('circle')
-        .attr("cx",xpos_func)
-        .attr("cy",ypos_func)
+        .append('g')
+        .attr("transform",function(d,i){
+            d.x = xpos_func(d,i);
+            d.y = ypos_func(d,i);
+            return "translate(" + d.x+","+d.y+")";
+        });
+
+    nodes.append("title").text(function(d,i){
+        str = ""
+        if(d[0] == "T"){ str = "Timing Rack: ";}
+        else {
+            crates = get_crates_in_rack(d[0])
+            crate_str = "";
+            if(crates.length == 1){
+                crate_str = "crate "+crates[0];
+            }
+            else{
+                crate_str = "crates "+crates[0]+" and "+crates[1];
+            }
+            str = "Rack "+d[0]+" ("+crate_str+"): ";
+        }
+        str = str + (d[1]==1 ? 'on' : 'off');
+        return str;
+    });
+    nodes.append('circle')
         .attr("r",radius)
         .attr("class",function(d) { return d[1]==1 ? 'on' : 'off'; });
-    svg.selectAll('text')
-        .data(arr)
-        .enter()
-        .append('text')
+    nodes.append('text')
         .text(function(d){return d[0];})
         .attr("text-anchor","middle")
         .attr("font-size","16px")
         .attr("fill","white")
-        .attr("x",xpos_func)
-        .attr("y",function(d,i) { return ypos_func(d,i)+5;});
+        .attr("y",function(d,i) { return 5;});
 }
 
 function display_triggers(node,wordlist) {

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -533,12 +533,16 @@ function display_run_type(run_type,time_stamp) {
     if(det_state_desc.length > 0){
         appendToTitle('h3',det_state_desc);
     }
+
+    // The date object passed in from the DB has no timezone info,
+    // so JS assumes it's in GMT. So by printing it as a GMT time
+    // then editing the output timezone info in the string you
+    // end up at the right answer.
+    // Unfortunately the user has no way of seeing if the time is EST or EDT.
     date = new Date(Date.parse(time_stamp))
-    str= date.toString()
-    // This will probably break during when changing to/from DST
-    // JS doesn't seem to contain a good way for displaying a date with a tz
-    str = str.replace('GMT-0400 ','').replace('GMT-0500 ','')
-    str = str.replace('(EDT)','EDT').replace('(EST)','EST')
+    str= date.toUTCString()
+    str = str.replace('GMT','Eastern')
+
     appendToTitle('p',str);
 };
 function crate() {

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -584,5 +584,10 @@ function create_color_picker(node,title,class_name) {
                 append_square(row.append("th"),colors[i*colors_per_row+j]);
             }
         }
+function change_colors(class_name,color) {
+    var cols = document.getElementsByClassName(class_name);
+    for(i=0;i<cols.length;i++) {
+        cols[i].style.fill = color;
+        cols[i].style['background-color'] = color;
     }
 }

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -575,7 +575,7 @@ function display_mtc(node,mtc_data){
         }
     }
     display_bit_mask(mtc_data.N100_crates,node,"N100",size_info,mtca_relay_text_factory("N100"));
-    display_bit_mask(mtc_data.N20_crates,node,"N20",size_info,mtca_relay_text_factory("N100"));
+    display_bit_mask(mtc_data.N20_crates,node,"N20",size_info,mtca_relay_text_factory("N20"));
     display_bit_mask(mtc_data.ESUMHI_crates,node,"ESUM HI",size_info,mtca_relay_text_factory("ESUM HI"));
     display_bit_mask(mtc_data.ESUMLO_crates,node,"ESUM LO",size_info,mtca_relay_text_factory("ESUM LO"));
     display_bit_mask(mtc_data.OWLELO_crates,node,"OWLE LO",size_info,mtca_relay_text_factory("OWLE LO"));

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -1,9 +1,15 @@
 function flattenArray(arr) {
     return [].concat.apply([],arr);
 }
+function linspace(min, max, N) {
+    var a = [];
+    for (var i=0; i < N; i++) {
+        a[i] = min + (max-min)*i/(N-1);
+    }
+    return a;
+}
 function display_binary_crate_view(key,crates_data,sizeinfo,node)
 {
-    //color_on = getComputedStyle(document.querySelector('.on')).fill;
     var coloringFunc = function(data) {
         return function(k,i) {
         var v = data[k];
@@ -61,7 +67,7 @@ function display_continuous_crate_view(key,crates_data,sizeinfo,color_scale,node
     // For now this just assumes a linear scale from 0-255.
     // May have to generalize at some point.
     function draw_continous_crate_view(color_scale){
-        var scale = d3.scale.linear().domain([0,255]).range(color_scale);
+        var scale = d3.scale.linear().domain(linspace(0,255,color_scale.length)).range(color_scale);
         var coloringFunc = function(data) {
             return function(k, i) {
                 var v = data[k];
@@ -69,8 +75,7 @@ function display_continuous_crate_view(key,crates_data,sizeinfo,color_scale,node
                     return 'background-color:#e0e0e0';
                 }
                 else {
-
-                    return 'background-color:' + scale(+v);
+                    return 'background-color:' + scale(v);
         }};}
         return display_crate_view(key,crates_data,sizeinfo,node,{'attrib':'style','func':coloringFunc});
     }

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -555,11 +555,16 @@ function display_mtc(node,mtc_data){
     var size_info ={};
     size_info['width']= node.node().parentElement.parentElement.clientWidth
     size_info['height']= 25;
-    mtcd_mask_text_factory = function(name) {
-        return function(d,i) {
-            return "Sending "+name+" signal to crate "+i+": "+(d ? "enabled" : "disabled");
+
+    text_factory =function(verb,direction){
+        return function(name){
+            return function(d,i) {
+                return verb+" "+name+" signal "+direction+" crate "+i+": "+(d ? "enabled" : "disabled");
+            }
         }
     }
+    mtcd_mask_text_factory = text_factory("Sending","to");
+
     display_bit_mask(mtc_data.gt_crates,node,"GT",size_info,mtcd_mask_text_factory("GT"));
     display_bit_mask(mtc_data.ped_crates,node,"PED",size_info,mtcd_mask_text_factory("PED"));
 
@@ -569,11 +574,7 @@ function display_mtc(node,mtc_data){
         .attr('class',"col-xs-12")
         .append('hr');
 
-    mtca_relay_text_factory = function(name){
-        return function(d,i){
-            return "Summing "+name+" from crate "+i+": "+(d ? "enabled" : "disabled");
-        }
-    }
+    mtca_relay_text_factory = text_factory("Summing","from");
     display_bit_mask(mtc_data.N100_crates,node,"N100",size_info,mtca_relay_text_factory("N100"));
     display_bit_mask(mtc_data.N20_crates,node,"N20",size_info,mtca_relay_text_factory("N20"));
     display_bit_mask(mtc_data.ESUMHI_crates,node,"ESUM HI",size_info,mtca_relay_text_factory("ESUM HI"));

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -540,50 +540,6 @@ function crate() {
     }
     return my;
 }
-function create_color_picker(node,title,class_name) {
-    var title_node = node.selectAll(".dropdown_title");
-    var menu_node = node.select(".dropdown-menu");
-    var colors= ['aqua', 'black', 'blue', 'fuchsia', 'gray', 'green',
-    'lime', 'maroon', 'navy', 'olive', 'orange', 'purple','lightpurlpe',
-    'red', 'silver', 'teal', 'azure', 'yellow', 'beige','darkslategrey'];
-
-    function append_square(node,color) {
-        function change_colors() {
-            var cols = document.getElementsByClassName(class_name);
-            for(i=0;i<cols.length;i++) {
-                cols[i].style.fill = color;
-                cols[i].style['background-color'] = color;
-            }
-        }
-        node.append('svg')
-            .attr("width",20)
-            .attr('height',20)
-            .append('circle')
-            .attr("cx",10)
-            .attr("cy",10)
-            .attr("r",8)
-            .attr("fill",color)
-            .on("click",change_colors);
-    }
-
-        title_node.append('p').text(title)
-        title_node.append('svg')
-            .attr("width",20)
-            .attr('height',20)
-            .append('circle')
-            .attr("cx",10)
-            .attr("cy",10)
-            .attr("r",8)
-            .attr("class",class_name);
-
-    var colors_per_row = 10
-    for(var i = 0;i<Math.ceil(colors.length/colors_per_row);i++) {
-        row = menu_node.append("tr");
-        for(var j = 0;j<colors_per_row;j++) {
-            if(i*colors_per_row+j < colors.length){
-                append_square(row.append("th"),colors[i*colors_per_row+j]);
-            }
-        }
 function change_colors(class_name,color) {
     var cols = document.getElementsByClassName(class_name);
     for(i=0;i<cols.length;i++) {

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -174,9 +174,8 @@ function display_crate_view(key,crates_data,sizeinfo,node,styling)
             .attr('class',"col-md-10 col-md-offset-1");
     g.datum(d).call(crate);
 }
-function get_crates_in_rack(irack) {
+function num_crates_in_rack(irack) {
     if(irack>11 || irack <=0) {
-        //Maybe should error?
         return 0;
     }
     if([3,7,10].indexOf(irack) != -1)
@@ -184,6 +183,23 @@ function get_crates_in_rack(irack) {
         return 1;
     }
     return 2;
+}
+function get_crates_in_rack(irack) {
+    if (irack>11 || irack<= 0)
+    {return -1;}
+    if(typeof(irack) != 'number'){
+        irack = parseInt(irack);
+    }
+    crates_below = 0;
+    for(var i=1; i<irack;i++){
+        crates_below += num_crates_in_rack(i);
+    }
+    console.log(irack+" "+num_crates_in_rack(irack));
+    if(num_crates_in_rack(irack) == 1)
+    {
+        return [crates_below];
+    }
+    return  [crates_below,crates_below+1];
 }
 function num_crates_on(det_cont_info) {
     var count = 0;
@@ -196,7 +212,7 @@ function num_crates_on(det_cont_info) {
         if(det_cont_info.hasOwnProperty(key)) {
             if(key.indexOf('rack') != -1 && key.indexOf("timing") == -1) {
                 if(det_cont_info[key]) {
-                    count += get_crates_in_rack(parseInt(key.split('rack')[1]));
+                    count += num_crates_in_rack(parseInt(key.split('rack')[1]));
                 }
             }
         }

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -444,7 +444,7 @@ function get_enabled_dacs(dacs,gt_mask)
     }
     return new_dict;
 }
-function display_mtca_thresholds(node,dacs,trigger_scan){
+function display_mtca_thresholds(node,dacs,trigger_scan,enabled_dacs){
     function dac_to_volts(value) { return (10.0/4096)*value - 5.0; }
     volt_dict = {}
 
@@ -460,6 +460,13 @@ function display_mtca_thresholds(node,dacs,trigger_scan){
         .data(keys)
         .enter()
         .append('tr')
+        .attr('class',function(key) {
+            if(!enabled_dacs)
+            { return ""; }
+            if(enabled_dacs && enabled_dacs[key])
+            { return 'on'; }
+            return 'off';
+        })
         .selectAll('td')
         .data( function(key,i) {
             dac_count = dacs[key];

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -343,7 +343,6 @@ function display_mtca_thresholds(dacs,trigger_scan){
         }
     }
 
-    //Maybe someday tie this into the trigger scan
     display_dictionary_as_list(mtc,volt_dict,'MTCA Thresholds');
 }
 function display_crate_mask(mask,dom_node,title,size_info) {

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -539,6 +539,40 @@ function get_enabled_dacs(dacs,gt_mask)
     }
     return new_dict;
 }
+
+function display_mtc(node,mtc_data){
+
+    display_triggers(node,mtc_data.gt_words);
+
+    enabled_dacs = get_enabled_dacs(mtc_data.MTCA_DACs,mtc_data.gt_words);
+    display_mtca_thresholds(node,mtc_data.MTCA_DACs,trigger_scan,enabled_dacs);
+
+    display_lockout_width(node,mtc_data.lockout_width);
+    display_control_reg(node,mtc_data.control_reg);
+    if(mtc_data.control_reg.filter(function(x) { x.indexOf("PED") > -1;}))
+    {display_ped_delay(node,mtc_data.ped_delay);}
+    display_prescale(node,mtc_data.prescale);
+    var size_info ={};
+    size_info['width']= node.node().parentElement.parentElement.clientWidth
+    size_info['height']= 25;
+    display_bit_mask(mtc_data.gt_crates,node,"GT",size_info);
+    display_bit_mask(mtc_data.ped_crates,node,"PED",size_info);
+
+    node.append('h3')
+        .text("MTCA Relays")
+        .append('div')
+        .attr('class',"col-xs-12")
+        .append('hr');
+
+    display_bit_mask(mtc_data.N100_crates,node,"N100",size_info);
+    display_bit_mask(mtc_data.N20_crates,node,"N20",size_info);
+    display_bit_mask(mtc_data.ESUMHI_crates,node,"ESUM HI",size_info);
+    display_bit_mask(mtc_data.ESUMLO_crates,node,"ESUM LO",size_info);
+    display_bit_mask(mtc_data.OWLELO_crates,node,"OWLE LO",size_info);
+    display_bit_mask(mtc_data.OWLEHI_crates,node,"OWLE HI",size_info);
+    display_bit_mask(mtc_data.OWLN_crates,node,"OWLN",size_info);
+}
+
 function display_mtca_thresholds(node,dacs,trigger_scan,enabled_dacs){
     function dac_to_volts(value) { return (10.0/4096)*value - 5.0; }
     volt_dict = {}

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -33,19 +33,18 @@ function get_colors() {
     return d3.entries(color_scales);
 }
 
-function create_hover_text_color_bar(node,colors)
+function create_hover_text_color_bar(key,node,colors)
 {
-    function draw_bar(colors) {
+    var draw_bar = function(colors) {
         percents = linspace(0,100,colors.length);
         var draw_node = node.append('div')
                 .style("display",'inline')
-                .attr('id','color-bar');
+                .attr('class','color-bar');
         help_ico = draw_node.append('div')
             .attr('class',"glyphicon glyphicon-question-sign");
         var svg = draw_node.append('svg').attr("height",20);
-        var defs = svg.append('defs')
-        var linearGradient = defs.append('linearGradient')
-            .attr('id', 'linear-gradient');
+        var linearGradient = svg.append('linearGradient')
+            .attr('id', key+'-linear-gradient');
         linearGradient
             .attr('x1', '0%')
             .attr('x2', '100%')
@@ -59,7 +58,7 @@ function create_hover_text_color_bar(node,colors)
             .attr('x','10px')
             .attr("width", '95%')
             .attr("height", '100%')
-            .style("fill", "url(#linear-gradient)")
+            .style("fill", "url(#"+key+"-linear-gradient)")
             .attr('rx',6)
             .attr('ry',6)
             .attr('opacity',0)
@@ -70,8 +69,8 @@ function create_hover_text_color_bar(node,colors)
     }
 
     draw_bar(colors);
-    redraw = function(new_colors) {
-        node.select("#color-bar").remove();
+    var redraw = function(new_colors) {
+        node.select(".color-bar").remove();
         draw_bar(new_colors);
     }
     return redraw;

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -760,15 +760,10 @@ function display_run_type(run_type,time_stamp) {
         appendToTitle('h3',det_state_desc);
     }
 
-    // The date object passed in from the DB has no timezone info,
-    // so JS assumes it's in GMT. So by printing it as a GMT time
-    // then editing the output timezone info in the string you
-    // end up at the right answer.
-    // Unfortunately the user has no way of seeing if the time is EST or EDT.
-    date = new Date(Date.parse(time_stamp))
-    str= date.toUTCString()
-    str = str.replace('GMT','Eastern')
-
+    // Passed time stamp is assumed to be in Eastern time.
+    // The DB should always be in Sudbury so this is safe
+    date = moment.tz(time_stamp, "America/Toronto");
+    str = date.format("MMMM Do YYYY - h:mm:ss z");
     appendToTitle('p',str);
 };
 function crate() {

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -85,6 +85,7 @@ function display_colorable_continuous_crate_view(key,crates_data,sizeinfo,node,b
         .attr('class','pull-right');
 
     var color_scales = get_colors()
+
     color_menu.selectAll("option")
         .data(color_scales)
       .enter().append("option")

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -41,7 +41,8 @@ function create_hover_text_color_bar(key,node,colors)
                 .style("display",'inline')
                 .attr('class','color-bar');
         help_ico = draw_node.append('div')
-            .attr('class',"glyphicon glyphicon-question-sign");
+            .attr('class',"glyphicon glyphicon-info-sign")
+            .attr('title', "Color scale 0 - 255");
         var svg = draw_node.append('svg').attr("height",20);
         var linearGradient = svg.append('linearGradient')
             .attr('id', key+'-linear-gradient');

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -76,7 +76,7 @@ function create_hover_text_color_bar(key,node,colors)
     return redraw;
 }
 
-function display_colorable_continuous_crate_view(key,crates_data,sizeinfo,node)
+function display_colorable_continuous_crate_view(key,crates_data,sizeinfo,node,bar_node)
 {
     node = node.append("div").attr("class","colorable_crate");
     color_menu = node.append("select")
@@ -88,16 +88,18 @@ function display_colorable_continuous_crate_view(key,crates_data,sizeinfo,node)
         .data(color_scales)
       .enter().append("option")
         .text(function(d) { return d.key; });
-
     default_index = 2;
     var default_color_scale = color_scales[default_index].value;
     color_menu.property("selectedIndex", default_index);
+
+    var bar_redraw = create_hover_text_color_bar(key, bar_node,default_color_scale);
 
     var redraw = display_continuous_crate_view(key,crates_data,sizeinfo,default_color_scale,node);
 
     function change_color_scale() {
         scale = color_scales[this.selectedIndex].value;
         redraw(scale);
+        bar_redraw(scale);
     }
     color_menu.on("change", change_color_scale);
 }

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -594,24 +594,24 @@ function display_bit_mask(mask,dom_node,title,size_info) {
     var step_size = width/(mask.length+1);
     var xpos_func = function(d,i) { return title_width+i*step_size; }
     var ypos_func = function(d,i) { return height/2.0; }
-    svg.selectAll("circle")
+
+    nodes = svg.append('g').selectAll("circle")
         .data(mask)
         .enter()
-        .append("circle")
-        .attr("cx",xpos_func)
-        .attr("cy",ypos_func)
+        .append('g')
+        .attr('transform',function(d,i){
+            return "translate("+xpos_func(d,i)+", "+ypos_func(d,i)+")";});
+
+    nodes.append("circle")
         .attr("r",height/2.0)
         .attr("class",function(d) { return d ? 'on' : 'off'; })
-    svg.selectAll('text')
-        .data(mask)
-        .enter()
-        .append('text')
+
+    nodes.append('text')
         .text(function(d,i){return i.toString();})
         .attr("text-anchor","middle")
         .attr("font-size","10px")
         .attr("fill","white")
-        .attr("x",xpos_func)
-        .attr("y",function(d,i) { return ypos_func(d,i)+3;});
+        .attr("y",function(d,i) { return 3;});
 };
 function display_run_type(run_type,time_stamp) {
     var run_type_translation = {

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -578,7 +578,7 @@ function display_mtca_thresholds(node,dacs,trigger_scan,enabled_dacs){
             return row;
         });
 }
-function display_bit_mask(mask,dom_node,title,size_info) {
+function display_bit_mask(mask,dom_node,title,size_info,title_text) {
     var width = size_info.width;
     var height =size_info.height;
     dv = dom_node.append("div");
@@ -601,6 +601,11 @@ function display_bit_mask(mask,dom_node,title,size_info) {
         .append('g')
         .attr('transform',function(d,i){
             return "translate("+xpos_func(d,i)+", "+ypos_func(d,i)+")";});
+
+    if(title_text)
+    {
+        nodes.append("title").text(title_text);
+    }
 
     nodes.append("circle")
         .attr("r",height/2.0)

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -18,7 +18,42 @@ function display_binary_crate_view(key,crates_data,sizeinfo,node)
 
     display_crate_view(key,crates_data,sizeinfo,node,{'attrib':'class','func':coloringFunc});
 }
-function display_continuous_crate_view(key,crates_data,sizeinfo,node)
+
+function get_colors() {
+    var color_scales = {};
+    for (var key in colorbrewer) {
+        color_scales[key] = colorbrewer[key][5];
+    }
+    return d3.entries(color_scales);
+}
+
+function display_colorable_continuous_crate_view(key,crates_data,sizeinfo,node)
+{
+    node = node.append("div").attr("class","colorable_crate");
+    color_menu = node.append("select")
+        .attr("id","color-scale-menu")
+        .attr('class','pull-right');
+
+    var color_scales = get_colors()
+    color_menu.selectAll("option")
+        .data(color_scales)
+      .enter().append("option")
+        .text(function(d) { return d.key; });
+
+    default_index = 2;
+    var default_color_scale = color_scales[default_index].value;
+    color_menu.property("selectedIndex", default_index);
+
+    var redraw = display_continuous_crate_view(key,crates_data,sizeinfo,default_color_scale,node);
+
+    function change_color_scale() {
+        scale = color_scales[this.selectedIndex].value;
+        redraw(scale);
+    }
+    color_menu.on("change", change_color_scale);
+}
+
+function display_continuous_crate_view(key,crates_data,sizeinfo,color_scale,node)
 {
     // This function draws a crate view at the given node and returns
     // a function that will re-draw view for different colors.
@@ -39,7 +74,7 @@ function display_continuous_crate_view(key,crates_data,sizeinfo,node)
         }};}
         return display_crate_view(key,crates_data,sizeinfo,node,{'attrib':'style','func':coloringFunc});
     }
-    crate_node = draw_continous_crate_view(colorbrewer['BuPu'][3]);
+    crate_node = draw_continous_crate_view(color_scale);
     function redraw(color_scale){
         node.select("#crate").remove()
         draw_continous_crate_view(color_scale)

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -762,7 +762,7 @@ function display_run_type(run_type,time_stamp) {
     // Passed time stamp is assumed to be in Eastern time.
     // The DB should always be in Sudbury so this is safe
     date = moment.tz(time_stamp, "America/Toronto");
-    str = date.format("MMMM Do YYYY - h:mm:ss z");
+    str = date.format("MMMM Do YYYY - HH:mm:ss z");
     appendToTitle('p',str);
 };
 function crate() {

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -194,7 +194,6 @@ function get_crates_in_rack(irack) {
     for(var i=1; i<irack;i++){
         crates_below += num_crates_in_rack(i);
     }
-    console.log(irack+" "+num_crates_in_rack(irack));
     if(num_crates_in_rack(irack) == 1)
     {
         return [crates_below];

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -327,13 +327,21 @@ function display_dictionary_as_list(node,dict,title) {
         .text(function(d) { return d+' = '+dict[d].toString();});
 
 }
-function display_mtca_thresholds(dacs){
+function display_mtca_thresholds(dacs,trigger_scan){
     var mtc = d3.select('#mtc');
 
     function dac_to_volts(value) { return (10.0/4096)*value - 5.0; }
     volt_dict = {}
-    for(var key in dacs)
-    { volt_dict[key] = dac_to_volts(dacs[key]).toFixed(2)+"V"; }
+    for(var key in dacs) {
+        var dac_count = dacs[key];
+        volt_dict[key] = dac_to_volts(dac_count).toFixed(2)+"V";
+        if(trigger_scan[key]) {
+            var baseline = trigger_scan[key][0];
+            var adc_to_nhit = trigger_scan[key][1];
+            var nhits = (dac_count - baseline)*adc_to_nhit;
+            volt_dict[key] += " = "+nhits.toFixed(1)+" NHit";
+        }
+    }
 
     //Maybe someday tie this into the trigger scan
     display_dictionary_as_list(mtc,volt_dict,'MTCA Thresholds');

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -140,6 +140,7 @@ function display_prescale(prescale) {
 function display_caen(caen_info) {
     var caen = d3.select("#CAEN");
     caen.append('h4').text("Acquisition Mode = "+caen_info.acquisition_mode);
+    display_dictionary_as_list(caen,caen_info,"CAEN");
 };
 function display_tubii(tubii_info) {
     var tubii = d3.select("#tubii");

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -76,6 +76,36 @@ function display_crate_view(key,crates_data,sizeinfo,node,styling)
             .attr('class',"col-md-10 col-md-offset-1");
     g.datum(d).call(crate);
 }
+function get_crates_in_rack(irack) {
+    if(irack>11 || irack <=0) {
+        //Maybe should error?
+        return 0;
+    }
+    if([3,7,10].indexOf(irack) != -1)
+    {
+        return 1;
+    }
+    return 2;
+}
+function num_crates_on(det_cont_info) {
+    var count = 0;
+    if(det_cont_info['iboot'] == 0)
+    {
+        return 0;
+    }
+    for (var key in det_cont_info)
+    {
+        if(det_cont_info.hasOwnProperty(key)) {
+            if(key.indexOf('rack') != -1 && key.indexOf("timing") == -1) {
+                if(det_cont_info[key]) {
+                    count += get_crates_in_rack(parseInt(key.split('rack')[1]));
+                }
+            }
+        }
+    }
+    return count;
+
+}
 function display_detector_control(detector_control_info) {
     var det_cont = d3.select("#detector_control");
     var bounds = det_cont.node().parentElement.parentElement.clientWidth
@@ -114,22 +144,18 @@ function display_detector_control(detector_control_info) {
         .attr("x",xpos_func)
         .attr("y",function(d,i) { return ypos_func(d,i)+5;});
 }
-function display_triggers(wordlist) {
-    var mtc = d3.select('#mtc');
-    display_array_as_list(mtc,wordlist,'Enabled Triggers');
+function display_triggers(node,wordlist) {
+    display_array_as_list(node,wordlist,'Enabled Triggers');
 };
-function display_ped_delay(delay) {
-    var mtc = d3.select('#mtc')
-    mtc.append("h3").text("Pedestal Delay = "+ delay.toString() +"ns");
+function display_ped_delay(node,delay) {
+    node.append("h3").text("Pedestal Delay = "+ delay.toString() +"ns");
 
 };
-function display_lockout_width(lockout) {
-    var mtc = d3.select('#mtc')
-    mtc.append("h3").text("Lockout Width = "+ lockout.toString()+"ns");
+function display_lockout_width(node,lockout) {
+    node.append("h3").text("Lockout Width = "+ lockout.toString()+"ns");
 };
-function display_control_reg(wordlist) {
-    var mtc = d3.select('#mtc')
-    display_array_as_list(mtc,wordlist,'Control Register Values');
+function display_control_reg(node,wordlist) {
+    display_array_as_list(node,wordlist,'Control Register Values');
 };
 function display_crates(title,crates) {
     var mtc = d3.select('#mtc');
@@ -141,8 +167,7 @@ function display_crates(title,crates) {
         .append('li')
         .text(function(d) { return d;});
 };
-function display_prescale(prescale) {
-    var mtc = d3.select('#mtc');
+function display_prescale(node,prescale) {
     mtc.append('h3').text('Prescale = '+prescale.toString());
 };
 function display_caen(caen_info) {
@@ -336,8 +361,7 @@ function display_dictionary_as_list(node,dict,title) {
         .text(function(d) { return d+' = '+dict[d].toString();});
 
 }
-function display_mtca_thresholds(dacs,trigger_scan){
-    var mtc = d3.select('#mtc');
+function display_mtca_thresholds(node,dacs,trigger_scan){
 
     function dac_to_volts(value) { return (10.0/4096)*value - 5.0; }
     volt_dict = {}
@@ -352,7 +376,7 @@ function display_mtca_thresholds(dacs,trigger_scan){
         }
     }
 
-    display_dictionary_as_list(mtc,volt_dict,'MTCA Thresholds');
+    display_dictionary_as_list(node,volt_dict,'MTCA Thresholds');
 }
 function display_crate_mask(mask,dom_node,title,size_info) {
     var width = size_info.width;

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -762,7 +762,7 @@ function display_run_type(run_type,time_stamp) {
     // Passed time stamp is assumed to be in Eastern time.
     // The DB should always be in Sudbury so this is safe
     date = moment.tz(time_stamp, "America/Toronto");
-    str = date.format("MMMM Do YYYY - HH:mm:ss z");
+    str = date.format("ddd, MMM Do YYYY - HH:mm:ss z");
     appendToTitle('p',str);
 };
 function crate() {

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -176,10 +176,27 @@ function display_crates(title,crates) {
 function display_prescale(node,prescale) {
     mtc.append('h3').text('Prescale = '+prescale.toString());
 };
-function display_caen(caen_info) {
-    var caen = d3.select("#CAEN");
-    caen.append('h4').text("Acquisition Mode = "+caen_info.acquisition_mode);
-    display_dictionary_as_list(caen,caen_info,"CAEN");
+
+function display_caen(node,caen_info) {
+    var size_info = {};
+    size_info['width'] = node.node().parentElement.parentElement.parentElement.clientWidth;
+    size_info['height'] = 25;
+    display_bit_mask(caen_info.enabled_channels,node,"Enabled Channels" ,size_info);
+    node.append('h4').text("Acquisition Mode = "+caen_info.acquisition_mode);
+    node.append('h4').text("Trigger Logic Levels = "+caen_info.trigger_voltage_level);
+    node.append('h4').text("Number of Post Trigger Samples = "+ caen_info.post_trigger);
+    node.append('h4').text("LVDS Mode = "+ caen_info.lvds_mode);
+    if (caen_info.channel_offsets){
+        var offset_list = node.append('h4').text("Channel Offsets")
+        node.append('ul')
+            .selectAll('li')
+            .data(caen_info.channel_offsets)
+            .enter()
+            .append('li')
+            .text(function(d,i) {
+                unit = d == 1 || d == -1 ? "Volt" : "Volts";
+                return "Channel "+i+" = "+d+" "+unit;});
+    }
 };
 
 function display_tubii(tubii_info) {
@@ -418,7 +435,7 @@ function display_mtca_thresholds(node,dacs,trigger_scan){
             return row;
         });
 }
-function display_crate_mask(mask,dom_node,title,size_info) {
+function display_bit_mask(mask,dom_node,title,size_info) {
     var width = size_info.width;
     var height =size_info.height;
     dv = dom_node.append("div");
@@ -431,7 +448,7 @@ function display_crate_mask(mask,dom_node,title,size_info) {
     var title_percent = 0.10;
     var title_width = title_percent*width;
     width=(1- title_percent)*width;
-    var step_size = width/21;
+    var step_size = width/(mask.length+1);
     var xpos_func = function(d,i) { return title_width+i*step_size; }
     var ypos_func = function(d,i) { return height/2.0; }
     svg.selectAll("circle")

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -3,6 +3,8 @@ function flattenArray(arr) {
 }
 function display_binary_crate_view(key,crates_data,sizeinfo,node)
 {
+    color_on = getComputedStyle(document.querySelector('.on')).fill;
+    console.log(color_on);
     var coloringFunc = function(data) {
         return function(k,i) {
         var v = data[k];
@@ -15,7 +17,7 @@ function display_binary_crate_view(key,crates_data,sizeinfo,node)
             return 'background-color:green';
     };}
 
-    display_crate_view(key,crates_data,sizeinfo,node,coloringFunc);
+    display_crate_view(key,crates_data,sizeinfo,node,{'attrib':'style','func':coloringFunc});
 }
 function display_continuous_crate_view(key,crates_data,sizeinfo,node)
 {
@@ -32,9 +34,9 @@ function display_continuous_crate_view(key,crates_data,sizeinfo,node)
 
                 return 'background-color:' + scale(+v);
     }};}
-    display_crate_view(key,crates_data,sizeinfo,node,coloringFunc);
+    display_crate_view(key,crates_data,sizeinfo,node,{'attrib':'style','func':coloringFunc});
 }
-function display_crate_view(key,crates_data,sizeinfo,node,coloringFunc)
+function display_crate_view(key,crates_data,sizeinfo,node,styling)
 {
     var d = crates_data.map(function(crate,i) {
     if(crate) {
@@ -57,9 +59,17 @@ function display_crate_view(key,crates_data,sizeinfo,node,coloringFunc)
         .caption(true)
         .height(height)
         .width(width);
-    if(coloringFunc){
-        crate.coloringFunction(coloringFunc)
+    if(styling){
+        stylingFunc = crate.stylingFunction;
+        if(styling.coloringFunc){
+            stylingFunction.coloringFunction = styling.coloringFunc;
+        }
+        if(styling.attrib){
+            stylingFunction.attrib = styling.attrib;
+        }
+        crate.stylingFunction(stylingFunc);
     }
+
     var g = node.append('div')
             .attr('id','crate')
             .attr('width',width)

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -22,7 +22,20 @@ function display_binary_crate_view(key,crates_data,sizeinfo,node)
             return 'on';
     };}
 
-    display_crate_view(key,crates_data,sizeinfo,node,{'attrib':'class','func':coloringFunc});
+    hover_text_func = function(data) {
+    return function(d,i) {
+        v = data[d];
+        if(v == null){
+            return "Unknown";
+        }
+        else if(v ==0){
+            return "off";
+        }
+        return "on";
+    }};
+
+    display_crate_view(key,crates_data,sizeinfo,node,
+            {'attrib':'class','func':coloringFunc},hover_text_func);
 }
 
 function get_colors() {
@@ -124,7 +137,16 @@ function display_continuous_crate_view(key,crates_data,sizeinfo,color_scale,node
                 else {
                     return 'background-color:' + scale(v);
         }};}
-        return display_crate_view(key,crates_data,sizeinfo,node,{'attrib':'style','func':coloringFunc});
+        hover_text_func = function(data) {
+        return function(d,i) {
+            v = data[d];
+            if(v == null){
+                return "Unknown";
+            }
+            return v;
+        }};
+        return display_crate_view(key,crates_data,sizeinfo,node,
+                {'attrib':'style','func':coloringFunc},hover_text_func);
     }
     crate_node = draw_continous_crate_view(color_scale);
     function redraw(color_scale){
@@ -133,7 +155,7 @@ function display_continuous_crate_view(key,crates_data,sizeinfo,color_scale,node
     }
     return redraw
 }
-function display_crate_view(key,crates_data,sizeinfo,node,styling)
+function display_crate_view(key,crates_data,sizeinfo,node,styling,hover_text)
 {
     var d = crates_data.map(function(crate,i) {
     if(crate) {
@@ -156,6 +178,9 @@ function display_crate_view(key,crates_data,sizeinfo,node,styling)
         .caption(true)
         .height(height)
         .width(width);
+    if(hover_text){
+    crate.hover_text(hover_text);
+    }
     if(styling){
         stylingFunc = crate.stylingFunction();
         if(styling.func){

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -550,10 +550,10 @@ function display_run_type(run_type,time_stamp) {
         {
             if(run_type & (1<<i)) {
                 if(i-low_bit >= Object.keys(trans_map).length) {
-                   ret.push("SPARE (???)");
+                   ret.push(" SPARE (???)");
                 }
                 else {
-                    ret.push(trans_map[i]);
+                    ret.push(" "+trans_map[i]);
                 }
             }
         }

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -601,11 +601,14 @@ function display_mtca_thresholds(node,dacs,trigger_scan,enabled_dacs){
         .enter()
         .append('tr')
         .attr('class',function(key) {
-            if(!enabled_dacs)
-            { return ""; }
             if(enabled_dacs && enabled_dacs[key])
             { return 'success'; }
             return '';
+        })
+        .attr('title',function(key){
+            if(enabled_dacs && enabled_dacs[key])
+            { return key+' is masked in'; }
+            return key+' is NOT masked in';
         })
         .selectAll('td')
         .data( function(key,i) {

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -22,7 +22,7 @@ function display_continuous_crate_view(key,crates_data,sizeinfo,node)
 {
     // For now this just assumes a linear scale from 0-255.
     // May have to generalize at some point.
-    var scale = d3.scale.linear().domain([0,255]).range(['#6666ff','#ff0000']);
+    var scale = d3.scale.linear().domain([0,255]).range(['#6666ff','#ffcc00']);
     var coloringFunc = function(data) {
         return function(k, i) {
             var v = data[k];

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -144,19 +144,24 @@ function display_detector_control(detector_control_info) {
         .attr("x",xpos_func)
         .attr("y",function(d,i) { return ypos_func(d,i)+5;});
 }
+
 function display_triggers(node,wordlist) {
     display_array_as_list(node,wordlist,'Enabled Triggers');
 };
+
 function display_ped_delay(node,delay) {
     node.append("h3").text("Pedestal Delay = "+ delay.toString() +"ns");
 
 };
+
 function display_lockout_width(node,lockout) {
     node.append("h3").text("Lockout Width = "+ lockout.toString()+"ns");
 };
+
 function display_control_reg(node,wordlist) {
     display_array_as_list(node,wordlist,'Control Register Values');
 };
+
 function display_crates(title,crates) {
     var mtc = d3.select('#mtc');
     mtc.append('h3').text(title);
@@ -167,6 +172,7 @@ function display_crates(title,crates) {
         .append('li')
         .text(function(d) { return d;});
 };
+
 function display_prescale(node,prescale) {
     mtc.append('h3').text('Prescale = '+prescale.toString());
 };
@@ -175,10 +181,11 @@ function display_caen(caen_info) {
     caen.append('h4').text("Acquisition Mode = "+caen_info.acquisition_mode);
     display_dictionary_as_list(caen,caen_info,"CAEN");
 };
+
 function display_tubii(tubii_info) {
     var tubii = d3.select("#tubii");
     var bounds = tubii.node().parentElement.parentElement.clientWidth
-	var height = 50;
+    var height = 50;
     var width = bounds;
     var step_size = width/30;
     radius = step_size;
@@ -255,8 +262,8 @@ function display_tubii(tubii_info) {
         .attr("height",radius)
         .attr("fill",function(d) { return d[1]==1 ? 'green' : 'red'; })
         .attr("class",function(d) { return d[1]==1 ? 'on' : 'off'; })
-	.append("svg:title")
-	.text(function(d){return d[2];});
+        .append("svg:title")
+        .text(function(d){return d[2];});
     svg.selectAll('text')
         .data(arr)
         .enter()

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -33,6 +33,50 @@ function get_colors() {
     return d3.entries(color_scales);
 }
 
+function create_hover_text_color_bar(node,colors)
+{
+    function draw_bar(colors) {
+        percents = linspace(0,100,colors.length);
+        var draw_node = node.append('div')
+                .style("display",'inline')
+                .attr('id','color-bar');
+        help_ico = draw_node.append('div')
+            .attr('class',"glyphicon glyphicon-question-sign");
+        var svg = draw_node.append('svg').attr("height",20);
+        var defs = svg.append('defs')
+        var linearGradient = defs.append('linearGradient')
+            .attr('id', 'linear-gradient');
+        linearGradient
+            .attr('x1', '0%')
+            .attr('x2', '100%')
+        for(var i=0; i<colors.length;i++)
+        {
+        linearGradient.append('stop')
+            .attr('offset',percents[i]+'%')
+            .attr('stop-color', colors[i]);
+        }
+        var bar = svg.append("rect")
+            .attr('x','10px')
+            .attr("width", '95%')
+            .attr("height", '100%')
+            .style("fill", "url(#linear-gradient)")
+            .attr('rx',6)
+            .attr('ry',6)
+            .attr('opacity',0)
+        help_ico.on('mouseover',function() {
+            bar.transition().duration(1000).attr('opacity',1)});
+        help_ico.on('mouseout',function() {
+            bar.transition().duration(1000).attr('opacity',0)});
+    }
+
+    draw_bar(colors);
+    redraw = function(new_colors) {
+        node.select("#color-bar").remove();
+        draw_bar(new_colors);
+    }
+    return redraw;
+}
+
 function display_colorable_continuous_crate_view(key,crates_data,sizeinfo,node)
 {
     node = node.append("div").attr("class","colorable_crate");

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -356,8 +356,7 @@ function display_caen(node,caen_info) {
             .enter()
             .append('li')
             .text(function(d,i) {
-                unit = d == 1 || d == -1 ? "Volt" : "Volts";
-                return "Channel "+i+" = "+d+" "+unit;});
+                return "Channel "+i+" = "+d+"V";});
     }
 };
 

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -93,7 +93,6 @@ function display_detector_control(detector_control_info) {
         .attr("cx",xpos_func)
         .attr("cy",ypos_func)
         .attr("r",radius)
-        .attr("fill",function(d) { return d[1]==1 ? 'green' : 'red'; })
         .attr("class",function(d) { return d[1]==1 ? 'on' : 'off'; });
     svg.selectAll('text')
         .data(arr)
@@ -473,6 +472,50 @@ function crate() {
         height = value;
         return my;
     }
-
     return my;
+}
+function create_color_picker(node,title,class_name) {
+    var title_node = node.selectAll(".dropdown_title");
+    var menu_node = node.select(".dropdown-menu");
+    var colors= ['aqua', 'black', 'blue', 'fuchsia', 'gray', 'green',
+    'lime', 'maroon', 'navy', 'olive', 'orange', 'purple','lightpurlpe',
+    'red', 'silver', 'teal', 'azure', 'yellow', 'beige','darkslategrey'];
+
+    function append_square(node,color) {
+        function change_colors() {
+            var cols = document.getElementsByClassName(class_name);
+            for(i=0;i<cols.length;i++) {
+                cols[i].style.fill = color;
+            }
+        }
+        node.append('svg')
+            .attr("width",20)
+            .attr('height',20)
+            .append('circle')
+            .attr("cx",10)
+            .attr("cy",10)
+            .attr("r",8)
+            .attr("fill",color)
+            .on("click",change_colors );
+    }
+
+        title_node.append('p').text(title)
+        title_node.append('svg')
+            .attr("width",20)
+            .attr('height',20)
+            .append('circle')
+            .attr("cx",10)
+            .attr("cy",10)
+            .attr("r",8)
+            .attr("class",class_name);
+
+    var colors_per_row = 10
+    for(var i = 0;i<Math.ceil(colors.length/colors_per_row);i++) {
+        row = menu_node.append("tr");
+        for(var j = 0;j<colors_per_row;j++) {
+            if(i*colors_per_row+j < colors.length){
+                append_square(row.append("th"),colors[i*colors_per_row+j]);
+            }
+        }
+    }
 }

--- a/minard/static/js/detector_state.js
+++ b/minard/static/js/detector_state.js
@@ -3,21 +3,20 @@ function flattenArray(arr) {
 }
 function display_binary_crate_view(key,crates_data,sizeinfo,node)
 {
-    color_on = getComputedStyle(document.querySelector('.on')).fill;
-    console.log(color_on);
+    //color_on = getComputedStyle(document.querySelector('.on')).fill;
     var coloringFunc = function(data) {
         return function(k,i) {
         var v = data[k];
         if (v === null || typeof v === 'undefined')
-            return 'background-color:#e0e0e0';
+            return 'unknown';
         else if (v===0) {
-            return 'background-color:grey';
+            return 'off';
         }
         else
-            return 'background-color:green';
+            return 'on';
     };}
 
-    display_crate_view(key,crates_data,sizeinfo,node,{'attrib':'style','func':coloringFunc});
+    display_crate_view(key,crates_data,sizeinfo,node,{'attrib':'class','func':coloringFunc});
 }
 function display_continuous_crate_view(key,crates_data,sizeinfo,node)
 {
@@ -60,14 +59,14 @@ function display_crate_view(key,crates_data,sizeinfo,node,styling)
         .height(height)
         .width(width);
     if(styling){
-        stylingFunc = crate.stylingFunction;
-        if(styling.coloringFunc){
-            stylingFunction.coloringFunction = styling.coloringFunc;
+        stylingFunc = crate.stylingFunction();
+        if(styling.func){
+            stylingFunc = stylingFunc.coloringFunction(styling.func);
         }
         if(styling.attrib){
-            stylingFunction.attrib = styling.attrib;
+            stylingFunc = stylingFunc.attribute(styling.attrib);
         }
-        crate.stylingFunction(stylingFunc);
+        crate = crate.stylingFunction(stylingFunc);
     }
 
     var g = node.append('div')
@@ -496,6 +495,7 @@ function create_color_picker(node,title,class_name) {
             var cols = document.getElementsByClassName(class_name);
             for(i=0;i<cols.length;i++) {
                 cols[i].style.fill = color;
+                cols[i].style['background-color'] = color;
             }
         }
         node.append('svg')

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -34,31 +34,30 @@
     </div>
     {% else %}
     <div class="row">
-        <span>
-        <div id="on_colors" class="dropdown">
-        <button class="btn btn-default dropdown-toggle" type="button"  data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-            <div class="dropdown_title"></div>
-        <span class="caret"></span>
-        </button>
-        <table class="dropdown-menu" aria-labelledby="dropdownMenu1">
-        </table>
-        </div>
-
-        <div id="off_colors" class="dropdown">
-        <button class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-            <div class="dropdown_title"></div>
-        <span class="caret"></span>
-        </button>
-        <table class="dropdown-menu" aria-labelledby="dropdownMenu1">
-        </table>
-        </div>
-        </span>
         <div class="col-md-6 col-md-offset-3">
             <center id="run_title">
                 <ul class="pager">
-                    <li class="previous"><a href="{{ url_for('state', run=run-1) }}">Prev</a></li>
+                    {% if colors[0] and not colors[1] %}
+                        <li class="previous"><a href="{{ url_for('state', run=run-1,oncolor=colors[0]) }}">Prev</a></li>
+                    {% elif not colors[0] and colors[1] %}
+                        <li class="previous"><a href="{{ url_for('state', run=run-1,offcolor=colors[1]) }}">Prev</a></li>
+                    {% elif colors[0] and colors[1]  %}
+                        <li class="previous"><a href="{{ url_for('state', run=run-1,oncolor=colors[0],offcolor=colors[1]) }}">Prev</a></li>
+                    {% else %}
+                        <li class="previous"><a href="{{ url_for('state', run=run-1)}}">Prev</a></li>
+                    {% endif %}
+
                     <li><h1 style="display:inline"> Run {{ run }} </h2></li>
-                    <li class="next"><a href="{{ url_for('state', run=run+1) }}">Next</a></li>
+
+                    {% if colors[0] and not colors[1] %}
+                        <li class="next"><a href="{{ url_for('state', run=run+1,oncolor=colors[0]) }}">Next</a></li>
+                    {% elif not colors[0] and colors[1] %}
+                        <li class="next"><a href="{{ url_for('state', run=run+1,offcolor=colors[1]) }}">Next</a></li>
+                    {% elif colors[0] and colors[1]  %}
+                        <li class="next"><a href="{{ url_for('state', run=run+1,oncolor=colors[0],offcolor=colors[1]) }}">Next</a></li>
+                    {% else %}
+                        <li class="next"><a href="{{ url_for('state', run=run+1)}}">Next</a></li>
+                    {% endif %}
                 </ul>
             </center>
         </div>

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -50,11 +50,13 @@
             {% endif %}
             {% if caen_state %}
                 {% call collapsible_header('CAEN','CAEN') %}
-                    <ul>
-                    {% for key,val in caen_state.iteritems() %}
-                        <li> {{key}} = {{ val }} </li>
-                    {% endfor %}
-                    </ul>
+                    {% call collapsible_header('Dump Data','CAENDump') %}
+                        <ul>
+                        {% for key,val in caen_state.iteritems() %}
+                            <li> {{key}} = {{ val }} </li>
+                        {% endfor %}
+                        </ul>
+                    {% endcall %}
                 {% endcall %}
             {% endif %}
             {% if tubii_state %}

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -104,6 +104,8 @@
     </div>
 {% endblock %}
 {% block script %}
+    <script src="{{ url_for('static', filename='js/moment.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/moment-timezone-with-data.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/d3.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/colorbrewer.js') }}"></script>
     <script src="{{ url_for('static', filename='js/crate.js') }}"></script>

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -135,8 +135,6 @@
         var run_data = false;
         var det_cont_info = false;
 
-        create_color_picker(d3.select("#on_colors"),"On","on");
-        create_color_picker(d3.select("#off_colors"),"Off","off");
 
         {% if run_state %}
             run_data = {{ run_state | tojson | safe }}
@@ -144,6 +142,20 @@
         {% if detector_control_state %}
             det_cont_info  = {{ detector_control_state | tojson | safe }};
         {% endif %}
+        {% if colors %}
+            colors = {{ colors | tojson | safe }}
+        {% endif %}
+        console.log(colors);
+        function change_colors(class_name,color) {
+            var cols = document.getElementsByClassName(class_name);
+            console.log(cols.length);
+            for(i=0;i<cols.length;i++) {
+                console.log(color);
+                cols[i].style.fill = color;
+                cols[i].style['background-color'] = color;
+            }
+        }
+
         d3.select("#collapsesummary").classed("in",true);
         var summary = d3.select("#summary");
         if (mtc_data) {
@@ -244,6 +256,14 @@
                 var svg = tubii.selectAll("svg").attr("width",width);
             }
         };
+
+        // The coloring has to go last so it can color everything drawn above
+        if(colors[0]){
+           change_colors("on",colors[0]);
+        }
+        if(colors[1]) {
+            change_colors("off",colors[1]);
+        }
         resize()
         window.addEventListener("resize", resize,false);
        </script>

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -144,12 +144,9 @@
         {% if colors %}
             colors = {{ colors | tojson | safe }}
         {% endif %}
-        console.log(colors);
         function change_colors(class_name,color) {
             var cols = document.getElementsByClassName(class_name);
-            console.log(cols.length);
             for(i=0;i<cols.length;i++) {
-                console.log(color);
                 cols[i].style.fill = color;
                 cols[i].style['background-color'] = color;
             }

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -133,7 +133,6 @@
             if (Object.keys(enabled_dacs).length){
                 enabled_triggers_node.attr('class','col-sm-3');
                 thresholds_node = summary.append("div").attr('class','col-sm-9');
-                thresholds_node.append('h3').text("Thresholds");
                 display_mtca_thresholds(thresholds_node,enabled_dacs,trigger_scan);
             }
             display_triggers(enabled_triggers_node,mtc_data.gt_words);

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -127,44 +127,15 @@
 
         var summary = d3.select("#summary");
         if (mtc_data) {
-            var mtc = d3.select('#mtc');
-            display_triggers(mtc,mtc_data.gt_words);
             enabled_triggers_node = summary.append("div").attr('class','col-sm-3');
-            thresholds_node = summary.append("div")
-                        .attr('class','col-sm-9');
-
+            thresholds_node = summary.append("div").attr('class','col-sm-9');
             display_triggers(enabled_triggers_node,mtc_data.gt_words);
-
             enabled_dacs = get_enabled_dacs(mtc_data.MTCA_DACs,mtc_data.gt_words);
-            display_mtca_thresholds(mtc,mtc_data.MTCA_DACs,trigger_scan,enabled_dacs);
-
-            node = thresholds_node.append('h3').text("Thresholds");
+            thresholds_node.append('h3').text("Thresholds");
             display_mtca_thresholds(thresholds_node,enabled_dacs,trigger_scan);
 
-            display_lockout_width(mtc,mtc_data.lockout_width);
-            display_control_reg(mtc,mtc_data.control_reg);
-            if(mtc_data.control_reg.filter(function(x) { x.indexOf("PED") > -1;}))
-                {display_ped_delay(mtc,mtc_data.ped_delay);}
-            display_prescale(mtc,mtc_data.prescale);
-            var size_info ={};
-            size_info['width']= mtc.node().parentElement.parentElement.clientWidth
-            size_info['height']= 25;
-            display_bit_mask(mtc_data.gt_crates,mtc,"GT",size_info);
-            display_bit_mask(mtc_data.ped_crates,mtc,"PED",size_info);
-
-            mtc.append('h3')
-                .text("MTCA Relays")
-                .append('div')
-                .attr('class',"col-xs-12")
-                .append('hr');
-
-            display_bit_mask(mtc_data.N100_crates,mtc,"N100",size_info);
-            display_bit_mask(mtc_data.N20_crates,mtc,"N20",size_info);
-            display_bit_mask(mtc_data.ESUMHI_crates,mtc,"ESUM HI",size_info);
-            display_bit_mask(mtc_data.ESUMLO_crates,mtc,"ESUM LO",size_info);
-            display_bit_mask(mtc_data.OWLELO_crates,mtc,"OWLE LO",size_info);
-            display_bit_mask(mtc_data.OWLEHI_crates,mtc,"OWLE HI",size_info);
-            display_bit_mask(mtc_data.OWLN_crates,mtc,"OWLN",size_info);
+            var mtc = d3.select('#mtc');
+            display_mtc(mtc,mtc_data)
         }
         if (run_data) {
             display_run_type(run_data.run_type,run_data.timestamp)

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -108,7 +108,7 @@
         var caen_data = {{ caen_state | caen_human_readable | tojson |safe }};
         var crates_data = {{ crates_state | all_crates_human_readable |tojson |safe }};
         var tubii_data = {{ tubii_state | tubii_human_readable | tojson |safe }};
-        var trigger_scan = {{ trigger_scan |trigger_scan_human_readable | tojson |safe }};
+        var trigger_scan = {{ trigger_scan | trigger_scan_human_readable | tojson |safe }};
         var run_data = false;
         var det_cont_info = false;
         {% if run_state %}

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -25,25 +25,25 @@
 {% endblock %}
 {% block body %}
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/detector_state.css') }}" media="screen">
-    {{ super() }}
-    <div class="container">
-        {% if err %}
-	    <div class="alert alert-danger" role="alert">
-	    <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-            Error talking to the DB : {{ err }}
-	    </div>
-        {% else %}
-	    <div class="row">
-		<div class="col-md-6 col-md-offset-3">
-		    <center id="run_title">
-			<ul class="pager">
-			    <li class="previous"><a href="{{ url_for('state', run=run-1) }}">Prev</a></li>
-			    <li><h1 style="display:inline"> Run {{ run }} </h2></li>
-			    <li class="next"><a href="{{ url_for('state', run=run+1) }}">Next</a></li>
-			</ul>
-		    </center>
-		</div>
-	    </div>
+{{ super() }}
+<div class="container">
+    {% if err %}
+    <div class="alert alert-danger" role="alert">
+        <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+        Error talking to the DB : {{ err }}
+    </div>
+    {% else %}
+    <div class="row">
+        <div class="col-md-6 col-md-offset-3">
+            <center id="run_title">
+                <ul class="pager">
+                    <li class="previous"><a href="{{ url_for('state', run=run-1) }}">Prev</a></li>
+                    <li><h1 style="display:inline"> Run {{ run }} </h2></li>
+                    <li class="next"><a href="{{ url_for('state', run=run+1) }}">Next</a></li>
+                </ul>
+            </center>
+        </div>
+    </div>
             {% if mtc_state %}
                 {% call collapsible_header('MTC','mtc') %}
                 {% endcall %}
@@ -171,8 +171,8 @@
         if (det_cont_info) {
             display_detector_control(det_cont_info);
         }
-	if (tubii_data) {
-	    display_tubii(tubii_data);
+        if (tubii_data) {
+            display_tubii(tubii_data);
         }
         if (caen_data) {
             display_caen(caen_data);
@@ -188,9 +188,9 @@
                 var width = mtc.node().parentElement.parentElement.clientWidth
                 var svg = mtc.selectAll("svg").attr("width",width);
             }
-	    if(tubii_data ){
-	        var tubii = d3.select("#tubii")
-	        var width = tubii.node().parentElement.parentElement.clientWidth
+            if(tubii_data ){
+                var tubii = d3.select("#tubii")
+                    var width = tubii.node().parentElement.parentElement.clientWidth
                 var svg = tubii.selectAll("svg").attr("width",width);
             }
         };

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -167,15 +167,15 @@
             var size_info ={};
             size_info['width']= mtc.node().parentElement.parentElement.clientWidth
             size_info['height']= 25;
-            display_crate_mask(mtc_data.gt_crates,mtc,"GT",size_info);
-            display_crate_mask(mtc_data.ped_crates,mtc,"PED",size_info);
-            display_crate_mask(mtc_data.N100_crates,mtc,"N100",size_info);
-            display_crate_mask(mtc_data.N20_crates,mtc,"N20",size_info);
-            display_crate_mask(mtc_data.ESUMHI_crates,mtc,"ESUM HI",size_info);
-            display_crate_mask(mtc_data.ESUMLO_crates,mtc,"ESUM LO",size_info);
-            display_crate_mask(mtc_data.OWLELO_crates,mtc,"OWLE LO",size_info);
-            display_crate_mask(mtc_data.OWLEHI_crates,mtc,"OWLE HI",size_info);
-            display_crate_mask(mtc_data.OWLN_crates,mtc,"OWLN",size_info);
+            display_bit_mask(mtc_data.gt_crates,mtc,"GT",size_info);
+            display_bit_mask(mtc_data.ped_crates,mtc,"PED",size_info);
+            display_bit_mask(mtc_data.N100_crates,mtc,"N100",size_info);
+            display_bit_mask(mtc_data.N20_crates,mtc,"N20",size_info);
+            display_bit_mask(mtc_data.ESUMHI_crates,mtc,"ESUM HI",size_info);
+            display_bit_mask(mtc_data.ESUMLO_crates,mtc,"ESUM LO",size_info);
+            display_bit_mask(mtc_data.OWLELO_crates,mtc,"OWLE LO",size_info);
+            display_bit_mask(mtc_data.OWLEHI_crates,mtc,"OWLE HI",size_info);
+            display_bit_mask(mtc_data.OWLN_crates,mtc,"OWLN",size_info);
         }
         if (run_data) {
             display_run_type(run_data.run_type,run_data.timestamp)
@@ -226,7 +226,9 @@
     display_tubii(tubii_data);
         }
         if (caen_data) {
-            display_caen(caen_data);
+            caen = d3.select("#CAEN");
+            node = caen.insert("div",":first-child");
+            display_caen(node,caen_data);
         }
         resize = function() {
             if(det_cont_info){

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -149,6 +149,13 @@
             size_info['height']= 25;
             display_bit_mask(mtc_data.gt_crates,mtc,"GT",size_info);
             display_bit_mask(mtc_data.ped_crates,mtc,"PED",size_info);
+
+            mtc.append('h3')
+                .text("MTCA Relays")
+                .append('div')
+                .attr('class',"col-xs-12")
+                .append('hr');
+
             display_bit_mask(mtc_data.N100_crates,mtc,"N100",size_info);
             display_bit_mask(mtc_data.N20_crates,mtc,"N20",size_info);
             display_bit_mask(mtc_data.ESUMHI_crates,mtc,"ESUM HI",size_info);

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -64,6 +64,8 @@
             </center>
         </div>
     </div>
+                {% call collapsible_header('Executive Summary','summary') %}
+                {% endcall %}
             {% if mtc_state %}
                 {% call collapsible_header('MTC','mtc') %}
                 {% endcall %}
@@ -143,6 +145,8 @@
         {% if detector_control_state %}
             det_cont_info  = {{ detector_control_state | tojson | safe }};
         {% endif %}
+        d3.select("#collapsesummary").classed("in",true);
+        var summary = d3.select("#summary");
         if(crates_data) {
             var N100 = d3.select("#N100Triggers");
             var N20 = d3.select("#N20Triggers");
@@ -154,9 +158,16 @@
             sizeinfo = {};
             sizeinfo.width = width;
             sizeinfo.height = height;
-            N100.append('h3').text("Num Enabled = "+crates_data['num_n100_triggers'].toString());
-            N20.append('h3').text("Num Enabled = "+crates_data['num_n20_triggers'].toString());
-            Seq.append('h3').text("Num Enabled = "+crates_data['num_sequencers'].toString());
+            add_line = function(node,text)
+            {
+                node.append('h3').text(text);
+            };
+            add_line(N100,"Num Enabled = "+crates_data['num_n100_triggers'].toString());
+            add_line(N20,"Num Enabled = "+crates_data['num_n20_triggers'].toString());
+            add_line(Seq,"Num Enabled = "+crates_data['num_sequencers'].toString());
+            add_line(summary,"Number of Sequencers Enabled = "+crates_data['num_sequencers'].toString());
+            add_line(summary,"Number of N100s Enabled = "+crates_data['num_n100_triggers'].toString());
+            add_line(summary,"Number of N20s Enabled = "+crates_data['num_n20_triggers'].toString());
             display_binary_crate_view('n100_triggers',crates_data.crates,sizeinfo,N100)
             display_binary_crate_view('n20_triggers',crates_data.crates,sizeinfo,N20)
             display_binary_crate_view('sequencers',crates_data.crates,sizeinfo,Seq)
@@ -170,14 +181,16 @@
             display_continuous_crate_view('vbal_1',crates_data.crates,sizeinfo,vbal1)
         }
         if (mtc_data) {
-            display_triggers(mtc_data.gt_words);
-            display_mtca_thresholds(mtc_data.MTCA_DACs,trigger_scan);
-            display_lockout_width(mtc_data.lockout_width);
-            display_control_reg(mtc_data.control_reg);
+            var mtc = d3.select('#mtc');
+            display_triggers(mtc,mtc_data.gt_words);
+            display_triggers(summary,mtc_data.gt_words);
+            display_mtca_thresholds(mtc,mtc_data.MTCA_DACs,trigger_scan);
+            display_mtca_thresholds(summary,mtc_data.MTCA_DACs,trigger_scan);
+            display_lockout_width(mtc,mtc_data.lockout_width);
+            display_control_reg(mtc,mtc_data.control_reg);
             if(mtc_data.control_reg.filter(function(x) { x.indexOf("PED") > -1;}))
-                {display_ped_delay( mtc_data.ped_delay);}
-            display_prescale(mtc_data.prescale);
-            var mtc = d3.select("#mtc")
+                {display_ped_delay(mtc,mtc_data.ped_delay);}
+            display_prescale(mtc,mtc_data.prescale);
             var size_info ={};
             size_info['width']= mtc.node().parentElement.parentElement.clientWidth
             size_info['height']= 25;
@@ -195,6 +208,7 @@
             display_run_type(run_data.run_type,run_data.timestamp)
         }
         if (det_cont_info) {
+            summary.append("h3").text("Number of Crates On = "+num_crates_on(det_cont_info));
             display_detector_control(det_cont_info);
         }
         if (tubii_data) {

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -127,12 +127,16 @@
 
         var summary = d3.select("#summary");
         if (mtc_data) {
-            enabled_triggers_node = summary.append("div").attr('class','col-sm-3');
-            thresholds_node = summary.append("div").attr('class','col-sm-9');
-            display_triggers(enabled_triggers_node,mtc_data.gt_words);
             enabled_dacs = get_enabled_dacs(mtc_data.MTCA_DACs,mtc_data.gt_words);
-            thresholds_node.append('h3').text("Thresholds");
-            display_mtca_thresholds(thresholds_node,enabled_dacs,trigger_scan);
+            enabled_triggers_node = summary.append("div");
+            //Only display threhsold info if there's some enabled triggers in it
+            if (Object.keys(enabled_dacs).length){
+                enabled_triggers_node.attr('class','col-sm-3');
+                thresholds_node = summary.append("div").attr('class','col-sm-9');
+                thresholds_node.append('h3').text("Thresholds");
+                display_mtca_thresholds(thresholds_node,enabled_dacs,trigger_scan);
+            }
+            display_triggers(enabled_triggers_node,mtc_data.gt_words);
 
             var mtc = d3.select('#mtc');
             display_mtc(mtc,mtc_data)

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -129,15 +129,17 @@
         if (mtc_data) {
             var mtc = d3.select('#mtc');
             display_triggers(mtc,mtc_data.gt_words);
-            display_triggers(summary,mtc_data.gt_words);
+            enabled_triggers_node = summary.append("div").attr('class','col-sm-3');
+            thresholds_node = summary.append("div")
+                        .attr('class','col-sm-9');
+
+            display_triggers(enabled_triggers_node,mtc_data.gt_words);
 
             enabled_dacs = get_enabled_dacs(mtc_data.MTCA_DACs,mtc_data.gt_words);
             display_mtca_thresholds(mtc,mtc_data.MTCA_DACs,trigger_scan,enabled_dacs);
 
-            node = summary.append('h3').text("Thresholds");
-            display_mtca_thresholds(summary,enabled_dacs,trigger_scan);
-
-
+            node = thresholds_node.append('h3').text("Thresholds");
+            display_mtca_thresholds(thresholds_node,enabled_dacs,trigger_scan);
 
             display_lockout_width(mtc,mtc_data.lockout_width);
             display_control_reg(mtc,mtc_data.control_reg);
@@ -183,7 +185,8 @@
                 node.append('h3').text(text);
             };
 
-            table = summary.append('table').attr('class','table')
+            table = summary.append('div').attr('class','col-md-12')
+                           .append('table').attr('class','table')
             head = table.append('thead').append('tr')
             head.append('th').text('# Sequencers')
             head.append('th').text('# N100s')

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -47,7 +47,7 @@
                         <li class="previous"><a href="{{ url_for('state', run=run-1)}}">Prev</a></li>
                     {% endif %}
 
-                    <li><h1 style="display:inline"> Run {{ run }} </h2></li>
+                    <li><h1 style="display:inline"> Run {{ run }} </h1></li>
 
                     {% if colors[0] and not colors[1] %}
                         <li class="next"><a href="{{ url_for('state', run=run+1,oncolor=colors[0]) }}">Next</a></li>

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -3,7 +3,7 @@
    <div class="panel-group" style="margin:10px">
        <div class="panel panel-default">
            <div class="panel-heading">
-               <h4 class="panel-title">
+               <h4 id="title-{{name}}" class="panel-title">
                    <a data-toggle="collapse" href="#collapse{{name}}">
                        {{title}}
                    </a>
@@ -196,14 +196,17 @@
             display_binary_crate_view('n100_triggers',crates_data.crates,sizeinfo,N100)
             display_binary_crate_view('n20_triggers',crates_data.crates,sizeinfo,N20)
             display_binary_crate_view('sequencers',crates_data.crates,sizeinfo,Seq)
-            display_colorable_continuous_crate_view('vthrs',crates_data.crates,sizeinfo,vThr);
+            bar_node = d3.select("#title-VThr");
+            display_colorable_continuous_crate_view('vthrs',crates_data.crates,sizeinfo,vThr,bar_node)
+
             vbal_table = VBal.append('table');
-            vbal_table.append('tr').append('th').append('h3').text("VBal 0");
+            vbal0_bar_node = vbal_table.append('tr').append('th').append('h4').text("VBal 0 ");
             vbal0 = vbal_table.append('tr').append('th');
-            vbal_table.append('tr').append('th').append('h3').text("VBal 1");
+            vbal1_bar_node = vbal_table.append('tr').append('th').append('h4').text("VBal 1 ");
             vbal1 = vbal_table.append('tr').append('th');
-            display_colorable_continuous_crate_view('vbal_0',crates_data.crates,sizeinfo,vbal0);
-            display_colorable_continuous_crate_view('vbal_1',crates_data.crates,sizeinfo,vbal1);
+
+            display_colorable_continuous_crate_view('vbal_0',crates_data.crates,sizeinfo,vbal0,vbal0_bar_node);
+            display_colorable_continuous_crate_view('vbal_1',crates_data.crates,sizeinfo,vbal1,vbal1_bar_node);
         }
         if (det_cont_info) {
             summary.append("h3").text("Crates On = "+num_crates_on(det_cont_info));

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -34,6 +34,26 @@
     </div>
     {% else %}
     <div class="row">
+
+        <span>
+        <div id="on_colors" class="dropdown">
+        <button class="btn btn-default dropdown-toggle" type="button"  data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+            <div class="dropdown_title"></div>
+        <span class="caret"></span>
+        </button>
+        <table class="dropdown-menu" aria-labelledby="dropdownMenu1">
+        </table>
+        </div>
+
+        <div id="off_colors" class="dropdown">
+        <button class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+            <div class="dropdown_title"></div>
+        <span class="caret"></span>
+        </button>
+        <table class="dropdown-menu" aria-labelledby="dropdownMenu1">
+        </table>
+        </div>
+        </span>
         <div class="col-md-6 col-md-offset-3">
             <center id="run_title">
                 <ul class="pager">
@@ -113,6 +133,10 @@
         var trigger_scan = {{ trigger_scan | trigger_scan_human_readable | tojson |safe }};
         var run_data = false;
         var det_cont_info = false;
+
+        create_color_picker(d3.select("#on_colors"),"On","on");
+        create_color_picker(d3.select("#off_colors"),"Off","off");
+
         {% if run_state %}
             run_data = {{ run_state | tojson | safe }}
         {% endif %}

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -37,27 +37,9 @@
         <div class="col-md-6 col-md-offset-3">
             <center id="run_title">
                 <ul class="pager">
-                    {% if colors[0] and not colors[1] %}
-                        <li class="previous"><a href="{{ url_for('state', run=run-1,oncolor=colors[0]) }}">Prev</a></li>
-                    {% elif not colors[0] and colors[1] %}
-                        <li class="previous"><a href="{{ url_for('state', run=run-1,offcolor=colors[1]) }}">Prev</a></li>
-                    {% elif colors[0] and colors[1]  %}
-                        <li class="previous"><a href="{{ url_for('state', run=run-1,oncolor=colors[0],offcolor=colors[1]) }}">Prev</a></li>
-                    {% else %}
-                        <li class="previous"><a href="{{ url_for('state', run=run-1)}}">Prev</a></li>
-                    {% endif %}
-
+                    <li class="previous"><a id="prev-link" href="{{ url_for('state', run=run-1)}}">Prev</a></li>
                     <li><h1 style="display:inline"> Run {{ run }} </h1></li>
-
-                    {% if colors[0] and not colors[1] %}
-                        <li class="next"><a href="{{ url_for('state', run=run+1,oncolor=colors[0]) }}">Next</a></li>
-                    {% elif not colors[0] and colors[1] %}
-                        <li class="next"><a href="{{ url_for('state', run=run+1,offcolor=colors[1]) }}">Next</a></li>
-                    {% elif colors[0] and colors[1]  %}
-                        <li class="next"><a href="{{ url_for('state', run=run+1,oncolor=colors[0],offcolor=colors[1]) }}">Next</a></li>
-                    {% else %}
-                        <li class="next"><a href="{{ url_for('state', run=run+1)}}">Next</a></li>
-                    {% endif %}
+                    <li class="next"><a id="next-link" href="{{ url_for('state', run=run+1)}}">Next</a></li>
                 </ul>
             </center>
         </div>
@@ -141,9 +123,7 @@
         {% if detector_control_state %}
             det_cont_info  = {{ detector_control_state | tojson | safe }};
         {% endif %}
-        {% if colors %}
-            colors = {{ colors | tojson | safe }}
-        {% endif %}
+        colors = [url_params.oncolor, url_params.offcolor];
 
         d3.select("#collapsesummary").classed("in",true);
         var summary = d3.select("#summary");
@@ -249,12 +229,25 @@
         };
 
         // The coloring has to go last so it can color everything drawn above
-        if(colors[0]){
-           change_colors("on",colors[0]);
+        url_str = ""
+        if(colors[0] && colors[1])
+        {
+            change_colors("on",colors[0]);
+            change_colors("off",colors[1]);
+            url_str = "?oncolor="+colors[0]+"&offcolor="+colors[1];
         }
-        if(colors[1]) {
+        else if(colors[0]){
+            url_str = "?oncolor="+colors[0];
+            change_colors("on",colors[0]);
+        }
+        else if(colors[1]) {
+            url_str = "?offcolor="+colors[1];
             change_colors("off",colors[1]);
         }
+        prev_link = document.getElementById("prev-link");
+        next_link = document.getElementById("next-link");
+        prev_link.setAttribute('href', prev_link.getAttribute('href')+url_str);
+        next_link.setAttribute('href', next_link.getAttribute('href')+url_str);
         resize()
         window.addEventListener("resize", resize,false);
        </script>

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -108,7 +108,7 @@
         var caen_data = {{ caen_state | caen_human_readable | tojson |safe }};
         var crates_data = {{ crates_state | all_crates_human_readable |tojson |safe }};
         var tubii_data = {{ tubii_state | tubii_human_readable | tojson |safe }};
-
+        var trigger_scan = {{ trigger_scan |trigger_scan_human_readable | tojson |safe }};
         var run_data = false;
         var det_cont_info = false;
         {% if run_state %}
@@ -145,7 +145,7 @@
         }
         if (mtc_data) {
             display_triggers(mtc_data.gt_words);
-            display_mtca_thresholds(mtc_data.MTCA_DACs);
+            display_mtca_thresholds(mtc_data.MTCA_DACs,trigger_scan);
             display_lockout_width(mtc_data.lockout_width);
             display_control_reg(mtc_data.control_reg);
             if(mtc_data.control_reg.filter(function(x) { x.indexOf("PED") > -1;}))

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -77,21 +77,23 @@
                    {% endcall %}
                    {% call collapsible_header('VBal','VBal') %}
                    {% endcall %}
-                   {% for i in range(20) %}
-                       {% if crates_state[i] %}
-                           {% call collapsible_header('Crate %i' % i,'crate%i' % i) %}
-                               {% for j in range(0,16) %}
-                                   {% call collapsible_header('Crate %i MB %i' % (i,j), 'Crate%iMB%i' % (i,j)) %}
-                                        <ul>
-                                        {% for key in crates_state[i][j] %}
-                                            <li>{{key}} = {{crates_state[i][j][key]}}</li>
-                                        {% endfor %}
-                                        </ul>
-                                   {% endcall %}
-                               {% endfor %}
-                           {% endcall %}
-                       {% endif %}
-                   {% endfor %}
+                   {% call collapsible_header('Data Dump','DataDump') %}
+                       {% for i in range(20) %}
+                           {% if crates_state[i] %}
+                               {% call collapsible_header('Crate %i' % i,'crate%i' % i) %}
+                                   {% for j in range(0,16) %}
+                                       {% call collapsible_header('Crate %i MB %i' % (i,j), 'Crate%iMB%i' % (i,j)) %}
+                                            <ul>
+                                            {% for key in crates_state[i][j] %}
+                                                <li>{{key}} = {{crates_state[i][j][key]}}</li>
+                                            {% endfor %}
+                                            </ul>
+                                       {% endcall %}
+                                   {% endfor %}
+                               {% endcall %}
+                           {% endif %}
+                       {% endfor %}
+                    {% endcall %}
                 {% endcall %}
             {% endif %}
     {% endif %}

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -125,17 +125,17 @@
         {% endif %}
         colors = [url_params.oncolor, url_params.offcolor];
 
-        d3.select("#collapsesummary").classed("in",true);
         var summary = d3.select("#summary");
         if (mtc_data) {
             var mtc = d3.select('#mtc');
             display_triggers(mtc,mtc_data.gt_words);
             display_triggers(summary,mtc_data.gt_words);
-            display_mtca_thresholds(mtc,mtc_data.MTCA_DACs,trigger_scan);
 
-            dacs = get_enabled_dacs(mtc_data.MTCA_DACs,mtc_data.gt_words);
+            enabled_dacs = get_enabled_dacs(mtc_data.MTCA_DACs,mtc_data.gt_words);
+            display_mtca_thresholds(mtc,mtc_data.MTCA_DACs,trigger_scan,enabled_dacs);
+
             node = summary.append('h3').text("Thresholds");
-            display_mtca_thresholds(summary,dacs,trigger_scan);
+            display_mtca_thresholds(summary,enabled_dacs,trigger_scan);
 
 
 

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -34,7 +34,6 @@
     </div>
     {% else %}
     <div class="row">
-
         <span>
         <div id="on_colors" class="dropdown">
         <button class="btn btn-default dropdown-toggle" type="button"  data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
@@ -64,62 +63,62 @@
             </center>
         </div>
     </div>
-                {% call collapsible_header('Executive Summary','summary') %}
-                {% endcall %}
-            {% if mtc_state %}
-                {% call collapsible_header('MTC','mtc') %}
-                {% endcall %}
-            {% endif %}
-            {% if caen_state %}
-                {% call collapsible_header('CAEN','CAEN') %}
-                    {% call collapsible_header('Dump Data','CAENDump') %}
-                        <ul>
-                        {% for key,val in caen_state.iteritems() %}
-                            <li> {{key}} = {{ val }} </li>
-                        {% endfor %}
-                        </ul>
-                    {% endcall %}
-                {% endcall %}
-            {% endif %}
-            {% if tubii_state %}
-                {% call collapsible_header('TUBii','tubii') %}
-                {% endcall %}
-            {% endif %}
-            {% if detector_control_state %}
-                {% call collapsible_header('Detector Control','detector_control') %}
-                {% endcall %}
-            {% endif %}
-            {% if crates_state %}
-                {% call collapsible_header('Crates','allCrates') %}
-                   {% call collapsible_header('N100 Triggers','N100Triggers') %}
-                   {% endcall %}
-                   {% call collapsible_header('N20 Triggers','N20Triggers') %}
-                   {% endcall %}
-                   {% call collapsible_header('Sequencers','Sequencers') %}
-                   {% endcall %}
-                   {% call collapsible_header('Channel Thresholds','VThr') %}
-                   {% endcall %}
-                   {% call collapsible_header('VBal','VBal') %}
-                   {% endcall %}
-                   {% call collapsible_header('Data Dump','DataDump') %}
-                       {% for i in range(20) %}
-                           {% if crates_state[i] %}
-                               {% call collapsible_header('Crate %i' % i,'crate%i' % i) %}
-                                   {% for j in range(0,16) %}
-                                       {% call collapsible_header('Crate %i MB %i' % (i,j), 'Crate%iMB%i' % (i,j)) %}
-                                            <ul>
-                                            {% for key in crates_state[i][j] %}
-                                                <li>{{key}} = {{crates_state[i][j][key]}}</li>
-                                            {% endfor %}
-                                            </ul>
-                                       {% endcall %}
-                                   {% endfor %}
+    <div id='summary'></div>
+    <hr>
+    {% if mtc_state %}
+        {% call collapsible_header('MTC','mtc') %}
+        {% endcall %}
+    {% endif %}
+    {% if caen_state %}
+        {% call collapsible_header('CAEN','CAEN') %}
+            {% call collapsible_header('Dump Data','CAENDump') %}
+                <ul>
+                {% for key,val in caen_state.iteritems() %}
+                    <li> {{key}} = {{ val }} </li>
+                {% endfor %}
+                </ul>
+            {% endcall %}
+        {% endcall %}
+    {% endif %}
+    {% if tubii_state %}
+        {% call collapsible_header('TUBii','tubii') %}
+        {% endcall %}
+    {% endif %}
+    {% if detector_control_state %}
+        {% call collapsible_header('Detector Control','detector_control') %}
+        {% endcall %}
+    {% endif %}
+    {% if crates_state %}
+        {% call collapsible_header('Crates','allCrates') %}
+           {% call collapsible_header('N100 Triggers','N100Triggers') %}
+           {% endcall %}
+           {% call collapsible_header('N20 Triggers','N20Triggers') %}
+           {% endcall %}
+           {% call collapsible_header('Sequencers','Sequencers') %}
+           {% endcall %}
+           {% call collapsible_header('Channel Thresholds','VThr') %}
+           {% endcall %}
+           {% call collapsible_header('VBal','VBal') %}
+           {% endcall %}
+           {% call collapsible_header('Data Dump','DataDump') %}
+               {% for i in range(20) %}
+                   {% if crates_state[i] %}
+                       {% call collapsible_header('Crate %i' % i,'crate%i' % i) %}
+                           {% for j in range(0,16) %}
+                               {% call collapsible_header('Crate %i MB %i' % (i,j), 'Crate%iMB%i' % (i,j)) %}
+                                    <ul>
+                                    {% for key in crates_state[i][j] %}
+                                        <li>{{key}} = {{crates_state[i][j][key]}}</li>
+                                    {% endfor %}
+                                    </ul>
                                {% endcall %}
-                           {% endif %}
-                       {% endfor %}
-                    {% endcall %}
-                {% endcall %}
-            {% endif %}
+                           {% endfor %}
+                       {% endcall %}
+                   {% endif %}
+               {% endfor %}
+            {% endcall %}
+        {% endcall %}
+    {% endif %}
     {% endif %}
     </div>
 {% endblock %}
@@ -147,45 +146,18 @@
         {% endif %}
         d3.select("#collapsesummary").classed("in",true);
         var summary = d3.select("#summary");
-        if(crates_data) {
-            var N100 = d3.select("#N100Triggers");
-            var N20 = d3.select("#N20Triggers");
-            var Seq = d3.select("#Sequencers");
-            var vThr = d3.select("#VThr");
-            var VBal = d3.select("#VBal");
-            var width = N100.node().parentElement.parentElement.clientWidth
-            var height = 500;
-            sizeinfo = {};
-            sizeinfo.width = width;
-            sizeinfo.height = height;
-            add_line = function(node,text)
-            {
-                node.append('h3').text(text);
-            };
-            add_line(N100,"Num Enabled = "+crates_data['num_n100_triggers'].toString());
-            add_line(N20,"Num Enabled = "+crates_data['num_n20_triggers'].toString());
-            add_line(Seq,"Num Enabled = "+crates_data['num_sequencers'].toString());
-            add_line(summary,"Number of Sequencers Enabled = "+crates_data['num_sequencers'].toString());
-            add_line(summary,"Number of N100s Enabled = "+crates_data['num_n100_triggers'].toString());
-            add_line(summary,"Number of N20s Enabled = "+crates_data['num_n20_triggers'].toString());
-            display_binary_crate_view('n100_triggers',crates_data.crates,sizeinfo,N100)
-            display_binary_crate_view('n20_triggers',crates_data.crates,sizeinfo,N20)
-            display_binary_crate_view('sequencers',crates_data.crates,sizeinfo,Seq)
-            display_continuous_crate_view('vthrs',crates_data.crates,sizeinfo,vThr)
-            vbal_table = VBal.append('table');
-            vbal_table.append('tr').append('th').append('h3').text("VBal 0");
-            vbal0 = vbal_table.append('tr').append('th');
-            vbal_table.append('tr').append('th').append('h3').text("VBal 1");
-            vbal1 = vbal_table.append('tr').append('th');
-            display_continuous_crate_view('vbal_0',crates_data.crates,sizeinfo,vbal0)
-            display_continuous_crate_view('vbal_1',crates_data.crates,sizeinfo,vbal1)
-        }
         if (mtc_data) {
             var mtc = d3.select('#mtc');
             display_triggers(mtc,mtc_data.gt_words);
             display_triggers(summary,mtc_data.gt_words);
             display_mtca_thresholds(mtc,mtc_data.MTCA_DACs,trigger_scan);
-            display_mtca_thresholds(summary,mtc_data.MTCA_DACs,trigger_scan);
+
+            dacs = get_enabled_dacs(mtc_data.MTCA_DACs,mtc_data.gt_words);
+            node = summary.append('h3').text("Thresholds");
+            display_mtca_thresholds(summary,dacs,trigger_scan);
+
+
+
             display_lockout_width(mtc,mtc_data.lockout_width);
             display_control_reg(mtc,mtc_data.control_reg);
             if(mtc_data.control_reg.filter(function(x) { x.indexOf("PED") > -1;}))
@@ -207,8 +179,46 @@
         if (run_data) {
             display_run_type(run_data.run_type,run_data.timestamp)
         }
+        if(crates_data) {
+            var N100 = d3.select("#N100Triggers");
+            var N20 = d3.select("#N20Triggers");
+            var Seq = d3.select("#Sequencers");
+            var vThr = d3.select("#VThr");
+            var VBal = d3.select("#VBal");
+            var width = N100.node().parentElement.parentElement.clientWidth
+            var height = 500;
+            sizeinfo = {};
+            sizeinfo.width = width;
+            sizeinfo.height = height;
+            add_line = function(node,text)
+            {
+                node.append('h3').text(text);
+            };
+
+            table = summary.append('table').attr('class','table')
+            head = table.append('thead').append('tr')
+            head.append('th').text('# Sequencers')
+            head.append('th').text('# N100s')
+            head.append('th').text('# N20s')
+            row = table.append('tbody') .append('tr')
+            row.append('td').append('big').text(crates_data['num_sequencers'])
+            row.append('td').append('big').text(crates_data['num_n100_triggers'])
+            row.append('td').append('big').text(crates_data['num_n20_triggers'])
+
+            display_binary_crate_view('n100_triggers',crates_data.crates,sizeinfo,N100)
+            display_binary_crate_view('n20_triggers',crates_data.crates,sizeinfo,N20)
+            display_binary_crate_view('sequencers',crates_data.crates,sizeinfo,Seq)
+            display_continuous_crate_view('vthrs',crates_data.crates,sizeinfo,vThr)
+            vbal_table = VBal.append('table');
+            vbal_table.append('tr').append('th').append('h3').text("VBal 0");
+            vbal0 = vbal_table.append('tr').append('th');
+            vbal_table.append('tr').append('th').append('h3').text("VBal 1");
+            vbal1 = vbal_table.append('tr').append('th');
+            display_continuous_crate_view('vbal_0',crates_data.crates,sizeinfo,vbal0)
+            display_continuous_crate_view('vbal_1',crates_data.crates,sizeinfo,vbal1)
+        }
         if (det_cont_info) {
-            summary.append("h3").text("Number of Crates On = "+num_crates_on(det_cont_info));
+            summary.append("h3").text("Crates On = "+num_crates_on(det_cont_info));
             display_detector_control(det_cont_info);
         }
         if (tubii_data) {

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -144,13 +144,6 @@
         {% if colors %}
             colors = {{ colors | tojson | safe }}
         {% endif %}
-        function change_colors(class_name,color) {
-            var cols = document.getElementsByClassName(class_name);
-            for(i=0;i<cols.length;i++) {
-                cols[i].style.fill = color;
-                cols[i].style['background-color'] = color;
-            }
-        }
 
         d3.select("#collapsesummary").classed("in",true);
         var summary = d3.select("#summary");

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -123,6 +123,7 @@
 {% endblock %}
 {% block script %}
     <script src="{{ url_for('static', filename='js/d3.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/colorbrewer.js') }}"></script>
     <script src="{{ url_for('static', filename='js/crate.js') }}"></script>
     <script src="{{ url_for('static', filename='js/detector_state.js') }}"></script>
     <script type="text/javascript">
@@ -208,14 +209,14 @@
             display_binary_crate_view('n100_triggers',crates_data.crates,sizeinfo,N100)
             display_binary_crate_view('n20_triggers',crates_data.crates,sizeinfo,N20)
             display_binary_crate_view('sequencers',crates_data.crates,sizeinfo,Seq)
-            display_continuous_crate_view('vthrs',crates_data.crates,sizeinfo,vThr)
+            display_colorable_continuous_crate_view('vthrs',crates_data.crates,sizeinfo,vThr);
             vbal_table = VBal.append('table');
             vbal_table.append('tr').append('th').append('h3').text("VBal 0");
             vbal0 = vbal_table.append('tr').append('th');
             vbal_table.append('tr').append('th').append('h3').text("VBal 1");
             vbal1 = vbal_table.append('tr').append('th');
-            display_continuous_crate_view('vbal_0',crates_data.crates,sizeinfo,vbal0)
-            display_continuous_crate_view('vbal_1',crates_data.crates,sizeinfo,vbal1)
+            display_colorable_continuous_crate_view('vbal_0',crates_data.crates,sizeinfo,vbal0);
+            display_colorable_continuous_crate_view('vbal_1',crates_data.crates,sizeinfo,vbal1);
         }
         if (det_cont_info) {
             summary.append("h3").text("Crates On = "+num_crates_on(det_cont_info));

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -75,6 +75,8 @@
                    {% endcall %}
                    {% call collapsible_header('Channel Thresholds','VThr') %}
                    {% endcall %}
+                   {% call collapsible_header('VBal','VBal') %}
+                   {% endcall %}
                    {% for i in range(20) %}
                        {% if crates_state[i] %}
                            {% call collapsible_header('Crate %i' % i,'crate%i' % i) %}
@@ -118,6 +120,7 @@
             var N20 = d3.select("#N20Triggers");
             var Seq = d3.select("#Sequencers");
             var vThr = d3.select("#VThr");
+            var VBal = d3.select("#VBal");
             var width = N100.node().parentElement.parentElement.clientWidth
             var height = 500;
             sizeinfo = {};
@@ -130,6 +133,13 @@
             display_binary_crate_view('n20_triggers',crates_data.crates,sizeinfo,N20)
             display_binary_crate_view('sequencers',crates_data.crates,sizeinfo,Seq)
             display_continuous_crate_view('vthrs',crates_data.crates,sizeinfo,vThr)
+            vbal_table = VBal.append('table');
+            vbal_table.append('tr').append('th').append('h3').text("VBal 0");
+            vbal0 = vbal_table.append('tr').append('th');
+            vbal_table.append('tr').append('th').append('h3').text("VBal 1");
+            vbal1 = vbal_table.append('tr').append('th');
+            display_continuous_crate_view('vbal_0',crates_data.crates,sizeinfo,vbal0)
+            display_continuous_crate_view('vbal_1',crates_data.crates,sizeinfo,vbal1)
         }
         if (mtc_data) {
             display_triggers(mtc_data.gt_words);

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -134,7 +134,6 @@
         var run_data = false;
         var det_cont_info = false;
 
-
         {% if run_state %}
             run_data = {{ run_state | tojson | safe }}
         {% endif %}

--- a/minard/templates/state.html
+++ b/minard/templates/state.html
@@ -1,6 +1,6 @@
 {% macro collapsible_header(title,name) %}
 <div class="row">
-   <div class="panel-group">
+   <div class="panel-group" style="margin:10px">
        <div class="panel panel-default">
            <div class="panel-heading">
                <h4 class="panel-title">
@@ -172,7 +172,7 @@
             display_detector_control(det_cont_info);
         }
         if (tubii_data) {
-            display_tubii(tubii_data);
+    display_tubii(tubii_data);
         }
         if (caen_data) {
             display_caen(caen_data);

--- a/minard/views.py
+++ b/minard/views.py
@@ -91,6 +91,9 @@ def state(run=None):
     try:
         run_state = detector_state.get_run_state(run)
         run = run_state['run']
+        # Have to put these in ISO foramt so flask doesn't mangle it later
+        run_state['timestamp'] = run_state['timestamp'].isoformat()
+        run_state['end_timestamp'] = run_state['end_timestamp'].isoformat()
     except Exception as e:
         return render_template('state.html', err=str(e))
 

--- a/minard/views.py
+++ b/minard/views.py
@@ -117,7 +117,9 @@ def state(run=None):
 
     if not any(crates_state):
         crates_state = None;
-
+    trigger_scan = None
+    if run_state['timestamp'] is not None:
+        trigger_scan = detector_state.get_trigger_scan_for_run(run)
     # The timestamp doesn't come with any timezone info. Here I'm adding that
     # info by hand. If the DB isn't running in EST timezone then this will be
     # wrong.
@@ -130,6 +132,7 @@ def state(run=None):
                                         caen_state = caen_state,
                                         tubii_state = tubii_state,
                                         crates_state = crates_state,
+                                        trigger_scan = trigger_scan,
                                         err = None)
 
 @app.route('/l2')

--- a/minard/views.py
+++ b/minard/views.py
@@ -93,7 +93,9 @@ def state(run=None):
         run = run_state['run']
         # Have to put these in ISO foramt so flask doesn't mangle it later
         run_state['timestamp'] = run_state['timestamp'].isoformat()
-        run_state['end_timestamp'] = run_state['end_timestamp'].isoformat()
+        # end_timestamp isn't that important. If it's not there, it's ignored
+        if(run_state['end_timestamp']):
+            run_state['end_timestamp'] = run_state['end_timestamp'].isoformat()
     except Exception as e:
         return render_template('state.html', err=str(e))
 

--- a/minard/views.py
+++ b/minard/views.py
@@ -3,7 +3,6 @@ from . import app
 from flask import render_template, jsonify, request, redirect, url_for
 from itertools import product
 import time
-from pytz import timezone
 from redis import Redis
 from os.path import join
 import json
@@ -121,11 +120,6 @@ def state(run=None):
     trigger_scan = None
     if run_state['timestamp'] is not None:
         trigger_scan = detector_state.get_trigger_scan_for_run(run)
-    # The timestamp doesn't come with any timezone info. Here I'm adding that
-    # info by hand. If the DB isn't running in EST timezone then this will be
-    # wrong.
-    est = timezone('Canada/Eastern')
-    run_state['timestamp'] = est.localize(run_state['timestamp'])
 
     oncolor = request.args.get('oncolor')
     offcolor = request.args.get('offcolor')

--- a/minard/views.py
+++ b/minard/views.py
@@ -136,7 +136,6 @@ def state(run=None):
     if(not offcolor):
         colors[1] = False
 
-    print(colors)
     return render_template('state.html', run=run,
                            run_state=run_state,
                            detector_control_state=detector_control_state,

--- a/minard/views.py
+++ b/minard/views.py
@@ -129,8 +129,13 @@ def state(run=None):
 
     oncolor = request.args.get('oncolor')
     offcolor = request.args.get('offcolor')
-    if(oncolor or offcolor):
-        colors = [oncolor, offcolor]
+    colors = [oncolor, offcolor]
+
+    if(not oncolor):
+        colors[0] = False
+    if(not offcolor):
+        colors[1] = False
+
     print(colors)
     return render_template('state.html', run=run,
                            run_state=run_state,

--- a/minard/views.py
+++ b/minard/views.py
@@ -84,6 +84,7 @@ def timefmt(timestamp):
 def status():
     return render_template('status.html', programs=PROGRAMS)
 
+
 @app.route('/state')
 @app.route('/state/')
 @app.route('/state/<int:run>')
@@ -93,7 +94,7 @@ def state(run=None):
         run = run_state['run']
     except Exception as e:
         return render_template('state.html', err=str(e))
-        
+
     detector_control_state = None
     if run_state['detector_control'] is not None:
         detector_control_state = detector_state.get_detector_control_state(run_state['detector_control'])
@@ -110,13 +111,13 @@ def state(run=None):
     if run_state['tubii'] is not None:
         tubii_state = detector_state.get_tubii_state(run_state['tubii'])
 
-    crates_state =[None]*20
+    crates_state = [None]*20
     for iCrate in range(20):
         if run_state['crate'+str(iCrate)] is not None:
             crates_state[iCrate] = detector_state.get_crate_state(run_state['crate'+str(iCrate)])
 
     if not any(crates_state):
-        crates_state = None;
+        crates_state = None
     trigger_scan = None
     if run_state['timestamp'] is not None:
         trigger_scan = detector_state.get_trigger_scan_for_run(run)
@@ -125,15 +126,23 @@ def state(run=None):
     # wrong.
     est = timezone('Canada/Eastern')
     run_state['timestamp'] = est.localize(run_state['timestamp'])
-    return render_template('state.html',run=run,
-                                        run_state = run_state,
-                                        detector_control_state = detector_control_state,
-                                        mtc_state = mtc_state,
-                                        caen_state = caen_state,
-                                        tubii_state = tubii_state,
-                                        crates_state = crates_state,
-                                        trigger_scan = trigger_scan,
-                                        err = None)
+
+    oncolor = request.args.get('oncolor')
+    offcolor = request.args.get('offcolor')
+    if(oncolor or offcolor):
+        colors = [oncolor, offcolor]
+    print(colors)
+    return render_template('state.html', run=run,
+                           run_state=run_state,
+                           detector_control_state=detector_control_state,
+                           mtc_state=mtc_state,
+                           caen_state=caen_state,
+                           tubii_state=tubii_state,
+                           crates_state=crates_state,
+                           trigger_scan=trigger_scan,
+                           colors=colors,
+                           err=None)
+
 
 @app.route('/l2')
 def l2():

--- a/minard/views.py
+++ b/minard/views.py
@@ -121,15 +121,6 @@ def state(run=None):
     if run_state['timestamp'] is not None:
         trigger_scan = detector_state.get_trigger_scan_for_run(run)
 
-    oncolor = request.args.get('oncolor')
-    offcolor = request.args.get('offcolor')
-    colors = [oncolor, offcolor]
-
-    if(not oncolor):
-        colors[0] = False
-    if(not offcolor):
-        colors[1] = False
-
     return render_template('state.html', run=run,
                            run_state=run_state,
                            detector_control_state=detector_control_state,
@@ -138,7 +129,6 @@ def state(run=None):
                            tubii_state=tubii_state,
                            crates_state=crates_state,
                            trigger_scan=trigger_scan,
-                           colors=colors,
                            err=None)
 
 


### PR DESCRIPTION
This adds displays for MTCA thresholds as well as channel thresholds and a few other channel level items
Also added are a few interesting values for the CAEN and many of the less interesting ones are hidden away.
There's also now a summary of some of the most critical values displayed at the top of the page,
this gives the masked in triggers, the thresholds for those triggers (the ones that have thresholds anyways), the number of N100/N20 Triggers enabled, the number of sequencers enabled and the number of crates that are on.

There's a number of aesthetic changes here too including having a more "telescoping" look to the collapsible display. Also the colors for many of the things can be configured by the user by adding the appropriate request to the url (e.g. /monitoring/state/10802?oncolor=red&offcolor=black).
And probably a bunch of  other changes I don't remember.

One specific thing I'd like input on is how to display non-binary channel values. Currently I do so with a crate display each pixel of which linearly changes from grey to yellow depending on the value being displayed (below is an example). I'd like a way for the user to again put the colors they'd prefer in URL but the prev/next run buttons have to preserve that URL and with just two options they way I do accomplish that is clunky (see line 41 of state.html), with 4 potential options my current method would be absurd. So if there's a better way to handle that, let me know.

![screen shot 2016-10-14 at 5 10 11 pm](https://cloud.githubusercontent.com/assets/4153907/19403038/a01ccf30-9232-11e6-93a8-104187984a33.png)



