### PR TITLE
Update nearline template with additional status code

### DIFF
--- a/minard/templates/nearline.html
+++ b/minard/templates/nearline.html
@@ -38,6 +38,8 @@
 			<th> Debug </th>
 			{% elif status|int == 4 %}
 			<th> Not run </th>
+                       {% elif status|int == 98 %}
+                       <th class="warning"> Not executable </th>
 			{% elif status|int == 99 %}
 			<th> In Progress </th>
 			{% else %}


### PR DESCRIPTION
Nearline has been updated with a new exit code to be used when a nonexecutable file is passed; this update will display a more useful message on the monitoring page in this case.