### PR TITLE
Add Rat tab (mark 2)

### DIFF
--- a/minard/nlrat.py
+++ b/minard/nlrat.py
@@ -1,0 +1,80 @@
+import detector_state
+import glob
+import os
+import re
+from redis import Redis
+
+REDIS_SET = "nlrat-runs"
+redis = Redis()
+
+RUN_TYPES = {
+    0:"Maintenance",
+    1:"Transition",
+    2:"Physics",
+    3:"Deployed Source",
+    4:"External Source",
+    5:"ECA",
+    6:"Diagnostic",
+    7:"Experimental",
+    }
+
+def extract_run_type(run_word):
+    '''Get the run type from the run word using RUN_TYPES
+    :param int run_word:
+    :returns string:
+    '''
+    for k, v in RUN_TYPES.iteritems():
+        if (run_word & (1 << k)):
+            return v
+    return "Unknown"
+
+def hists_available(run):
+    '''Are the histograms for this run available?
+    :param int: run number
+    :returns bool: true if they are
+    '''
+    return redis.sismember(REDIS_SET, run)
+
+def available_run_ids():
+    '''Get a list of available runs from the redis server
+    :returns list(int): in ascending order
+    '''
+    return sorted([int(x) for x in redis.smembers(REDIS_SET)], reverse=True)
+    
+def run_time(run):
+    '''Get the run start time using the detector state db
+    :param int run:
+    :returns str: "-" if not found
+    '''
+    try:
+        return detector_state.get_run_state(run)['timestamp'].strftime("%m-%d-%y %H:%M:%S")
+    except:
+        return "-"
+
+def run_type_word(run):
+    '''Get the run start time using the detector state db
+    :param int run:
+    :returns str: "-" if not found
+    '''
+    try:
+        return detector_state.get_run_state(run)['run_type']
+    except:
+        return "-"
+
+class Run:
+    '''Class to hold run info
+    '''
+    def __init__(self, id):
+        '''
+        :param int id:
+        :param str time:
+        '''
+        self.id = id
+        self.time = run_time(id)
+        self.type = extract_run_type(run_type_word(id))
+
+def available_runs():
+    '''Get the runs available, IDs and start times
+    :returns list(Run): reverse sorted by ID
+    '''
+    return [Run(id) for id in available_run_ids()]

--- a/minard/static/css/ratrun.css
+++ b/minard/static/css/ratrun.css
@@ -1,0 +1,22 @@
+/* make sidebar nav vertical */ 
+@media (min-width: 768px) {
+  .sidebar-nav .navbar .navbar-collapse {
+    padding: 0;
+    max-height: none;
+  }
+  .sidebar-nav .navbar ul {
+    float: none;
+    display: block;
+  }
+  .sidebar-nav .navbar li {
+    float: none;
+    display: block;
+  }
+  .sidebar-nav .navbar li a{
+    padding-top: 12px;
+    padding-bottom: 12px;
+  }
+  .sidebar-nav .navbar li .active{
+     border-bottom: 3px solid rgb(52,117,188);
+  }  
+}

--- a/minard/static/js/rat.js
+++ b/minard/static/js/rat.js
@@ -1,0 +1,198 @@
+function createPage(runNumber, plotDivName){
+    var histFileName = $SCRIPT_ROOT + "/static/nlrat/r" + runNumber.toString() + "_nl_th1f.root";
+    var ntupFileName = $SCRIPT_ROOT + "/static/nlrat/r" + runNumber.toString() + "_nl_ntups.zip";
+    document.getElementById("histbut").onclick = function(){window.open(histFileName);};
+    document.getElementById("ntupbut").onclick = function(){window.open(ntupFileName);};
+
+    displaySummary(histFileName, document.getElementById(plotDivName));
+}
+
+function createPlotDivs(names, parentDiv){
+    var fragment = document.createDocumentFragment();
+    names.forEach(function(name){
+            if (!document.getElementById(name)){
+                var row = document.createElement("div");
+                row.className = "row plot";
+
+                var col = document.createElement("div");
+                col.className = "col-md-12 plot";
+
+                var div = document.createElement("div");
+                div.id = name;
+                div.className = "plot";
+
+                col.appendChild(div);
+                row.appendChild(col);
+                fragment.appendChild(row);
+            }
+        });
+    parentDiv.appendChild(fragment);
+}
+
+function createPlotGrid(names, parentDiv){
+    var ncols = 3;
+    var nrows = Math.ceil(names.length/ncols);
+    var divs = [];
+
+    var fragment = document.createDocumentFragment();
+    var iName = 0;
+    for(var iRow = 0; iRow < nrows; iRow++){
+        var row = document.createElement("div");
+        row.className = "row plot";
+
+          for(var iCol = 0; iCol < ncols; iCol++){
+            var col = document.createElement("div");
+            col.className = "col-md-4 plot";
+
+            var div = document.createElement("div");
+            div.className = "plot";
+            div.id = names[iName++];
+
+            col.appendChild(div);
+            row.appendChild(col);
+            divs.push(div);
+        }
+        fragment.appendChild(row);
+    }
+    parentDiv.appendChild(fragment);
+    return divs;
+}
+
+function readBranch(keyName){
+    var name = keyName.substring(0, keyName.lastIndexOf("_"));
+    var num  = keyName.substring(keyName.lastIndexOf("_") + 1, keyName.length);
+    return {"name" : name, "num" : parseInt(num)};
+}
+
+function compareKeys(a, b){
+    var parsedA = readBranch(a);
+    var parsedB = readBranch(b);
+    if (parsedA.name === parsedB.name){
+        return parsedA.num - parsedB.num;
+    }
+    return a.localeCompare(b);
+}
+
+function readBranches(histNames){
+    var branchNames = new Set();
+    histNames.forEach(function(key){branchNames.add(readBranch(key).name)});
+    return Array.from(branchNames);
+}
+
+function addSidebarEntry(branchName, fragment){
+    var entry = document.createElement("li");
+    var link  = document.createElement("a");
+    link.href = "javascript:void(0)";
+
+    link.innerHTML = branchName;
+    link.className = "branchLink";
+
+    entry.appendChild(link);
+    fragment.appendChild(entry);
+}
+
+function fillSidebar(keyNames){
+    if(typeof(arguments.callee.done) == "undefined"){
+        var fragment = document.createDocumentFragment();
+        var branchNames = readBranches(keyNames);
+        branchNames.sort();
+        branchNames.forEach(function(branch){
+                addSidebarEntry(branch, fragment);
+            });
+
+        document.getElementById("sidebarlist").appendChild(fragment);
+        arguments.callee.done = 1;
+    }
+}
+
+function linkSidebar(histFileName, plotDiv){
+    if(typeof(arguments.callee.done) == "undefined"){
+        var links = document.getElementsByClassName("branchLink");
+        var linkArray  = [].slice.call(links, 0);
+        linkArray.forEach(
+                          function(link){
+                              link.addEventListener("click",
+                                                    function(){
+                                                        displayBranch(histFileName, plotDiv, link.innerHTML);
+                                                        $(".active").removeClass("active");
+                                                        link.className = "active";
+                                                    });
+
+                          });
+
+        document.getElementById("summary-button").addEventListener("click",
+                                                                   function(evt){
+                                                                       displaySummary(histFileName, plotDiv);
+                                                                       $(".active").removeClass("active");
+                                                                       evt.target.className = "active";
+                                                                   });
+        arguments.callee.done = 1;
+    }
+
+}
+
+function displaySummary(histFileName, plotDiv){
+    window.onresize = function(){displaySummary(histFileName, plotDiv);};
+    // open file
+    new JSROOT.TFile(histFileName, function(file){
+            // read the keys inside
+            var plotNames = [];
+            var keyNames = [];
+            file.fKeys.forEach(function(key){
+                    var keyName = key.fName;
+                    if(keyName === "StreamerInfo")
+                        return;
+
+                    if(typeof(branchName) != 'undefined' && readBranch(keyName).name != branchName){
+                        return;
+                    }
+
+                    plotNames.push(keyName);
+                });
+            plotNames.sort(compareKeys);
+
+            $(".plot").remove();
+            createPlotGrid(plotNames, plotDiv);
+            plotNames.forEach(function(plotName){
+                    file.ReadObject(plotName, function(obj) {
+                            JSROOT.draw(plotName, obj, "E");
+                            JSROOT.draw(plotName, obj, "HISTF");
+                        });
+                });
+
+            fillSidebar(plotNames);
+            linkSidebar(histFileName, plotDiv);
+    });
+}
+
+
+function displayBranch(histFileName, plotDiv, branchName){
+    window.onresize = function(){displayBranch(histFileName, plotDiv, branchName);};
+    // open file
+    new JSROOT.TFile(histFileName, function(file){
+            // read the keys inside
+            var plotNames = [];
+            var keyNames = [];
+            file.fKeys.forEach(function(key){
+                    var keyName = key.fName;
+                    if(keyName === "StreamerInfo")
+                        return;
+
+                    if(typeof(branchName) != "undefined" && readBranch(keyName).name != branchName){
+                        return;
+                    }
+
+                    plotNames.push(keyName);
+                });
+            plotNames.sort(compareKeys);
+
+            $(".plot").remove();
+            createPlotDivs(plotNames, plotDiv);
+            plotNames.forEach(function(plotName){
+                    file.ReadObject(plotName, function(obj) {
+                            JSROOT.draw(plotName, obj, "E");
+                            JSROOT.draw(plotName, obj, "HISTF");
+                        });
+                });
+    });
+}

--- a/minard/templates/layout.html
+++ b/minard/templates/layout.html
@@ -44,6 +44,7 @@
                         {{ nav_link('detector', 'Detector') }}
                         {{ nav_link('daq', 'DAQ') }}
                         {{ nav_link('nearline', 'Nearline') }}
+                        {{ nav_link('rathome', 'RAT') }}
                         {{ nav_link('trigger', 'Trigger Scans') }}
                         <!-- Dropdown PMTcal -->
                         <li class='dropdown'>

--- a/minard/templates/rathome.html
+++ b/minard/templates/rathome.html
@@ -1,0 +1,28 @@
+{% extends "layout.html" %}
+{% block title %} RAT {% endblock %}
+{% block head %}
+    {{ super() }}
+{% endblock %}
+{% block body %}
+{{ super() }}
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Run #</th>
+          <th>Run Type</th>
+          <th>Start Time</th>
+        </tr>
+      </thead>
+      {% for run in runs %}
+      <tr>
+        <th> <a href = "{{ url_for('ratrun', run=run.id) }}"> {{run.id}} </a> </th>
+        <th> {{run.type}} </th>
+        <th> {{run.time}} </th>
+      </tr>
+      {% endfor %}
+    </table>
+  </div>
+</div>
+{% endblock %}

--- a/minard/templates/ratrun.html
+++ b/minard/templates/ratrun.html
@@ -1,0 +1,101 @@
+{% extends "layout.html" %}
+{% block title %} RAT {% endblock %}
+{% block head %}
+{{ super() }}
+
+<script type="text/javascript" src="https://root.cern/js/5.0.3/scripts/JSRootCore.min.js?2d&&io"></script>
+<link rel="stylesheet" href="{{url_for('static', filename='css/ratrun.css') }}">
+
+{% endblock %}
+
+{% block body %}
+   {{ super() }}
+<!-- The Run Title and nav buttons-->
+<div class="container">
+  <div class="row">
+    <div class="col-md-10 col-md-offset-1">
+    <center>
+      <ul class="pager">
+        <li class="previous"><a href="{{ url_for('ratrun', run=run.id-1) }}">Prev</a></li>
+        <li><h2 style="display:inline"> Run {{ run.id }} </h2></li>
+        <li class="next"><a href="{{ url_for('ratrun', run=run.id + 1) }}">Next</a></li>
+      </ul>
+      <h4> {{run.type}} </h4>
+      <h4> {{run.time}} </h4>
+    </center>
+    </div>
+  </div>
+
+    {% if error %}
+  <div class = "row">
+    <div class="col-md-10 col-md-offset-1">
+      <div class="alert alert-danger" role="alert">
+        <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+        Data unavailable
+      </div>
+    </div>
+  </div>
+  {% else %}
+
+  <!-- Download buttons-->
+  <div class="row">
+    <div class="col-md-10 col-md-offset-1">
+      <center>
+        <button id = "histbut" type="submit"> Download Histograms</button>
+        <button id = "ntupbut" type="submit"> Download Ntuple </button>
+      </center>
+    </div>
+  </div>
+
+
+
+  <div class="row" style="margin-top : 70px;">
+  </div>
+
+  <!-- Sidebar and plot area-->
+  <div class="row">
+    <div class="col-md-2">
+      <div class="sidebar-nav">
+        <div class="navbar navbar-default" role="navigation">
+          <div class="navbar-header">
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".sidebar-navbar-collapse">
+              <span class="sr-only">Toggle navigation</span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+            </button>
+            <span class="visible-xs navbar-brand">Branches</span>
+          </div>
+          <div class="navbar-collapse collapse sidebar-navbar-collapse">
+            <ul class="nav navbar-nav" id="sidebarlist">
+              <li> <a class = "active" id="summary-button"href="javascript:void(0)"> Summary  </a> </li>
+            </ul>
+          </div><!--/.nav-collapse -->
+        </div>
+      </div>
+    </div>
+
+    <div class="col-md-10" id="plotarea">
+    </div>
+  </div>
+</div>
+<!-- Container end -->
+{% endif %}
+{% endblock %}
+
+{% block script %}
+{% if not error %}
+
+    <div id="loading" style="display: none;"> </div> <!-- JSROOT wants to dump loading messages somewhere-->
+    <script type="text/javascript">
+
+      $(document).ready(
+            function(){
+                JSROOT.AssertPrerequisites("io;2d;user:{{ url_for('static', filename='js/rat.js') }}", function(){
+                    createPage({{ run.id }}, "plotarea");
+            }, "loading");
+      });
+    </script>
+
+{% endif %}
+{% endblock %}

--- a/minard/views.py
+++ b/minard/views.py
@@ -14,6 +14,8 @@ from math import isnan
 import detector_state
 import pcadb
 import ecadb
+import nlrat
+
 
 TRIGGER_NAMES = \
 ['100L',
@@ -279,6 +281,14 @@ def snostream():
 @app.route('/nhit')
 def nhit():
   return render_template('nhit.html')
+
+@app.route('/rat')
+def rathome():
+    return render_template('rathome.html', runs=nlrat.available_runs())
+    
+@app.route('/rat/<int:run>')
+def ratrun(run = 0):
+    return render_template("ratrun.html", run=nlrat.Run(run), error= not nlrat.hists_available(run))
 
 @app.route('/l2_filter')
 def l2_filter():


### PR DESCRIPTION
I force pushed to this branch while the PR was closed, so git won't let me reopen #34 . The difference is the addition of a side bar that allows users to plot all the histograms for a single branch, or a summary page with everying in tiled plots. It also adds the run type/start time to the run page.

Accompanies #snoplus/nearline/15

* Serve the .root/.zip files containing histograms/ntuples produced by the nlrat processor and placed in space shared with the nearline machine. Corresponds to views /rat/r104_nl_th1f.root and rat/r104_nl_ntups.root for run 104

*  rathome.html shows the available run numbers, types and start times using functions defined in nlrat.py. Corresponds to view rat

*    ratrun.html and rat.js use JSROOT to display histograms for a run, either by branch or a summary selected on a side bar. Also has buttons for downloading the histograms and ntuples on a single page. Corresponds to view rat/104 for run 104.

Before merging this needs NLRAT_DIR to be set to some location shared with the nearline processor and matching OUT_DIR in #snoplus/nearline/15

I've tested this running over the Oxford network in safari, firefox and chrome. But I couldn't test if the one interaction with the detector database (run_time/type) works properly

@tlatorre-uchicago is it better for Minard to serve JSROOT like d3 etc. or shall I leave it as it is - pulling from cern? It's installed by default with ROOT.