### PR TITLE
Update nearline page to reflect signal error code

### DIFF
--- a/minard/templates/nearline.html
+++ b/minard/templates/nearline.html
@@ -41,6 +41,8 @@
 			<th> Not run </th>
                         {% elif status|int == 98 %}
                         <th class="warning"> Not executable </th>
+                        {% elif status|int == -1 %}
+                        <th class="warning"> Killed by signal </th>
 			{% elif status|int == 99 %}
 			<th> In Progress </th>
 			{% else %}


### PR DESCRIPTION
Just noticed that I don't have a case to deal with my own error code.