### PR TITLE
Remove a continue in detector state check

### DIFF
--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -197,47 +197,47 @@ def get_detector_state_check(run=0):
                messages.append("Sequencers disabled for crate %i, slot %i" % (crate, slot))
             for channel in range(32):
                 if hv_relay_mask1 is not None and hv_relay_mask2 is not None:
-                   hv_relay_mask = hv_relay_mask2 << 32 | hv_relay_mask1
-                   hv_enabled = hv_relay_mask & (1 << (slot*4 + (3-channel//8))) and hv_on
-                   if detector_state[crate][slot]['tr100_mask'] is None:
-                       messages.append("trigger settings unknown for crate %i, slot %i" % (crate, slot))
-                       continue
-                   if detector_state[crate][slot]['tr20_mask'] is None:
-                       messages.append("trigger settings unknown for crate %i, slot %i" % (crate, slot))
-                       continue
-                   if detector_state[crate][slot]['disable_mask'] is None:
-                       messages.append("sequencer settings unknown for crate %i, slot %i" % (crate, slot))
-                       continue
-                   n100 = bool(detector_state[crate][slot]['tr100_mask'][channel])
-                   n20 = bool(detector_state[crate][slot]['tr20_mask'][channel])
-                   sequencer = bool(~detector_state[crate][slot]['disable_mask'] & (1 << channel))
-                   try:
-                       n100_nominal, n20_nominal, sequencer_nominal = nominal_settings[crate][slot][channel]
-                   except KeyError:
-                       messages.append("unable to get nominal settings for %i/%i/%i" % (crate, slot, channel))
-                       continue
+                    hv_relay_mask = hv_relay_mask2 << 32 | hv_relay_mask1
+                    hv_enabled = hv_relay_mask & (1 << (slot*4 + (3-channel//8))) and hv_on
+                    if detector_state[crate][slot]['tr100_mask'] is None:
+                        messages.append("trigger settings unknown for crate %i, slot %i" % (crate, slot))
+                        continue
+                    if detector_state[crate][slot]['tr20_mask'] is None:
+                        messages.append("trigger settings unknown for crate %i, slot %i" % (crate, slot))
+                        continue
+                    if detector_state[crate][slot]['disable_mask'] is None:
+                        messages.append("sequencer settings unknown for crate %i, slot %i" % (crate, slot))
+                        continue
+                    n100 = bool(detector_state[crate][slot]['tr100_mask'][channel])
+                    n20 = bool(detector_state[crate][slot]['tr20_mask'][channel])
+                    sequencer = bool(~detector_state[crate][slot]['disable_mask'] & (1 << channel))
+                    try:
+                        n100_nominal, n20_nominal, sequencer_nominal = nominal_settings[crate][slot][channel]
+                    except KeyError:
+                        messages.append("unable to get nominal settings for %i/%i/%i" % (crate, slot, channel))
+                        continue
 
-                   if not hv_enabled:
-                       if n100:
-                           if hv_on:
-                               channels.append((crate,slot,channel,"HV relay is open, but N100 trigger is on"))
-                           else:
-                               channels.append((crate,slot,channel,"HV is off, but N100 trigger is on"))
-                       if n20:
-                           if hv_on:
-                               channels.append((crate,slot,channel,"HV relay is open, but N20 trigger is on"))
-                           else:
-                               channels.append((crate,slot,channel,"HV is off, but N20 trigger is on"))
-                   else:
-                       if n100_nominal != n100:
-                           channels.append((crate, slot, channel, "N100 trigger is %s, but nominal setting is %s" % \
-                               ("on" if n100 else "off", "on" if n100_nominal else "off")))
-                       if n20_nominal != n20:
-                           channels.append((crate, slot, channel, "N20 trigger is %s, but nominal setting is %s" % \
-                               ("on" if n20 else "off", "on" if n20_nominal else "off")))
-                       if sequencer_nominal != sequencer:
-                           channels.append((crate, slot, channel, "sequencer is %s, but nominal setting is %s" % \
-                               ("on" if sequencer else "off", "on" if sequencer_nominal else "off")))
+                    if not hv_enabled:
+                        if n100:
+                            if hv_on:
+                                channels.append((crate,slot,channel,"HV relay is open, but N100 trigger is on"))
+                            else:
+                                channels.append((crate,slot,channel,"HV is off, but N100 trigger is on"))
+                        if n20:
+                            if hv_on:
+                                channels.append((crate,slot,channel,"HV relay is open, but N20 trigger is on"))
+                            else:
+                                channels.append((crate,slot,channel,"HV is off, but N20 trigger is on"))
+                    else:
+                        if n100_nominal != n100:
+                            channels.append((crate, slot, channel, "N100 trigger is %s, but nominal setting is %s" % \
+                                ("on" if n100 else "off", "on" if n100_nominal else "off")))
+                        if n20_nominal != n20:
+                            channels.append((crate, slot, channel, "N20 trigger is %s, but nominal setting is %s" % \
+                                ("on" if n20 else "off", "on" if n20_nominal else "off")))
+                        if sequencer_nominal != sequencer:
+                            channels.append((crate, slot, channel, "sequencer is %s, but nominal setting is %s" % \
+                                ("on" if sequencer else "off", "on" if sequencer_nominal else "off")))
 
     return messages, channels
 

--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -195,9 +195,9 @@ def get_detector_state_check(run=0):
             slot_sequencers = detector_state[crate][slot]['disable_mask']
             if slot_sequencers is not None and slot_sequencers == 0xffffffff and (readout_mask & (1<<slot)):
                 messages.append("Sequencers disabled for crate %i, slot %i" % (crate, slot))
-            for channel in range(32):
-                if hv_relay_mask1 is not None and hv_relay_mask2 is not None:
-                    hv_relay_mask = hv_relay_mask2 << 32 | hv_relay_mask1
+            if hv_relay_mask1 is not None and hv_relay_mask2 is not None:
+                hv_relay_mask = hv_relay_mask2 << 32 | hv_relay_mask1
+                for channel in range(32):
                     hv_enabled = hv_relay_mask & (1 << (slot*4 + (3-channel//8))) and hv_on
                     if detector_state[crate][slot]['tr100_mask'] is None:
                         messages.append("trigger settings unknown for crate %i, slot %i" % (crate, slot))

--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -186,10 +186,6 @@ def get_detector_state_check(run=0):
         if hv_relay_mask1 is None or hv_relay_mask2 is None:
             messages.append("crate %i relay settings are unknown" % crate)
 
-        hv_relay_mask = 0
-        if hv_relay_mask1 is not None and hv_relay_mask2 is not None:
-            hv_relay_mask = hv_relay_mask2 << 32 | hv_relay_mask1
-
         for slot in range(16):
             if detector_state[crate][slot] is None:
                 messages.append("crate %i, slot %i is offline" % (crate, slot))
@@ -200,46 +196,48 @@ def get_detector_state_check(run=0):
             if slot_sequencers is not None and slot_sequencers == 0xffffffff and (readout_mask & (1<<slot)):
                messages.append("Sequencers disabled for crate %i, slot %i" % (crate, slot))
             for channel in range(32):
-                hv_enabled = hv_relay_mask & (1 << (slot*4 + (3-channel//8))) and hv_on
-                if detector_state[crate][slot]['tr100_mask'] is None:
-                    messages.append("trigger settings unknown for crate %i, slot %i" % (crate, slot))
-                    continue
-                if detector_state[crate][slot]['tr20_mask'] is None:
-                    messages.append("trigger settings unknown for crate %i, slot %i" % (crate, slot))
-                    continue
-                if detector_state[crate][slot]['disable_mask'] is None:
-                    messages.append("sequencer settings unknown for crate %i, slot %i" % (crate, slot))
-                    continue
-                n100 = bool(detector_state[crate][slot]['tr100_mask'][channel])
-                n20 = bool(detector_state[crate][slot]['tr20_mask'][channel])
-                sequencer = bool(~detector_state[crate][slot]['disable_mask'] & (1 << channel))
-                try:
-                    n100_nominal, n20_nominal, sequencer_nominal = nominal_settings[crate][slot][channel]
-                except KeyError:
-                    messages.append("unable to get nominal settings for %i/%i/%i" % (crate, slot, channel))
-                    continue
+                if hv_relay_mask1 is not None and hv_relay_mask2 is not None:
+                   hv_relay_mask = hv_relay_mask2 << 32 | hv_relay_mask1
+                   hv_enabled = hv_relay_mask & (1 << (slot*4 + (3-channel//8))) and hv_on
+                   if detector_state[crate][slot]['tr100_mask'] is None:
+                       messages.append("trigger settings unknown for crate %i, slot %i" % (crate, slot))
+                       continue
+                   if detector_state[crate][slot]['tr20_mask'] is None:
+                       messages.append("trigger settings unknown for crate %i, slot %i" % (crate, slot))
+                       continue
+                   if detector_state[crate][slot]['disable_mask'] is None:
+                       messages.append("sequencer settings unknown for crate %i, slot %i" % (crate, slot))
+                       continue
+                   n100 = bool(detector_state[crate][slot]['tr100_mask'][channel])
+                   n20 = bool(detector_state[crate][slot]['tr20_mask'][channel])
+                   sequencer = bool(~detector_state[crate][slot]['disable_mask'] & (1 << channel))
+                   try:
+                       n100_nominal, n20_nominal, sequencer_nominal = nominal_settings[crate][slot][channel]
+                   except KeyError:
+                       messages.append("unable to get nominal settings for %i/%i/%i" % (crate, slot, channel))
+                       continue
 
-                if not hv_enabled:
-                    if n100:
-                        if hv_on:
-                            channels.append((crate,slot,channel,"HV relay is open, but N100 trigger is on"))
-                        else:
-                            channels.append((crate,slot,channel,"HV is off, but N100 trigger is on"))
-                    if n20:
-                        if hv_on:
-                            channels.append((crate,slot,channel,"HV relay is open, but N20 trigger is on"))
-                        else:
-                            channels.append((crate,slot,channel,"HV is off, but N20 trigger is on"))
-                else:
-                    if n100_nominal != n100:
-                        channels.append((crate, slot, channel, "N100 trigger is %s, but nominal setting is %s" % \
-                            ("on" if n100 else "off", "on" if n100_nominal else "off")))
-                    if n20_nominal != n20:
-                        channels.append((crate, slot, channel, "N20 trigger is %s, but nominal setting is %s" % \
-                            ("on" if n20 else "off", "on" if n20_nominal else "off")))
-                    if sequencer_nominal != sequencer:
-                        channels.append((crate, slot, channel, "sequencer is %s, but nominal setting is %s" % \
-                            ("on" if sequencer else "off", "on" if sequencer_nominal else "off")))
+                   if not hv_enabled:
+                       if n100:
+                           if hv_on:
+                               channels.append((crate,slot,channel,"HV relay is open, but N100 trigger is on"))
+                           else:
+                               channels.append((crate,slot,channel,"HV is off, but N100 trigger is on"))
+                       if n20:
+                           if hv_on:
+                               channels.append((crate,slot,channel,"HV relay is open, but N20 trigger is on"))
+                           else:
+                               channels.append((crate,slot,channel,"HV is off, but N20 trigger is on"))
+                   else:
+                       if n100_nominal != n100:
+                           channels.append((crate, slot, channel, "N100 trigger is %s, but nominal setting is %s" % \
+                               ("on" if n100 else "off", "on" if n100_nominal else "off")))
+                       if n20_nominal != n20:
+                           channels.append((crate, slot, channel, "N20 trigger is %s, but nominal setting is %s" % \
+                               ("on" if n20 else "off", "on" if n20_nominal else "off")))
+                       if sequencer_nominal != sequencer:
+                           channels.append((crate, slot, channel, "sequencer is %s, but nominal setting is %s" % \
+                               ("on" if sequencer else "off", "on" if sequencer_nominal else "off")))
 
     return messages, channels
 

--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -179,9 +179,11 @@ def get_detector_state_check(run=0):
 
         if hv_relay_mask1 is None or hv_relay_mask2 is None:
             messages.append("crate %i relay settings are unknown" % crate)
-            continue
 
-        hv_relay_mask = hv_relay_mask2 << 32 | hv_relay_mask1
+        hv_relay_mask = 0
+        if hv_relay_mask1 is not None and hv_relay_mask2 is not None:
+            hv_relay_mask = hv_relay_mask2 << 32 | hv_relay_mask1
+
         for slot in range(16):
             if detector_state[crate][slot] is None:
                 messages.append("crate %i, slot %i is offline" % (crate, slot))

--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -194,7 +194,7 @@ def get_detector_state_check(run=0):
                 messages.append("crate %i, slot %i is out of the xl3 readout mask" % (crate, slot))
             slot_sequencers = detector_state[crate][slot]['disable_mask']
             if slot_sequencers is not None and slot_sequencers == 0xffffffff and (readout_mask & (1<<slot)):
-               messages.append("Sequencers disabled for crate %i, slot %i" % (crate, slot))
+                messages.append("Sequencers disabled for crate %i, slot %i" % (crate, slot))
             for channel in range(32):
                 if hv_relay_mask1 is not None and hv_relay_mask2 is not None:
                     hv_relay_mask = hv_relay_mask2 << 32 | hv_relay_mask1


### PR DESCRIPTION
that keeps other useful information from being returned when the relay states are unknown.
For a good example of where this is useful see run 101655.