### PR TITLE
Ping crates page

### DIFF
--- a/minard/pingcratesdb.py
+++ b/minard/pingcratesdb.py
@@ -1,0 +1,65 @@
+from redis import Redis
+
+redis = Redis()
+
+TIME_INDEX = 'pingcrates_runs_by_time'
+RUN_INDEX = 'pingcrates_runs_by_number'
+
+def add_run_to_db(run_dict):
+    '''
+    Creates Redis entries for a run. Requires run_number and time keys in 
+    run_dict
+    '''
+    key = 'pingcrates-run-%s' % run_dict['run_number']
+    p = redis.pipeline()
+    p.hmset(key, run_dict)
+    p.expire(key, 604800)
+    p.zadd(RUN_INDEX, key, float(run_dict['run_number']))
+    p.zadd(TIME_INDEX, key, float(run_dict['time']))
+    return p.execute() 
+    
+def runs_after_time(time, maxtime = '+inf'):
+    '''
+    Returns Redis entries for all runs between time and maxtime. 
+    Requires Redis instance, start-time and maximum time.
+    '''
+    keys = redis.zrangebyscore(TIME_INDEX, time, maxtime)
+    p = redis.pipeline()
+    for key in keys:
+        p.hgetall(key)
+    return p.execute()    
+        
+def runs_after_run(run, maxrun = '+inf'):
+    '''
+    Returns Redis entries for all runs between run and maxrun. 
+    Requires Redis instance, start-run and maximum run.
+    '''
+    keys = redis.zrangebyscore(RUN_INDEX, run, maxrun)
+    keys.reverse() # Sort with most recent first
+    p = redis.pipeline()
+    for key in keys:
+        p.hgetall(key)
+    return p.execute()    
+
+def get_run_by_number(runnum):
+    '''
+    Returns Redis entries for specific run by run number
+    Requires Redis instance, and run number.
+    '''
+    keys = redis.zrangebyscore(RUN_INDEX, runnum, runnum)
+    p = redis.pipeline()
+    for key in keys:
+        p.hgetall(key)
+    return p.execute()    
+
+def del_run_from_db(run_number):
+    '''
+    Delete run from Redis. Requires Redis instance and run number. 
+    '''
+    key = 'pingcrates-run-%s' % run_number
+    p = redis.pipeline()
+    p.delete(key)
+    p.zrem(RUN_INDEX, key)
+    p.zrem(TIME_INDEX, key)
+    return p.execute()
+ 

--- a/minard/templates/layout.html
+++ b/minard/templates/layout.html
@@ -79,7 +79,8 @@
                                 {{ nav_link('physicsdq', 'Physics Data Quality') }}
                                 {{ nav_link('calibdq_tellie', 'TELLIE  DQ') }}
                                 {{ nav_link('calibdq_smellie', 'SMELLIE DQ') }}
-                            </ul>
+                                {{ nav_link('pingcrates', 'Ping Crates') }}  
+                          </ul>
                         {{ nav_link('alarms', 'Alarms') }}
                     </ul>
                     <ul class="nav navbar-nav navbar-right">

--- a/minard/templates/pingcrates.html
+++ b/minard/templates/pingcrates.html
@@ -1,0 +1,45 @@
+{% extends "layout.html" %}
+{% block title %}Ping Crates{% endblock %}
+{% block head %}
+    {{ super() }}
+{% endblock %}
+{% block body %}
+{{ super() }}
+<div class="container">
+    <div class="page-header">
+    <h1 align="center">Ping Crates</h1>
+    </div>
+    <div class="row">
+        <div class="col-md-6 col-md-offset-3">
+            <table class="table">
+                <thead>
+                <tr>
+                    <th> Run Number </th>
+                    <th> Status </th>
+                    <th> Run Type </th>
+                    <th> Start Time </th>
+                </tr>
+                <tr>
+                    <tr class="success">
+                    <th><a href="{{url_for('pingcrates_run',run=1012) }}">{{1012}}</a></th>
+                    <th> {{"Pass"}} </th> 
+                    <th> {{"Physics"}} </th>
+                    <th> {{"10:20"}} </th>
+                    {% for run in runs %}
+                    {% if run.type == "Physics" %}
+                    </tr>
+                    <tr>
+                        <th><a href="{{url_for('pingcrates_run',run=run.id) }}">{{run.id}}</a></th>
+                        <th> {{"Pass"}} </th> 
+                        <th> {{run.type}} </th>
+                        <th> {{run.time}} </th>
+                    </tr>
+                    {% endif %}
+                    {% endfor %}
+                </tr>
+                </thead>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/minard/templates/pingcrates.html
+++ b/minard/templates/pingcrates.html
@@ -1,45 +1,42 @@
 {% extends "layout.html" %}
 {% block title %}Ping Crates{% endblock %}
 {% block head %}
-    {{ super() }}
+  {{ super() }}
 {% endblock %}
 {% block body %}
-{{ super() }}
-<div class="container">
-    <div class="page-header">
-    <h1 align="center">Ping Crates</h1>
-    </div>
-    <div class="row">
-        <div class="col-md-6 col-md-offset-3">
-            <table class="table">
-                <thead>
-                <tr>
-                    <th> Run Number </th>
-                    <th> Status </th>
-                    <th> Run Type </th>
-                    <th> Start Time </th>
-                </tr>
-                <tr>
-                    <tr class="success">
-                    <th><a href="{{url_for('pingcrates_run',run=1012) }}">{{1012}}</a></th>
-                    <th> {{"Pass"}} </th> 
-                    <th> {{"Physics"}} </th>
-                    <th> {{"10:20"}} </th>
-                    {% for run in runs %}
-                    {% if run.type == "Physics" %}
-                    </tr>
-                    <tr>
-                        <th><a href="{{url_for('pingcrates_run',run=run.id) }}">{{run.id}}</a></th>
-                        <th> {{"Pass"}} </th> 
-                        <th> {{run.type}} </th>
-                        <th> {{run.time}} </th>
-                    </tr>
-                    {% endif %}
-                    {% endfor %}
-                </tr>
-                </thead>
-            </table>
-        </div>
-    </div>
+  {{ super() }}
+
+<div class="page-header">
+  <h1 align="center">Ping Crates</h1>
 </div>
+
+<div class="container">
+  <table class="table table-hover">
+    <thead>
+      <tr> 
+        <th> Run Number </th>
+        <th> Status </th>
+        <th> Crates Failed N100 </th>
+        <th> Crates Failed N20 </th>
+        <th> Run Type </th>
+        <th> Start Time </th>
+      </tr>
+    </thead>
+    {% for run in runs if run %}
+      {% if run.status == "Fail" %}
+        <tr class="danger">
+      {% elif run.status == "Pass" %}
+        <tr class="success">
+      {% endif %}
+        <th><a href="{{url_for('pingcrates_run',run_number=run.run_number) }}">{{run.run_number}}</a></th>
+        <th> {{run.status}} </th> 
+        <th> {{run.n100_crates_failed}} </th>
+        <th> {{run.n20_crates_failed}} </th>
+        <th> {{run.run_type}} </th>
+        <th> {{run.time|timefmt}} </th>
+      </tr>
+    {% endfor %}
+  </table>
+</div>
+
 {% endblock %}

--- a/minard/templates/pingcrates_run.html
+++ b/minard/templates/pingcrates_run.html
@@ -1,0 +1,46 @@
+{% extends "layout.html" %}
+{% block title %} Ping Crates Run {% endblock %}
+{% block head %}
+{{ super() }}
+
+<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/pca.css') }}" media="screen">
+
+{% endblock %}
+
+{% block body %}
+{{ super() }}
+
+<div class="container">
+    <div class="page-header">
+     <h1 align="center">Ping Crates Plots</h1>
+    </div>
+</div>
+
+<div class="panel-group">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">
+              <a data-toggle="collapse" href="#pingcrates">Ping</a>
+            </h3>
+        </div>
+
+        <div id="pingcrates" class="panel-collapse collapse in">
+          <div class="panel-body">
+            <img src="{{ url_for('static', filename='pingcrates/run'+run+'/') }}"
+                 alt="N100 Baselines" class="img-responsive col-md-6">
+            <img src="{{ url_for('static', filename='pingcrates/run'+run+'/') }}"
+                 alt="N20 Baselines" class="img-responsive col-md-6">
+            <img src="{{ url_for('static', filename='pingcrates/run'+run+'/') }}"
+                 alt="N100 Peak By Crate" class="img-responsive col-md-6">
+            <img src="{{ url_for('static', filename='pingcrates/run'+run+'/') }}"
+                 alt="N20 Peak By Crate" class="img-responsive col-md-6">
+            <img src="{{ url_for('static', filename='pingcrates/run'+run+'/') }}"
+                 alt="N100 # Samples Above Thresold By Crate" class="img-responsive col-md-6">
+            <img src="{{ url_for('static', filename='pingcrates/run'+run+'/') }}"
+                 alt="N20 # of Samples Above Threshold By Crate" class="img-responsive col-md-6">
+          </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/minard/templates/pingcrates_run.html
+++ b/minard/templates/pingcrates_run.html
@@ -1,46 +1,134 @@
 {% extends "layout.html" %}
 {% block title %} Ping Crates Run {% endblock %}
 {% block head %}
-{{ super() }}
-
-<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/pca.css') }}" media="screen">
-
+  {{ super() }}
 {% endblock %}
-
 {% block body %}
-{{ super() }}
+  {{ super() }}
 
 <div class="container">
-    <div class="page-header">
-     <h1 align="center">Ping Crates Plots</h1>
+   <h1 align="center">Run {{run_number}}</h1>
+
+<div class="panel-group">
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h4 class="panel-title"> 
+        <a data-toggle="collapse" data-parent="accordion" href="#collapsepeak">>
+          Crate Average: Peaks
+        </a>
+      </h4> 
+      <div id="collapsepeak"class="panel-collapse collapse in">
+        <div class="panel-body">
+          <img src="{{ url_for('static', filename='pingcrates/run'+run_number+'/ping_3_102491.png') }}"
+            alt="N100 Peak By Crate" class="img-responsive col-md-6"></img>
+          <img src="{{ url_for('static', filename='pingcrates/run'+run_number+'/ping_9_102491.png') }}"
+            alt="N20 Peak By Crate" class="img-responsive col-md-6"></img>
+        </div>
+      </div>
     </div>
+  </div>
 </div>
 
 <div class="panel-group">
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <h3 class="panel-title">
-              <a data-toggle="collapse" href="#pingcrates">Ping</a>
-            </h3>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h4 class="panel-title"> 
+        <a data-toggle="collapse" data-parent="accordion" href="#collapsewidths">>
+          Crate Average: Trigger Widths
+        </a>
+      </h4> 
+      <div id="collapsewidths"class="panel-collapse collapse in">
+        <div class="panel-body">
+          <img src="{{ url_for('static', filename='pingcrates/run'+run_number+'/ping_4_102491.png') }}"
+            alt="N100 # Samples Above Thresold By Crate" class="img-responsive col-md-6"></img>
+          <img src="{{ url_for('static', filename='pingcrates/run'+run_number+'/ping_10_102491.png') }}"
+            alt="N20 # of Samples Above Threshold By Crate" class="img-responsive col-md-6"></img>
         </div>
-
-        <div id="pingcrates" class="panel-collapse collapse in">
-          <div class="panel-body">
-            <img src="{{ url_for('static', filename='pingcrates/run'+run+'/') }}"
-                 alt="N100 Baselines" class="img-responsive col-md-6">
-            <img src="{{ url_for('static', filename='pingcrates/run'+run+'/') }}"
-                 alt="N20 Baselines" class="img-responsive col-md-6">
-            <img src="{{ url_for('static', filename='pingcrates/run'+run+'/') }}"
-                 alt="N100 Peak By Crate" class="img-responsive col-md-6">
-            <img src="{{ url_for('static', filename='pingcrates/run'+run+'/') }}"
-                 alt="N20 Peak By Crate" class="img-responsive col-md-6">
-            <img src="{{ url_for('static', filename='pingcrates/run'+run+'/') }}"
-                 alt="N100 # Samples Above Thresold By Crate" class="img-responsive col-md-6">
-            <img src="{{ url_for('static', filename='pingcrates/run'+run+'/') }}"
-                 alt="N20 # of Samples Above Threshold By Crate" class="img-responsive col-md-6">
-          </div>
-        </div>
+      </div>
     </div>
+  </div>
+</div>
+
+<div class="panel-group">
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h4 class="panel-title"> 
+        <a data-toggle="collapse" data-parent="accordion" href="#collapsebl">>
+          Crate Average: Baselines
+        </a>
+      </h4> 
+      <div id="collapsebl"class="panel-collapse collapse">
+        <div class="panel-body">
+          <img src="{{ url_for('static', filename='pingcrates/run'+run_number+'/ping_5_102491.png') }}"
+            alt="N100 Peak By Crate" class="img-responsive col-md-6"></img>
+          <img src="{{ url_for('static', filename='pingcrates/run'+run_number+'/ping_11_102491.png') }}"
+            alt="N20 Peak By Crate" class="img-responsive col-md-6"></img>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="panel-group">
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h4 class="panel-title"> 
+        <a data-toggle="collapse" data-parent="accordion" href="#collapsepeakshist">>
+          Peaks
+        </a>
+      </h4> 
+      <div id="collapsepeakshist"class="panel-collapse collapse">
+        <div class="panel-body">
+          <img src="{{ url_for('static', filename='pingcrates/run'+run_number+'/ping_1_102491.png') }}"
+            alt="N100 Baselines" class="img-responsive col-md-6"></img>
+          <img src="{{ url_for('static', filename='pingcrates/run'+run_number+'/ping_7_102491.png') }}"
+            alt="N20 Baselines" class="img-responsive col-md-6"></img>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="panel-group">
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h4 class="panel-title"> 
+        <a data-toggle="collapse" data-parent="accordion" href="#collapsewidthhist">>
+          Trigger Widths
+        </a>
+      </h4> 
+      <div id="collapsewidthhist"class="panel-collapse collapse">
+        <div class="panel-body">
+          <img src="{{ url_for('static', filename='pingcrates/run'+run_number+'/ping_2_102491.png') }}"
+            alt="N100 Baselines" class="img-responsive col-md-6"></img>
+          <img src="{{ url_for('static', filename='pingcrates/run'+run_number+'/ping_8_102491.png') }}"
+            alt="N20 Baselines" class="img-responsive col-md-6"></img>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="panel-group">
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h4 class="panel-title"> 
+        <a data-toggle="collapse" data-parent="accordion" href="#collapsebaseline">>
+          Baselines
+        </a>
+      </h4> 
+      <div id="collapsebaseline"class="panel-collapse collapse">
+        <div class="panel-body">
+          <img src="{{ url_for('static', filename='pingcrates/run'+run_number+'/ping_0_102491.png') }}"
+            alt="N100 Baselines" class="img-responsive col-md-6"></img>
+          <img src="{{ url_for('static', filename='pingcrates/run'+run_number+'/ping_6_102491.png') }}"
+            alt="N20 Baselines" class="img-responsive col-md-6"></img>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 </div>
 
 {% endblock %}

--- a/minard/views.py
+++ b/minard/views.py
@@ -842,6 +842,16 @@ def physicsdq():
             proc_results.append(HLDQTools.generateHLDQProcStatus(run_info[i]))
     return render_template('physicsdq.html',physics_run_numbers=runNumbers, proc_results=proc_results, run_info=run_info, limit=limit,offset=offset)
 
+@app.route('/pingcrates')
+def pingcrates():
+    # Grab the available runs from the nlrat redis tables 
+    return render_template('pingcrates.html', runs=nlrat.available_runs())
+
+@app.route('/pingcrates_run/<int:run>')
+def pingcrates_run(run = 0):
+    # Grab the run info from the nlrat redis tables
+    return render_template('pingcrates_run.html', run=nlrat.Run(run))
+
 @app.route('/physicsdq/<run_number>')
 def physicsdq_run_number(run_number):
     ratdb_dict = HLDQTools.import_HLDQ_ratdb(int(run_number))

--- a/minard/views.py
+++ b/minard/views.py
@@ -22,6 +22,7 @@ import pcadb
 import ecadb
 import nlrat
 import noisedb
+import pingcratesdb
 from .channeldb import ChannelStatusForm, upload_channel_status, get_channels, get_channel_status, get_channel_status_form, get_channel_history, get_pmt_info, get_nominal_settings
 import re
 from .resistor import get_resistors, ResistorValuesForm, get_resistor_values_form, update_resistor_values
@@ -844,14 +845,13 @@ def physicsdq():
 
 @app.route('/pingcrates')
 def pingcrates():
-    # Grab the available runs from the nlrat redis tables 
-    return render_template('pingcrates.html', runs=nlrat.available_runs())
+    runs = pingcratesdb.runs_after_run(0)
+    return render_template('pingcrates.html', runs=runs)
 
-@app.route('/pingcrates_run/<int:run>')
-def pingcrates_run(run = 0):
-    # Grab the run info from the nlrat redis tables
-    return render_template('pingcrates_run.html', run=nlrat.Run(run))
-
+@app.route('/pingcrates_run/<run_number>')
+def pingcrates_run(run_number):
+    return render_template('pingcrates_run.html', run_number=run_number)
+ 
 @app.route('/physicsdq/<run_number>')
 def physicsdq_run_number(run_number):
     ratdb_dict = HLDQTools.import_HLDQ_ratdb(int(run_number))


### PR DESCRIPTION
This adds a ping crates page that displays information about the CAEN trigger signals during ping crates. The nearline processor that creates the plots is here: https://github.com/snoplus/nearline/pull/95.