### PR TITLE
add link to document describing the detector state check messages

### DIFF
--- a/minard/templates/detector_state_check.html
+++ b/minard/templates/detector_state_check.html
@@ -44,6 +44,7 @@
                     {% endfor %}
                     </ul>
                 {% endif %}
+                <a href="https://www.snolab.ca/snoplus/private/DocDB/cgi/ShowDocument?docid=4660">What do these messages mean? </a>
             </div>
             <div class="col-md-4">
                 <h2>Channel Settings</h2>


### PR DESCRIPTION
Document is still fairly rough and I'm not sure this is the best way to link to the information, but I thought it might be handy because I've been getting question fairly often about the various messages and what they mean.