### PR TITLE
Add spare to MTCA/+ relay check

### DIFF
--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -199,7 +199,7 @@ def get_detector_state_check(run=0):
             mtca_names = ['N100', 'N20', 'ESUMLO', 'ESUMHI', 'OWLELO', 'OWLEHI', 'OWLN']
             for i, (relay, mtca) in enumerate(zip(relay_mask,mtca_names)):
                 crates = []
-                potential_crates = range(19) if i<4 else [3,13,18]
+                potential_crates = range(20) if i<4 else [3,13,18]
                 for crate in potential_crates:
                     if relay is not None and not (relay & (1<<crate)):
                         crates.append(crate)


### PR DESCRIPTION
Currently we have "crate 19" N100 disconnected. Ping crates has shown that it is mapped to crate 9.