### PR TITLE
Fixes to nearline monitoring

### DIFF
--- a/minard/channelflagsdb.py
+++ b/minard/channelflagsdb.py
@@ -23,6 +23,8 @@ def get_channel_flags(limit):
     count_sync16 = {}
     count_sync24 = {}
     count_missed = {}
+    count_sync16_pr = {}
+    count_sync24_pr = {}
 
     for run, sync16, sync24 in rows:
         runs.append(run)
@@ -32,25 +34,30 @@ def get_channel_flags(limit):
         count_sync16[run] = 0
         count_sync24[run] = 0
         count_missed[run] = 0
+        count_sync16_pr[run] = 0
+        count_sync24_pr[run] = 0
 
-    result = conn.execute("SELECT DISTINCT ON (crate, slot, channel, run) run, crate, "
-                          "cmos_sync16, cgt_sync24, missed_count FROM channel_flags "
+    result = conn.execute("SELECT DISTINCT ON (crate, slot, channel, run) run, "
+                          "cmos_sync16, cgt_sync24, missed_count, cmos_sync16_pr, "
+                          "cgt_sync24_pr FROM channel_flags "
                           "WHERE run > %s ORDER BY crate, slot, channel, run DESC, timestamp DESC", \
                           int(current_run - limit))
 
     rows = result.fetchall()
 
-    for run, crate, cmos_sync16, cgt_sync24, missed_count in rows:
-        if crate == -1:
-            continue
-        if cmos_sync16 != 0:
+    for run, cmos_sync16, cgt_sync24, missed_count, cmos_sync16_pr, cgt_sync24_pr in rows:
+        if cmos_sync16 != 0 and cmos_sync16 is not None:
             count_sync16[run] += 1
-        if cgt_sync24 != 0:
+        if cgt_sync24 != 0 and cgt_sync24 is not None:
             count_sync24[run] += 1
-        if missed_count != 0:
+        if missed_count != 0 and missed_count is not None:
             count_missed[run] += 1
+        if cmos_sync16_pr != 0 and cmos_sync16_pr is not None:
+            count_sync16_pr[run] += 1
+        if cgt_sync24_pr != 0 and cgt_sync24_pr is not None:
+            count_sync24_pr[run] += 1
 
-    return runs, nsync16, nsync24, count_sync16, count_sync24, count_missed
+    return runs, nsync16, nsync24, count_sync16, count_sync24, count_missed, count_sync16_pr, count_sync24_pr
 
 
 def get_channel_flags_by_run(run):
@@ -62,7 +69,8 @@ def get_channel_flags_by_run(run):
 
     # Find all of the out-of-sync and missed-count channels for the run selected
     result = conn.execute("SELECT DISTINCT ON (crate, slot, channel) crate, slot, channel, "
-                          "cmos_sync16, cgt_sync24, missed_count FROM channel_flags "
+                          "cmos_sync16, cgt_sync24, missed_count, cmos_sync16_pr, "
+                          "cgt_sync24_pr FROM channel_flags "
                           "WHERE run = %s ORDER BY crate, slot, channel, run DESC, timestamp DESC", \
                           int(run))
 
@@ -71,60 +79,40 @@ def get_channel_flags_by_run(run):
     list_sync16 = []
     list_sync24 = []
     list_missed = []
-
-    for crate, slot, channel, sync16, sync24, missed in rows:
-        if crate == -1:
-            continue
-        if missed != 0:
-            list_missed.append((crate, slot, channel, missed))
-        if sync16 != 0:
-            list_sync16.append((crate, slot, channel, sync16))
-        if sync24 != 0:
-            list_sync24.append((crate, slot, channel, sync24))
-
     list_sync16_pr = []
     list_sync24_pr = []
 
-    # Now try and find out of sync channels identified in later runs
-    try:
-        result = conn.execute("SELECT run FROM channel_flags WHERE run > %s and sync16 > 0 "
-                              "ORDER by run ASC, timestamp DESC limit 1", int(run))
-        if result is None:
-            sync16run = run + 1
-        else:
-            sync16run = result.fetchone()[0]
-
-        result = conn.execute("SELECT run FROM channel_flags WHERE run > %s and sync24 > 0 "
-                              "ORDER by run ASC, timestamp DESC limit 1", int(run))
-        if result is None:
-            sync24run = run + 1
-        else:
-            sync24run = result.fetchone()[0]
-
-        result = conn.execute("SELECT DISTINCT ON (crate, slot, channel) crate, slot, channel, "
-                              "cmos_sync16_pr FROM channel_flags "
-                              "WHERE run = %s and sync16 > 0 "
-                              "ORDER by crate, slot, channel, run DESC, timestamp DESC", \
-                              int(sync16run))
-        rows = result.fetchall()
-
-        for crate, slot, channel, cmos_sync16_pr in rows:
-            if cmos_sync16_pr != 0:
-                list_sync16_pr.append((crate, slot, channel, cmos_sync16_pr))
-
-        result = conn.execute("SELECT DISTINCT ON (crate, slot, channel) crate, slot, channel, "
-                              "cgt_sync24_pr FROM channel_flags "
-                              "WHERE run = %s and sync24 > 0 "
-                              "ORDER by crate, slot, channel, run DESC, timestamp DESC", \
-                              int(sync24run))
-        rows = result.fetchall()
-
-        for crate, slot, channel, cgt_sync24_pr in rows:
-            if cgt_sync24_pr != 0:
-                list_sync24_pr.append((crate, slot, channel, cgt_sync24_pr))
-
-    except Exception as e:
-        pass
+    for crate, slot, channel, sync16, sync24, missed, sync16_pr, sync24_pr in rows:
+        if missed != 0 and missed is not None:
+            list_missed.append((crate, slot, channel, missed))
+        if sync16 != 0 and sync16 is not None:
+            list_sync16.append((crate, slot, channel, sync16))
+        if sync24 != 0 and sync24 is not None:
+            list_sync24.append((crate, slot, channel, sync24))
+        if sync16_pr != 0 and sync16_pr is not None:
+            list_sync16_pr.append((crate, slot, channel, sync16_pr))
+        if sync24_pr != 0 and sync24_pr is not None:
+            list_sync24_pr.append((crate, slot, channel, sync24_pr))
 
     return list_missed, list_sync16, list_sync24, list_sync16_pr, list_sync24_pr
- 
+
+
+def get_number_of_syncs(run):
+    '''
+    Get the number of sync16 and sync24s in a selected run
+    '''
+
+    conn = engine_nl.connect()
+
+    result = conn.execute("SELECT run, sync16, sync24 FROM channel_flags "
+                          "WHERE run = %s ORDER BY timestamp DESC limit 1", (run))
+
+    rows = result.fetchall()
+    nsync16s = 0
+    nsync24s = 0
+    for run, sync16, sync24 in rows:
+        nsync16s = sync16
+        nsync24s = sync24
+
+    return nsync16s, nsync24s
+

--- a/minard/nearline_monitor.py
+++ b/minard/nearline_monitor.py
@@ -4,7 +4,7 @@ from .pingcratesdb import ping_crates_list
 from .channelflagsdb import get_channel_flags, get_channel_flags_by_run
 from .triggerclockjumpsdb import get_clock_jumps, get_clock_jumps_by_run
 from .nlrat import RUN_TYPES
-from .occupancy import run_list, occupancy_by_trigger
+from .occupancy import run_list, occupancy_by_trigger, occupancy_by_trigger_limit
 
 # Limits for failing channel flags check
 OUT_OF_SYNC_1 = 32
@@ -26,33 +26,45 @@ def get_run_list(limit, selected_run, all_runs):
         ping_crates_status = ping_crates(limit, all_runs)
         channel_flags_status = channel_flags(limit, all_runs) 
         clock_jumps_status = clock_jumps(limit, all_runs)
-        occupancy_status = occupancy(all_runs)
+        occupancy_status = occupancy(limit, all_runs)
     else:
         ping_crates_status = ping_crates_run(selected_run)
         channel_flags_status = channel_flags_run(selected_run)
         clock_jumps_status = clock_jumps_run(selected_run)
-        occupancy_status = occupancy([selected_run])
+        occupancy_status = occupancy_run(selected_run)
 
     return clock_jumps_status, ping_crates_status, channel_flags_status, occupancy_status
 
 
-def occupancy(all_runs):
+def occupancy_run(run):
     '''
-    Return a dictionary of occupancy status by run
+    Return the ESUM occupancy status of a selected run
     '''
     occupancy_fail = {}
+    status,_,_,_ = occupancy_by_trigger_limit(0, run)
+    try:
+        if status[run] == 1:
+            occupancy_fail[run] = 1
+        elif status[run] == 0:
+            occupancy_fail[run] = 0
+    except Exception as e:
+        occupancy_fail[run] = -1
+
+    return occupancy_fail
+
+
+def occupancy(limit, all_runs):
+    '''
+    Return a dictionary of ESUM occupancy status by run
+    '''
+    occupancy_fail = {}
+    status,_,_,_ = occupancy_by_trigger_limit(limit, 0)
     for run in all_runs:
         try:
             # Check ESUMH Occupancy
-            issues = occupancy_by_trigger(6, run, True)
-            count_slots = 0
-            # If more than one slot has an issue
-            for i in issues:
-                for j in issues[i]:
-                    count_slots+=1
-            if count_slots > 1:
+            if status[run] == 1:
                 occupancy_fail[run] = 1
-            else:
+            elif status[run] == 0:
                 occupancy_fail[run] = 0
         except Exception as e:
             occupancy_fail[run] = -1
@@ -66,6 +78,17 @@ def clock_jumps_run(run):
     Return the clock jumps status for a selected run
     '''
     clock_jumps_status = {}
+    conn = engine_nl.connect()
+
+    result = conn.execute("SELECT run FROM trigger_clock_jumps WHERE run = %s", run)
+
+    # This should be the best way to check if the job ran for the given run
+    try:
+        result.fetchone()[0]
+    except Exception as e:
+        clock_jumps_status[run] = -1
+        return clock_jumps_status
+
     data10, data50 = get_clock_jumps_by_run(run)
     njump10 = len(data10)
     njump50 = len(data50)
@@ -85,7 +108,8 @@ def clock_jumps(limit, all_runs):
     Return a dictionary of clock jumps status by run
     '''
     clock_jumps_fail = {}
-    _, njump10, njump50 = get_clock_jumps(limit) 
+
+    _, njump10, njump50 = get_clock_jumps(limit, 0) 
     for run in all_runs:
         try:
             if((njump10[run] + njump50[run]) >= CLOCK_JUMP_1 and \
@@ -106,11 +130,22 @@ def channel_flags_run(run):
     '''
     Return the channel flags status for a selected run
     '''
+    channel_flags_status = {}
+    conn = engine_nl.connect()
+
+    result = conn.execute("SELECT sync16 FROM channel_flags WHERE run = %s", run)
+
+    # This should be the best way to check if the job ran for the given run
+    try:
+        result.fetchone()[0]
+    except Exception as e:
+        channel_flags_status[run] = -1
+        return channel_flags_status
+    
     missed, sync16, sync24, _, _ = get_channel_flags_by_run(run)
     missed = len(missed)
     sync16 = len(sync16)
     sync24 = len(sync24)
-    channel_flags_status = {}
     if((sync16 >= OUT_OF_SYNC_1 and sync16 < OUT_OF_SYNC_2) or \
         missed >= MISSED_COUNT_1 and missed < MISSED_COUNT_2):
         channel_flags_status[run] = 2
@@ -126,7 +161,7 @@ def channel_flags(limit, all_runs):
     '''
     Return a dictionary of channel flags status by run
     '''
-    _, _, _, count_sync16, count_sync24, count_missed = get_channel_flags(limit)
+    _, _, _, count_sync16, _, count_missed, count_sync16_pr, _ = get_channel_flags(limit)
     channel_flags_fail = {}
     for run in all_runs:
         run = int(run)
@@ -134,7 +169,8 @@ def channel_flags(limit, all_runs):
             if((count_sync16[run] >= OUT_OF_SYNC_1 and count_sync16[run] < OUT_OF_SYNC_2) or \
                 count_missed[run] >= MISSED_COUNT_1 and count_missed[run] < MISSED_COUNT_2):
                 channel_flags_fail[run] = 2
-            elif(count_sync16[run] >= OUT_OF_SYNC_2 or count_missed[run] >= MISSED_COUNT_2):
+            elif(count_sync16[run] >= OUT_OF_SYNC_2 or count_missed[run] >= MISSED_COUNT_2 or \
+                 count_sync16_pr[run] >= OUT_OF_SYNC_2):
                 channel_flags_fail[run] = 1
             else:
                 channel_flags_fail[run] = 0
@@ -153,13 +189,16 @@ def ping_crates_run(run):
 
     ping_crates_status = {}
     result = conn.execute("SELECT status FROM ping_crates WHERE run = %i" % run)
-    row = result.fetchone()[0]
-    if row == 0:
-        ping_crates_status[run] = 0
-    elif row == 1:
-        ping_crates_status[run] = 1
-    elif row == 2:
-        ping_crates_status[run] = 2
+    try:
+        row = result.fetchone()[0]
+        if row == 0:
+            ping_crates_status[run] = 0
+        elif row == 1:
+            ping_crates_status[run] = 1
+        elif row == 2:
+            ping_crates_status[run] = 2
+    except Exception as e:
+        ping_crates_status[run] = -1
 
     return ping_crates_status
 
@@ -168,7 +207,7 @@ def ping_crates(limit, all_runs):
     '''
     Return a dictionary of ping crates status by run
     '''
-    ping_list = ping_crates_list(limit)
+    ping_list = ping_crates_list(limit, 0)
     ping_crates_fail = {}
     ping_runs = []
     for i in ping_list:

--- a/minard/occupancy.py
+++ b/minard/occupancy.py
@@ -1,11 +1,60 @@
 from .db import engine_nl
 from .detector_state import get_latest_run
 
+def occupancy_by_trigger_limit(limit, selected_run):
+    """
+    Returns a dictionary of the ESUMH occupacy status
+    indexed by run
+    """
+    conn = engine_nl.connect()
+
+    latest_run = get_latest_run()
+
+    if selected_run == 0:
+        result = conn.execute("SELECT DISTINCT ON (run, crate, slot) "
+                              "run, status, crate, slot "
+                              "FROM esumh_occupancy_fail WHERE run > %s "
+                              "ORDER BY run, crate, slot", \
+                              (latest_run - limit))
+    else:
+        result = conn.execute("SELECT DISTINCT ON (run, crate, slot) "
+                              "run, status, crate, slot "
+                              "FROM esumh_occupancy_fail WHERE run = %s "
+                              "ORDER BY run, crate, slot", \
+                              (selected_run))
+
+    rows = result.fetchall()
+
+    crates = {}
+    slots = {}
+    status = {}
+    count = {}
+    for run, run_status, crate, slot in rows:
+        status[run] = run_status
+        if run_status == 0:
+            crates[run] = "None"
+            slots[run] = "None"
+            count[run] = 0
+            continue
+        try:
+            if crate != crates[run][-1]:
+                crates[run].append(crate)
+        except Exception as e:
+            crates[run] = [crate]
+        try:
+            slots[run].append(slot)
+            count[run]+=1
+        except Exception as e:
+            slots[run] = [slot]
+            count[run] = 1
+
+    return status, crates, slots, count
+ 
+
 def occupancy_by_trigger(trigger_type, run, find_issues):
     """
     Returns a list specifing the normalized occupancy
-    for the trigger type. Pass the find_issues flag
-    to look for issues with the occupancy
+    for the trigger type.
     """
     conn = engine_nl.connect()
 
@@ -16,6 +65,7 @@ def occupancy_by_trigger(trigger_type, run, find_issues):
                           (trigger_type, run))
 
     rows = result.fetchall()
+
     if not rows:
         return None
 
@@ -31,10 +81,6 @@ def occupancy_by_trigger(trigger_type, run, find_issues):
 
     data = [float(x) / trigger_norm for x in data]
 
-    if find_issues:
-        issues = check_occupancy(trigger_type, data, norm)
-        return issues
-
     return data
 
 
@@ -47,7 +93,7 @@ def run_list(limit):
 
     current_run = get_latest_run()
 
-    result = conn.execute("SELECT DISTINCT ON (run) run FROM trigger_occupancy "
+    result = conn.execute("SELECT DISTINCT ON (run) run FROM esumh_occupancy_fail "
                           "WHERE run > %s ORDER BY run DESC", (current_run - limit))
 
     rows = result.fetchall()
@@ -57,41 +103,4 @@ def run_list(limit):
 
     return runs
 
-
-def check_occupancy(trigger_type, data, norm):
-    """
-    Check the occupancy of each slot against a 
-    hard-coded value that was determined by 
-    looking at runs where slots had tripped off
-    and runs where the crate was missing its
-    ESUMH trigger. Returns a dictionary of issues
-    with the crate as keys and slots as values.
-    """
-    BAD_OCC = 3e-5
-
-    slot_average = [0.0]*304
-    channel_count = [32.0]*304
-
-    for i in range(len(data)):
-        crate = i/512
-        card = (i%512)/32
-        lcn = card + 16*crate
-        # These are offline channels, flagged
-        # by PMTCal selector
-        if data[i] < 0:
-            channel_count[lcn] -= 1
-            continue
-        slot_average[lcn] += data[i]
-
-    issues = {}
-    for i in range(304):
-        crate = i/16
-        slot = i%16
-        if channel_count[i] != 0 and slot_average[i]/(channel_count[i]) < BAD_OCC:
-            try:
-                issues[crate].append(slot)
-            except Exception:
-                issues[crate] = [slot]
-
-    return issues
 

--- a/minard/pingcratesdb.py
+++ b/minard/pingcratesdb.py
@@ -110,7 +110,7 @@ def crates_failed_messages(run):
     return messages
 
 
-def ping_crates_list(limit):
+def ping_crates_list(limit, selected_run):
     '''
     Returns a list of ping crates information for runs larger
     than the current run - limit
@@ -120,11 +120,17 @@ def ping_crates_list(limit):
 
     conn = engine_nl.connect()
 
-    # Get all ping crates information from detector state since (run - limit)
-    result = conn.execute("SELECT DISTINCT ON (run) timestamp, run,  n100_crates_failed, "
-                          "n20_crates_failed, n100_crates_warned, n20_crates_warned, "
-                          "status FROM ping_crates WHERE run > %s "
-                          "ORDER BY run, timestamp DESC", (run-limit))
+    if selected_run == 0:
+        # Get all ping crates information from detector state since (run - limit)
+        result = conn.execute("SELECT DISTINCT ON (run) timestamp, run,  n100_crates_failed, "
+                              "n20_crates_failed, n100_crates_warned, n20_crates_warned, "
+                              "status FROM ping_crates WHERE run > %s "
+                              "ORDER BY run, timestamp DESC", (run-limit))
+    else:
+        result = conn.execute("SELECT DISTINCT ON (run) timestamp, run,  n100_crates_failed, "
+                              "n20_crates_failed, n100_crates_warned, n20_crates_warned, "
+                              "status FROM ping_crates WHERE run = %s "
+                              "ORDER BY run, timestamp DESC", selected_run)
 
     ping_info = []
     for timestamp, run, n100, n20, n100w, n20w, status in result:

--- a/minard/static/css/minard.css
+++ b/minard/static/css/minard.css
@@ -123,14 +123,6 @@
     padding:2.25px;
 }
 
-#crateI table tr td {
-    padding:2.25px;
-}
-
-#crateJ table tr td {
-    padding:2.25px;
-}
-
 /* detector.html */
 #projection-menu {
     position: absolute;

--- a/minard/static/js/trigger_occupancy.js
+++ b/minard/static/js/trigger_occupancy.js
@@ -39,7 +39,7 @@ function setup(run) {
     $(".crate9").after("<br>");
 
     // Default values
-    var i = [0, 4, 6, 7, 10];
+    var i = [0, 4, 6];
     for(var x in i) {
        update(i[x], run);
     }
@@ -59,12 +59,6 @@ function update(trigger_type, run_number) {
         }
         else if(trigger_type == 6){
             d3.select('#crateZ').datum(values).call(crate_update);
-        }
-        else if(trigger_type == 7){
-            d3.select('#crateI').datum(values).call(crate_update);
-        }
-        else if(trigger_type == 10){
-            d3.select('#crateJ').datum(values).call(crate_update);
         }
     });
 }

--- a/minard/templates/channelflags.html
+++ b/minard/templates/channelflags.html
@@ -10,6 +10,7 @@
 
   <h2 align="left">Information For the User</h2>
     <table class="table table-hover">
+      <tr> <th> The channel flags processor looks for channels out-of-sync or dropping data. These channels will be thrown away in analysis, so we want to make sure there aren't too many of these channels being flagged during data taking. The processor also keeps track of the number of sync16 and sync24s that occur during the run. The number of out-of-sync channels for previous runs shows any channel identified in the run that will be thrown away for previvous runs up to the most recent run with a sync16 (usually just the previous run). Click the run number to see a list of the channels with these error flags. </th> </tr>
       <tr class="success"> <th> There aren't too many channels out-of-sync or dropping data, the run status is "Pass". Click the run number to see the list of channels. </th> </tr>
       <tr class="danger"> <th>  If over 64 channels are out of sync or more than 256 channels with missed counts, the run status is "Fail"  </th> </tr>
       <tr class="warning"> <th> If more than 32 channels are out-of-sync or there are more than 64 channels with missed counts, the run status is "Notice" </th> </tr>
@@ -24,30 +25,33 @@
 </div>
 
 <div class="container">
-  Select
-  <select id="limit" onchange="get_limit(this.value);">
+  List runs over the last
+  <select id="limit" onchange="get_limit(this.value, 0);">
     <option selected value="{{limit}}">{{limit}}</option>
     {% for n in [10, 25, 50, 100, 500] %}
       {% if n != limit %}
         <option value="{{n}}">{{n}}</option>
       {% endif %}
     {% endfor %}
-  </select> previous runs
+  </select> runs, or select run:
+
+  <input style="margin-bottom: 30px; width: 80px;" type="text" id="run" value={{selected_run}} onKeyDown="if(event.keyCode==13) get_limit(0, this.value);"></input>
+
   <table class="table table-hover">
     <thead>
       <tr> 
         <th> Run Number </th>
         <th> # Sync 16s </th>
         <th> # Sync 24s </th>
-        <th> # Channels w/ Sync 16 Flags </th>
-        <th> # Channels w/ Sync 24 Flags </th>
-        <th> # Channels w/ Missed Counts </th>
+        <th> # Channels Out-Of-Sync Current Run </th>
+        <th> # Channels Out-Of-Sync Previous Runs</th>
+        <th> # Channels With Missed Counts </th>
       </tr>
     </thead>
     {% for run in runs %}
-        {% if (missed[run] >= 64 and missed[run] < 256) or (sync16s[run] >= 32 and sync16s[run] < 64) %}
+        {% if (missed[run] >= 64 and missed[run] < 256) or (sync16s[run] >= 32 and sync16s[run] < 64 and sync16s_pr[run] < 64) %}
             <tr class="warning">
-        {% elif sync16s[run] >= 64 or missed[run] >= 256 %}
+        {% elif sync16s[run] >= 64 or missed[run] >= 256 or sync16s_pr[run] >= 64 %}
             <tr class="danger">
         {% else %}
             <tr class="success">
@@ -55,8 +59,8 @@
         <th> <a href="{{ url_for("channelflagsbychannel",run_number=run)}}">{{run}}</a> </th>
         <th> {{nsync16[run]}}</th>
         <th> {{nsync24[run]}}</th>
-        <th> {{sync16s[run]}}</th>
-        <th> {{sync24s[run]}}</th>
+        <th> {{sync16s[run] + sync24s[run]}} </th>
+        <th> {{sync16s_pr[run] + sync24s_pr[run]}} </th>
         <th> {{missed[run]}}</th>
       </tr>
     {% endfor %}
@@ -65,9 +69,10 @@
 {% endblock %}
 {% block script %}
   <script>
-    function get_limit(limit){
+    function get_limit(limit, run){
       params = {};
       params["limit"] = limit;
+      params["run"] = run;
       window.location.replace($SCRIPT_ROOT + "/channelflags?" + $.param(params));
     }
   </script>

--- a/minard/templates/channelflagsbychannel.html
+++ b/minard/templates/channelflagsbychannel.html
@@ -113,7 +113,7 @@ tr:nth-child(even) {
         </tr> 
       {% endif %}
   </table>
-  <h4> CMOS Sync 16 Identified in Later Run(s) </h4>
+  <h4> CMOS Sync 16 Identified for Previous Run(s) </h4>
   <table class="table table-hover">
     <thead>
       <tr>
@@ -141,7 +141,7 @@ tr:nth-child(even) {
         </tr> 
       {% endif %}
   </table>
-  <h4> CGT Sync 24 Identified in Later Run(s) </h4>
+  <h4> CGT Sync 24 Identified for Previous Run(s) </h4>
   <table class="table table-hover">
     <thead>
       <tr>

--- a/minard/templates/nearline_monitoring_summary.html
+++ b/minard/templates/nearline_monitoring_summary.html
@@ -37,7 +37,7 @@ tr:nth-child(even) {
 </div>
 
 <div class="container">
-  List physics runs over the last  
+  List runs over the last  
   <select id="limit" onchange="get_runs(this.value, 0);">
     {% if selected_run != 0 %}
       <option selected value="-">-</option>
@@ -51,7 +51,7 @@ tr:nth-child(even) {
     {% endfor %}
   </select> runs, or select run: 
 
-  <input style="margin-bottom: 30px; width: 80px;" type="text" id="run" value={{selected_run}} onKeyDown="if(event.keyCode==13) get_runs(1, this.value);"></input>
+  <input style="margin-bottom: 30px; width: 80px;" type="text" id="run" value={{selected_run}} onKeyDown="if(event.keyCode==13) get_runs(0, this.value);"></input>
 
   <table class="table table-hover">
     <thead>

--- a/minard/templates/occupancy_by_trigger.html
+++ b/minard/templates/occupancy_by_trigger.html
@@ -6,45 +6,64 @@
 {% block body %}
   {{ super() }}
 
+<div class="container">
+
+  <h2 align="left">Information For the User</h2>
+    <table class="table table-hover">
+      <tr> <th> The trigger occupancy processor looks at the occupancy of ESUMH triggered events and checks the occupancy of each slot to make sure its not too low. Low occupancy slots are most often caused by either a loss of high voltage (relays trip open) or the ESUMH trigger not working. For shorter runs it is possible to get false failures, so look for trends across runs. Clicking the run number will display the ESUMH, N100L, and N20LB occupancy for the run. The processor only runs on physics runs longer than 30 minutes long.
+      <tr class="success"> <th> The occupancy of ESUMH triggered events is not low in any slot in the detector. </th> </tr>
+      <tr class="danger"> <th>  The occupancy of ESUMH triggered events for one or more slots in the detector is low.  </th> </tr>
+  </table>
+
+</div>
+
+
 <div class="page-header">
   <h1 align="center">Occupancy By Trigger</h1>
 </div>
 
 <div class="container">
   <div class="col-md-6 col-md-offset-3">
-    Show:
-    <select id="limit" onchange="get_limit(this.value);">
+    Show runs over the last
+    <select id="limit" onchange="get_limit(this.value, 0);">
       <option selected value="{{limit}}">{{limit}}</option>
       {% for n in [10, 25, 50, 100, 500] %}
         {% if n != limit %}
           <option value="{{n}}">{{n}}</option>
         {% endif %}
       {% endfor %}
-    </select> previous runs
+    </select> runs, or select run:
+
+    <input style="margin-bottom: 30px; width: 80px;" type="text" id="run" value={{selected_run}} onKeyDown="if(event.keyCode==13) get_limit(0, this.value);"></input>
+
     <table class="table table-hover">
       <thead>
         <tr> 
           <th> Run </th>
           <th> Crate </th>
-          <th> Number of Slots </th>
+          <th> Slots </th>
         </tr>
       </thead>
       <thead>
-        {% for run in runs %}
-          {% if count[run] > 1 %}
-            <tr class="danger">
-          {% else %}
-            <tr class="success"> 
-          {% endif %}
-            <th><a href="{{url_for('occupancy_by_trigger_run',run_number=run) }}">{{run}}</a></th>
-            {% if crates[run] %}
-              <th> {{crates[run]}} </th>
-              {% if slots[run] %}
-                <th> {{slots[run]}} </th>
-              {% endif %}
+        {% if runs %}
+          {% for run in runs %}
+            {% if count[run] >= 1 %}
+              <tr class="danger">
+            {% else %}
+              <tr class="success"> 
             {% endif %}
-          </tr>
-        {% endfor %}
+              <th><a href="{{url_for('occupancy_by_trigger_run',run_number=run) }}">{{run}}</a></th>
+              {% if crates[run] %}
+                <th> {{crates[run]}} </th>
+                {% if slots[run] %}
+                  <th> {{slots[run]}} </th>
+                {% endif %}
+              {% endif %}
+            </tr>
+          {% endfor %}
+        {% else %}
+          <th> No data found </th>
+        {% endif %}
       </thead>
     </table>
   </div>
@@ -52,9 +71,10 @@
 {% endblock %}
 {% block script %}
   <script>
-    function get_limit(limit){
+    function get_limit(limit, run){
       params = {};
       params["limit"] = limit;
+      params["run"] = run;
       window.location.replace($SCRIPT_ROOT + "/occupancy_by_trigger?" + $.param(params));
     }
   </script>

--- a/minard/templates/occupancy_by_trigger_run.html
+++ b/minard/templates/occupancy_by_trigger_run.html
@@ -40,7 +40,7 @@
                         N100L
                     </a>
                 </h3>
-                <div id="collapsen100l" class="panel-collapse collapse">
+                <div id="collapsen100l" class="panel-collapse collapse in">
                     <div class="panel-body" id="crateX" align="center"> </div>
                 </div>
             </div>
@@ -55,38 +55,8 @@
                         N20LB
                     </a>
                 </h3>
-                <div id="collapsen20lb" class="panel-collapse collapse">
+                <div id="collapsen20lb" class="panel-collapse collapse in">
                     <div class="panel-body" id="crateY" align="center"> </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div class="panel-group">
-        <div class="panel panel-default-test">
-            <div class="panel-heading">
-                <h3 class="panel-title" align="center">
-                    <a data-toggle="collapse" data-parent="accordion" href="#collapseowln">
-                        OWLN
-                    </a>
-                </h3>
-                <div id="collapseowln" class="panel-collapse collapse">
-                    <div class="panel-body" id="crateI" align="center"> </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div class="panel-group">
-        <div class="panel panel-default-test">
-            <div class="panel-heading">
-                <h3 class="panel-title" align="center">
-                    <a data-toggle="collapse" data-parent="accordion" href="#collapsepgt">
-                        PGT
-                    </a>
-                </h3>
-                <div id="collapsepgt" class="panel-collapse collapse">
-                    <div class="panel-body" id="crateJ" align="center"> </div>
                 </div>
             </div>
         </div>

--- a/minard/templates/pingcrates.html
+++ b/minard/templates/pingcrates.html
@@ -9,6 +9,7 @@
 <div class="container">
   <h2 align="left">Information For the User</h2>
     <table class="table table-hover">
+      <tr> <th> Ping crates runs at the beginning of every physics runs and pedestals each slot in the detector individually. The ping crates processor loops over those events and looks at the CAEN signals for N100L and N20LB. Any issues with the trigger signals are identified by looking at the peak, width, rise time, and fall time. Click the run number to see plots showing information about the N100 and N20 trigger signals. <th> <tr>
       <tr class="success"> <th> If the run status is "Pass" the N100 and N20 trigger signals look good for all crates and slots! </th> </tr>
       <tr class="danger"> <th>  If the run status is "Fail" note it in the shift report and the shift slack. No immediate action is needed, but it might be a data quality issue. </th> </tr>
       <tr class="warning"> <th> If the run status is "Notice" a detector expert will take a look. No action is needed. </th> </tr>
@@ -21,15 +22,18 @@
 </div>
 
 <div class="container">
-  Show:
-  <select id="limit" onchange="get_limit(this.value);">
+  List runs over the last
+  <select id="limit" onchange="get_limit(this.value, 0);">
     <option selected value="{{limit}}">{{limit}}</option>
     {% for n in [10, 25, 50, 100, 500] %}
       {% if n != limit %}
         <option value="{{n}}">{{n}}</option>
       {% endif %}
     {% endfor %}
-  </select> previous runs
+  </select> runs, or select run:
+
+  <input style="margin-bottom: 30px; width: 80px;" type="text" id="run" value={{selected_run}} onKeyDown="if(event.keyCode==13) get_limit(0, this.value);"></input>
+
   <table class="table table-hover">
     <thead>
       <tr> 
@@ -64,9 +68,10 @@
 {% endblock %}
 {% block script %}
   <script>
-    function get_limit(limit){
+    function get_limit(limit, run){
       params = {};
       params["limit"] = limit;
+      params["run"] = run;
       window.location.replace($SCRIPT_ROOT + "/pingcrates?" + $.param(params));
     }
   </script>

--- a/minard/templates/trigger_clock_jump.html
+++ b/minard/templates/trigger_clock_jump.html
@@ -10,6 +10,7 @@
 
   <h2 align="left">Information For the User</h2>
     <table class="table table-hover">
+      <tr> <th> The trigger clock jump processor looks for bit-flips on the 10MHz and 50MHz clocks that cause jumps in the clock ticks. This page reports the number of those clock jumps for both clocks. The trigger clock jumps are corrected in RAT using the other clock, but a run with many clock jumps might have other problems. Click the run number to see a list of the GTID and size of the clock jumps.
       <tr class="success"> <th> The run status is "Pass" if there were less than 10 total clock jumps on the 10MHz and 50MHz clocks. </th> </tr>
       <tr class="danger"> <th>  The run status is "Fail" if there were more than 20 total clock jumps on the 10MHz and 50MHz clocks. This is not necessarily an issue because these clock jumps are corrected, but it might indicate an issue with the run. </th> </tr>
       <tr class="warning"> <th> The run status is "Notice" if there were between 10 and 20 total clock jumps on the 10MHz and 50MHz clocks. </th> </tr>
@@ -23,15 +24,18 @@
 </div>
 
 <div class="container">
-  Select
-  <select id="limit" onchange="get_limit(this.value);">
+  List runs over the last
+  <select id="limit" onchange="get_limit(this.value, 0);">
     <option selected value="{{limit}}">{{limit}}</option>
     {% for n in [10, 25, 50, 100, 500] %}
       {% if n != limit %}
         <option value="{{n}}">{{n}}</option>
       {% endif %}
     {% endfor %}
-  </select> previous runs
+  </select> runs, or select run:
+
+  <input style="margin-bottom: 30px; width: 80px;" type="text" id="run" value={{selected_run}} onKeyDown="if(event.keyCode==13) get_limit(0, this.value);"></input>
+
   <table class="table table-hover">
     <thead>
       <tr> 
@@ -58,9 +62,10 @@
 {% endblock %}
 {% block script %}
   <script>
-    function get_limit(limit){
+    function get_limit(limit, run){
       params = {};
       params["limit"] = limit;
+      params["run"] = run;
       window.location.replace($SCRIPT_ROOT + "/trigger_clock_jump?" + $.param(params));
     }
   </script>

--- a/minard/triggerclockjumpsdb.py
+++ b/minard/triggerclockjumpsdb.py
@@ -1,7 +1,7 @@
 from .db import engine_nl
 from .detector_state import get_latest_run
 
-def get_clock_jumps(limit):
+def get_clock_jumps(limit, selected_run):
     """
     Returns a list of runs and dictionaries
     specifing the number of clock jump for 
@@ -11,9 +11,16 @@ def get_clock_jumps(limit):
 
     current_run = get_latest_run()
 
-    result = conn.execute("SELECT DISTINCT ON (run) run "
-                          "FROM trigger_clock_jumps WHERE run > %i "
-                          "ORDER BY run DESC, timestamp DESC" % (current_run - limit))
+    if selected_run == 0:
+        result = conn.execute("SELECT DISTINCT ON (run) run "
+                              "FROM trigger_clock_jumps WHERE run > %i "
+                              "ORDER BY run DESC, timestamp DESC" % \
+                              (current_run - limit))
+    else:
+        result = conn.execute("SELECT DISTINCT ON (run) run "
+                              "FROM trigger_clock_jumps WHERE run = %i "
+                              "ORDER BY run DESC, timestamp DESC" % \
+                              (selected_run))
 
     rows = result.fetchall()
 
@@ -26,11 +33,18 @@ def get_clock_jumps(limit):
         njump10[run[0]] = 0
         njump50[run[0]] = 0
 
-    result = conn.execute("SELECT DISTINCT ON (run, gtid10, gtid50) "
-                          "run, clockjump10, clockjump50 "
-                          "FROM trigger_clock_jumps WHERE run > %i "
-                          "ORDER BY run DESC, gtid10, gtid50, timestamp DESC" \
-                          % (current_run - limit))
+    if selected_run == 0:
+        result = conn.execute("SELECT DISTINCT ON (run, gtid10, gtid50) "
+                              "run, clockjump10, clockjump50 "
+                              "FROM trigger_clock_jumps WHERE run > %i "
+                              "ORDER BY run DESC, gtid10, gtid50, timestamp DESC" \
+                              % (current_run - limit))
+    else:
+        result = conn.execute("SELECT DISTINCT ON (run, gtid10, gtid50) "
+                              "run, clockjump10, clockjump50 "
+                              "FROM trigger_clock_jumps WHERE run = %i "
+                              "ORDER BY run DESC, gtid10, gtid50, timestamp DESC" \
+                              % (selected_run))
 
     rows = result.fetchall()
 


### PR DESCRIPTION
- Ability to select by run for all nearline monitoring pages
- Include new esumh occupancy table that fixes the very slow trigger occupancy pages
- Trigger occupancy by run page now just shows esumh, n100, n20
- Channel flags page now display out-of-sync channels for previous runs
- Add a more in depth description of what the nearline monitoring page is showing for each page