### PR TITLE
New "critical" job type and add muon follower to nearline table list

### DIFF
--- a/minard/nearline_settings.py
+++ b/minard/nearline_settings.py
@@ -1,6 +1,6 @@
 # List of all nearline job types
-jobTypes = ["Critical","All","DAQ","SMELLIE","BLINDNESS_CHUNKER","PCATELLIE","RUN","TELLIE","ECA","PING_CRATES","PMTCalStatus","ANALYSIS","DQHL","CHS","DQLL","PMTNOISE","CHANNEL_FLAGS","CLOCK_JUMPS", "TRIGGER_OCCUPANCY"]
+jobTypes = ["Critical","All","DAQ","SMELLIE","BLINDNESS_CHUNKER","PCATELLIE","RUN","TELLIE","ECA","PING_CRATES","PMTCalStatus","ANALYSIS","DQHL","CHS","DQLL","PMTNOISE","CHANNEL_FLAGS","CLOCK_JUMPS", "TRIGGER_OCCUPANCY", "MUON_FOLLOWER"]
 
 # List of jobs absolutely critical for a gold run
 # Others like ping crates are nice to have
-criticalJobs = ["BLINDNESS_CHUNKER","RUN","CLOCK_JUMPS","DQHL","CHANNEL_FLAGS","CHS","DAQ","DQLL"]
+criticalJobs = ["BLINDNESS_CHUNKER","RUN","CLOCK_JUMPS","DQHL","CHANNEL_FLAGS","CHS","DAQ","DQLL", "MUON_FOLLOWER"]

--- a/minard/nearline_settings.py
+++ b/minard/nearline_settings.py
@@ -1,3 +1,6 @@
 # List of all nearline job types
-jobTypes = ["All","DAQ","SMELLIE","BLINDNESS_CHUNKER","PCATELLIE","RUN","TELLIE","ECA","PING_CRATES","PMTCalStatus","ANALYSIS","DQHL","CHS","DQLL","PMTNOISE","CHANNEL_FLAGS","CLOCK_JUMPS", "TRIGGER_OCCUPANCY"]
+jobTypes = ["Critical","All","DAQ","SMELLIE","BLINDNESS_CHUNKER","PCATELLIE","RUN","TELLIE","ECA","PING_CRATES","PMTCalStatus","ANALYSIS","DQHL","CHS","DQLL","PMTNOISE","CHANNEL_FLAGS","CLOCK_JUMPS", "TRIGGER_OCCUPANCY"]
 
+# List of jobs absolutely critical for a gold run
+# Others like ping crates are nice to have
+criticalJobs = ["BLINDNESS_CHUNKER","RUN","CLOCK_JUMPS","DQHL","CHANNEL_FLAGS","CHS","DAQ","DQLL"]

--- a/minard/templates/nearline_summary.html
+++ b/minard/templates/nearline_summary.html
@@ -69,7 +69,7 @@
         {% if failures and mode == 1 %}
     	  {% for program, status, run in failures %}
             <tr>
-              {% if jobs == "All" or jobs == program %}
+              {% if jobs == "All" or jobs == program or (jobs == "Critical" and program in criticalJobs) %}
     	        {% if status|int == 1 %}
     	          <th class="danger"> Failed </th>
                 {% elif status|int == 97 %}

--- a/minard/views.py
+++ b/minard/views.py
@@ -465,17 +465,15 @@ def nearline_summary():
     limit = request.args.get("limit", 100, type=int)
     mode = request.args.get("mode", 1, type=int)
     runtype = request.args.get("runtype", -1, type=int)
-    #run = int(redis.get('nearline:current_run'))
-    run = 106801
+    run = int(redis.get('nearline:current_run'))
 
     # Nearline job types and ways in which the jobs fail
     jobtypes = nearline_settings.jobTypes
     runTypes = nlrat.RUN_TYPES
     runTypes[-1] = "All"
 
-    criticalJobs = ["BLINDNESS_CHUNKER","RUN","CLOCK_JUMPS","DQHL","CHANNEL_FLAGS",\
-                    "CHS","DAQ","DQLL"]
- 
+    criticalJobs = nearline_settings.criticalJobs
+
     # Check if any jobs were not launched
     program_check = {}
     not_launched = []

--- a/minard/views.py
+++ b/minard/views.py
@@ -418,13 +418,16 @@ def nearline_summary():
     limit = request.args.get("limit", 100, type=int)
     mode = request.args.get("mode", 1, type=int)
     runtype = request.args.get("runtype", -1, type=int)
-    run = int(redis.get('nearline:current_run'))
-    detector_run = detector_state.get_latest_run()
+    #run = int(redis.get('nearline:current_run'))
+    run = 106801
 
     # Nearline job types and ways in which the jobs fail
     jobtypes = nearline_settings.jobTypes
     runTypes = nlrat.RUN_TYPES
     runTypes[-1] = "All"
+
+    criticalJobs = ["BLINDNESS_CHUNKER","RUN","CLOCK_JUMPS","DQHL","CHANNEL_FLAGS",\
+                    "CHS","DAQ","DQLL"]
  
     # Check if any jobs were not launched
     program_check = {}
@@ -454,10 +457,11 @@ def nearline_summary():
                 failures.append((program, status, run-previous_run))
         # Check if all the jobs were run
         for i in range(len(jobtypes)):
-            if jobtypes[i] not in program_check[previous_run] and jobtypes[i] != "All":
+            if jobtypes[i] not in program_check[previous_run] and \
+               jobtypes[i] != "All" and jobtypes[i] != "Critical":
                 not_launched.append((jobtypes[i], run-previous_run)) 
 
-    return render_template('nearline_summary.html', run=run, failures=failures, jobs=jobs, jobtypes=jobtypes, mode=mode, not_launched=not_launched, limit=limit, runTypes=runTypes, selectedType=selectedType, runtype=runtype)
+    return render_template('nearline_summary.html', run=run, failures=failures, jobs=jobs, jobtypes=jobtypes, criticalJobs=criticalJobs, mode=mode, not_launched=not_launched, limit=limit, runTypes=runTypes, selectedType=selectedType, runtype=runtype)
 
 @app.route('/get_l2')
 def get_l2():


### PR DESCRIPTION
Allow nearline summary page to be sorted by "critical" job types, where "critical" is defined as jobs required for processing a physics run and run selection. Also add muon follower to the list of nearline jobs.