### PR TITLE
Add resync information to channel flags page

### DIFF
--- a/minard/nearline_monitor.py
+++ b/minard/nearline_monitor.py
@@ -169,7 +169,7 @@ def channel_flags(limit, run_range_low, run_range_high, all_runs, summary, gold)
     '''
     Return a dictionary of channel flags status by run
     '''
-    _, _, _, count_sync16, _, count_missed, count_sync16_pr, _, _, _, _ = \
+    _, _, _, _, count_sync16, _, count_missed, count_sync16_pr, _, _, _, _ = \
         get_channel_flags(limit, run_range_low, run_range_high, summary, gold)
     channel_flags_fail = {}
     for run in all_runs:

--- a/minard/templates/channelflags.html
+++ b/minard/templates/channelflags.html
@@ -64,6 +64,7 @@
           <th> Run Number </th>
           <th> # Sync 16s </th>
           <th> # Sync 24s </th>
+          <th> Resync </th>
           <th> # Channels Out-Of-Sync Current Run </th>
           <th> # Channels Out-Of-Sync Previous Runs</th>
           <th> # Channels With Missed Counts </th>
@@ -84,6 +85,13 @@
               <th> <a href="{{ url_for("channelflagsbychannel",run_number=run)}}">{{run}}</a> </th>
               <th> {{nsync16[run]}}</th>
               <th> {{nsync24[run]}}</th>
+              {% if nresyncs[run] == 1 %}
+                <th> Yes </th>
+              {% elif nresyncs[run] == 0 %}
+                <th> No </th>
+              {% else %}
+                <th> - </th>
+              {% endif %}
               <th> {{sync16s[run] + sync24s[run]}} </th>
               <th> {{sync16s_pr[run] + sync24s_pr[run]}} </th>
               <th> {{missed[run]}}</th>

--- a/minard/views.py
+++ b/minard/views.py
@@ -1226,7 +1226,7 @@ def channelflags():
         gold_runs = golden_run_list(selected_run, limit, run_range_low, run_range_high)
 
     if not selected_run:
-        runs, nsync16, nsync24, sync16s, sync24s, missed, sync16s_pr, sync24s_pr, normal, owl, other = channelflagsdb.get_channel_flags(limit, run_range_low, run_range_high, False, gold_runs)
+        runs, nsync16, nsync24, nresyncs, sync16s, sync24s, missed, sync16s_pr, sync24s_pr, normal, owl, other = channelflagsdb.get_channel_flags(limit, run_range_low, run_range_high, False, gold_runs)
     else:
         nsync16 = {}
         nsync24 = {}
@@ -1235,6 +1235,7 @@ def channelflags():
         sync24s = {}
         sync16s_pr = {}
         sync24s_pr = {}
+        nresyncs = {}
         runs = [selected_run]
         missed_count, cmos_sync16, cgt_sync24, cmos_sync16_pr, cgt_sync24_pr, normal, owl, other = channelflagsdb.get_channel_flags_by_run(selected_run)
         sync16s[selected_run] = len(cmos_sync16)
@@ -1242,8 +1243,8 @@ def channelflags():
         sync24s[selected_run] = len(cgt_sync24)
         sync24s_pr[selected_run] = len(cgt_sync24_pr)
         missed[selected_run] = len(missed_count)
-        nsync16[selected_run], nsync24[selected_run] = channelflagsdb.get_number_of_syncs(selected_run)
-    return render_template('channelflags.html', runs=runs, nsync16=nsync16, nsync24=nsync24, sync16s=sync16s, sync24s=sync24s, missed=missed, sync16s_pr=sync16s_pr, sync24s_pr=sync24s_pr, limit=limit, selected_run=selected_run, run_range_low=run_range_low, run_range_high=run_range_high, normal=normal, owl=owl, other=other, gold=gold)
+        nsync16[selected_run], nsync24[selected_run], nresyncs[selected_run] = channelflagsdb.get_number_of_syncs(selected_run)
+    return render_template('channelflags.html', runs=runs, nsync16=nsync16, nsync24=nsync24, nresyncs=nresyncs, sync16s=sync16s, sync24s=sync24s, missed=missed, sync16s_pr=sync16s_pr, sync24s_pr=sync24s_pr, limit=limit, selected_run=selected_run, run_range_low=run_range_low, run_range_high=run_range_high, normal=normal, owl=owl, other=other, gold=gold)
 
 @app.route('/channelflagsbychannel/<run_number>')
 def channelflagsbychannel(run_number):


### PR DESCRIPTION
Should also fix a bug where if the previous run was resynced and there was no sync 16 in that run (other than the resync) than the next run reported that the channels were out of sync.