### PR TITLE
add crate-level plots to noise page; reverse run ordering on noise page

### DIFF
--- a/minard/templates/noise.html
+++ b/minard/templates/noise.html
@@ -6,6 +6,11 @@
 {% block body %}
 {{ super() }}
 
+<div>
+    <img src="{{ url_for('static', filename='pmtnoise/noise-rate_time-series.png') }}" alt="Noise time-series">
+    <img src="{{ url_for('static', filename='pmtnoise/qhs-hhp_time-series.png') }}" alt="HHS time-series">
+</div>
+
 <div class="container">
     <table class="table table-hover">
       <thead>
@@ -22,7 +27,7 @@
       </tr>
     </thead>
     <tbody>
-      {% for run in runs if run %}
+      {% for run in runs|reverse if run %}
       {% if "n_pgt" in run and run["n_pgt"]|int() > 10000 %}
       <tr class="info">
       {% else %}


### PR DESCRIPTION
Adds two plots generated on nearline to the general noise page, and sorts run details below in descending.

![minard-crate-plots](https://user-images.githubusercontent.com/7518185/35841518-4a50d2ba-0ab1-11e8-92c5-0aec3a95971f.png)