### PR TITLE
Nearline failures / reprocessing / check rates summary changes

### DIFF
--- a/minard/nearlinedb.py
+++ b/minard/nearlinedb.py
@@ -72,9 +72,17 @@ def get_failed_runs(run, run_range_low=0, run_range_high=0):
     failed = [-1, 1, 2, 3, 97, 98]
     failed_map = {}
     for run, name, status in rows:
+        multiple_failure = False
         if job_status[(run, name)] in failed and status in failed:
             try:
-                failed_map[run].append((str(name), int(status)))
+                # Don't double count when the job has failed multiple
+                # times for the same run, which can happen when the job
+                # has been reprocessed
+                for i in range(len(failed_map[run])):
+                    if failed_map[run][i][0] == name:
+                        multiple_failure = True
+                if not multiple_failure:
+                    failed_map[run].append((str(name), int(status)))
             except KeyError:
                 failed_map[run] = [(str(name), int(status))]
 

--- a/minard/nearlinedb.py
+++ b/minard/nearlinedb.py
@@ -90,3 +90,36 @@ def get_failed_runs(run, run_range_low=0, run_range_high=0):
     failed_runs = sorted(failed_runs, reverse=True)
 
     return failed_runs, failed_map
+
+def reprocessed_runs():
+    """
+    Get a list of runs that have been automatically reprocessed
+    """
+    conn = engine_nl.connect()
+
+    result = conn.execute("SELECT DISTINCT ON (run) run FROM reprocessed_run "
+                          "ORDER BY run DESC")
+
+    rows = result.fetchall()
+
+    reprocessed_runs = []
+    for run in rows:
+        reprocessed_runs.append(run[0])
+
+    return reprocessed_runs
+
+def reprocessed_run(run):
+    """
+    Return whether the run has been reprocessed
+    """
+    conn = engine_nl.connect()
+
+    result = conn.execute("SELECT run FROM reprocessed_run WHERE run = %s", (run,))
+
+    rows = result.fetchone()
+
+    if rows is None:
+        return False
+
+    return True 
+

--- a/minard/templates/check_rates.html
+++ b/minard/templates/check_rates.html
@@ -26,6 +26,8 @@
 
     <input type="button" onclick="window.location.replace($SCRIPT_ROOT + '/cmos_rates_check');" value = "Check CMOS Rates" <span title="Check most recent CMOS polling against nominal rates."> </input>
 
+    <input type="button" onclick="window.location.replace($SCRIPT_ROOT + '/check_rates_summary');" value = "Check Rates Summary" <span title="Summarize the rates and currents for each crate."> </input>
+
     <div class="row">
         <div class="col-md-10 col-md-offset-1" id="crateY" style="text-align:center"></div>
     </div>

--- a/minard/templates/layout.html
+++ b/minard/templates/layout.html
@@ -82,7 +82,6 @@
                                 {{ nav_link('channelflags', 'Channel Flags') }}  
                                 {{ nav_link('trigger_clock_jump', 'Trigger Clock Jumps') }}
                                 {{ nav_link('muon_list', 'Muons') }}
-                                {{ nav_link('check_rates_summary', 'Check Rates Summary') }}
                                 {{ nav_link('rathome', 'RAT') }}
                                 {{ nav_link('dropout_overview', 'Dropout') }}
                             </ul>

--- a/minard/templates/layout.html
+++ b/minard/templates/layout.html
@@ -89,6 +89,7 @@
                         <li class='dropdown'>
 			<a href='#' class='dropdown-toggle' data-toggle='dropdown'>PMTcal <b class='caret'></b></a>
                             <ul class='dropdown-menu'>
+                                <li> <a href="https://snopluspmts.physics.berkeley.edu/">Overview</a></li>
                                 {{ nav_link('eca', 'ECA') }}
                                 {{ nav_link('pcatellie', 'PCA Tellie') }}
 				{{ nav_link('noise', 'PMT Noise') }}

--- a/minard/templates/nearline.html
+++ b/minard/templates/nearline.html
@@ -56,6 +56,13 @@
                         </th>
 		    </tr>
 		    {% endfor %}
+                    {% if reprocessed %}
+                    <th> - </th>
+                    <th> REPROCESSING JOB </th>
+                    <th>
+                        <a href="{{ "/monitoring/nearline/logs/%i/RELAUNCH.log" % (run) }}">RELAUNCH.log</a>
+                    </th>
+                    {% endif %}     
 		</table>
 	    </div>
 	</div>

--- a/minard/templates/nearline_failures.html
+++ b/minard/templates/nearline_failures.html
@@ -8,7 +8,7 @@
 <div class="container">
   <div class="row">
     <div class="col-md-12">
-      <h3> Select nearline jobs with the following conditions: </h3>
+      <h3> List failed nearline jobs with the following conditions: </h3>
       <table class="table table-hover">
         <tr>
           <th> Job Name: </th>

--- a/minard/views.py
+++ b/minard/views.py
@@ -460,9 +460,11 @@ def nearline(run=None):
     if run is None:
         run = nearlinedb.current_run()
 
+    reprocessed = nearlinedb.reprocessed_run(run)
+
     programs = nearlinedb.get_nearline_status(run)
 
-    return render_template('nearline.html', run=run, programs=programs)
+    return render_template('nearline.html', run=run, programs=programs, reprocessed=reprocessed)
 
 @app.route('/nearline_failures')
 def nearline_failures():


### PR DESCRIPTION
- Move check rates summary page from the layout
- Fix bug where jobs that failed multiple times for the same run were being double counted on the failures page
- Post reprocessing information to nearline page