### PR TITLE
Nhit monitor update

### DIFF
--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -513,13 +513,13 @@ def get_nhit_monitor_thresholds_nearline(limit=100, offset=0):
 
     return [dict(zip(keys,row)) for row in rows]
 
-def get_nhit_monitor_nearline(run):
+def get_nhit_monitor_nearline(key):
     """
     Return an nhit monitor record from the nearline database.
     """
     conn = engine_nl.connect()
 
-    result = conn.execute("SELECT * FROM nhit_monitor WHERE run=%s", (run,))
+    result = conn.execute("SELECT * FROM nhit_monitor WHERE key=%s", (key,))
 
     if result is None:
         return None

--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 from .views import app
-from .db import engine
+from .db import engine, engine_nl
 from .channeldb import get_nominal_settings_for_run
 from collections import defaultdict
 
@@ -488,6 +488,38 @@ def get_nhit_monitor(key):
     conn = engine.connect()
 
     result = conn.execute("SELECT * FROM nhit_monitor WHERE key=%s", (key,))
+
+    if result is None:
+        return None
+
+    keys = result.keys()
+    row = result.fetchone()
+
+    return dict(zip(keys,row))
+
+def get_nhit_monitor_thresholds_nearline(limit=100, offset=0):
+    """
+    Returns a list of the latest nhit monitor records in the nearline database.
+    """
+    conn = engine_nl.connect()
+
+    result = conn.execute("SELECT * FROM nhit_monitor_thresholds ORDER BY timestamp DESC LIMIT %s OFFSET %s", (limit,offset))
+
+    if result is None:
+        return None
+
+    keys = result.keys()
+    rows = result.fetchall()
+
+    return [dict(zip(keys,row)) for row in rows]
+
+def get_nhit_monitor_nearline(run):
+    """
+    Return an nhit monitor record from the nearline database.
+    """
+    conn = engine_nl.connect()
+
+    result = conn.execute("SELECT * FROM nhit_monitor WHERE run=%s", (run,))
 
     if result is None:
         return None

--- a/minard/templates/layout.html
+++ b/minard/templates/layout.html
@@ -47,7 +47,7 @@
                                 {{ nav_link('detector', 'Occupancy') }}
                                 {{ nav_link('nhit', 'Nhit Distribution') }}
                                 {{ nav_link('daq', 'CMOS Rates, Base Currents, and Occupancy') }}
-                                {{ nav_link('nhit_monitor_thresholds', 'Nhit Monitor') }}
+                                {{ nav_link('nhit_monitor_thresholds_nearline', 'Nhit Monitor') }}
                                 {{ nav_link('trigger', 'Trigger Scans') }}
                                 {{ nav_link('state', 'Detector State', run=0) }}
                                 {{ nav_link('detector_state_check', 'Detector State Check', run=0) }}

--- a/minard/templates/nhit_monitor_nearline.html
+++ b/minard/templates/nhit_monitor_nearline.html
@@ -1,0 +1,141 @@
+{% extends "layout.html" %}
+{% block title %}Nhit Monitor{% endblock %}
+{% block head %}
+    <!-- metrics-graphics stylesheet goes above super() because we want bootstrap's style
+    (which is linked in super()) to override it. -->
+    <link rel="stylesheet" type="text/css"  href="{{ url_for('static',filename='css/metricsgraphics.css') }}">
+    <link rel="stylesheet" type="text/css"  href="{{ url_for('static',filename='css/mg_line_brushing.css') }}">
+    {{ super() }}
+{% endblock %}
+{% block body %}
+    {{ super() }}
+    <div class="container">
+	{% if error %}
+	<div class="alert alert-danger" role="alert">
+	<span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+	Error: {{ error }}
+	</div>
+	{% else %}
+	<div class="row">
+	    <div class="col-md-12" id='nhit-100-lo'></div>
+        </div>
+	<div class="row">
+	    <div class="col-md-12" id='nhit-100-med'></div>
+        </div>
+	<div class="row">
+	    <div class="col-md-12" id='nhit-100-hi'></div>
+        </div>
+	<div class="row">
+	    <div class="col-md-12" id='nhit-20'></div>
+        </div>
+	<div class="row">
+	    <div class="col-md-12" id='nhit-20-lb'></div>
+        </div>
+	{% endif %}
+    </div>
+{% endblock %}
+{% block script %}
+    <script src="{{ url_for('static', filename='js/d3.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/metricsgraphics.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/mg_line_brushing.js') }}"></script>
+
+    <script>
+        var nhit_100_lo = {{ results['nhit_100_lo'] | tojson }};
+        var nhit_100_med = {{ results['nhit_100_med'] | tojson }};
+        var nhit_100_hi = {{ results['nhit_100_hi'] | tojson }};
+        var nhit_20 = {{ results['nhit_20'] | tojson }};
+        var nhit_20_lb = {{ results['nhit_20_lb'] | tojson }};
+
+        var nhit_100_lo_data = new Array();
+        for (var i=0; i < nhit_100_lo.length; i++) {
+            nhit_100_lo_data.push({'x': i, 'y': nhit_100_lo[i]});
+        }
+        var nhit_100_med_data = new Array();
+        for (var i=0; i < nhit_100_med.length; i++) {
+            nhit_100_med_data.push({'x': i, 'y': nhit_100_med[i]});
+        }
+        var nhit_100_hi_data = new Array();
+        for (var i=0; i < nhit_100_hi.length; i++) {
+            nhit_100_hi_data.push({'x': i, 'y': nhit_100_hi[i]});
+        }
+        var nhit_20_data = new Array();
+        for (var i=0; i < nhit_20.length; i++) {
+            nhit_20_data.push({'x': i, 'y': nhit_20[i]});
+        }
+        var nhit_20_lb_data = new Array();
+        for (var i=0; i < nhit_20_lb.length; i++) {
+            nhit_20_lb_data.push({'x': i, 'y': nhit_20_lb[i]});
+        }
+
+        MG.data_graphic({
+            title: "Nhit 100 Lo",
+            description: "Nhit 100 Lo trigger efficiency curve",
+            data: nhit_100_lo_data,
+            chart_type: 'point',
+            width: $('#nhit-100-lo').width(),
+            height: 250,
+            left: 100,
+            target: '#nhit-100-lo',
+            x_accessor: 'x',
+            y_accessor: 'y',
+            x_label: 'nhit',
+            y_label: 'trigger efficiency'
+        });
+        MG.data_graphic({
+            title: "Nhit 100 Med",
+            description: "Nhit 100 Med trigger efficiency curve",
+            data: nhit_100_med_data,
+            chart_type: 'point',
+            width: $('#nhit-100-med').width(),
+            height: 250,
+            left: 100,
+            target: '#nhit-100-med',
+            x_accessor: 'x',
+            y_accessor: 'y',
+            x_label: 'nhit',
+            y_label: 'trigger efficiency'
+        });
+        MG.data_graphic({
+            title: "Nhit 100 Hi",
+            description: "Nhit 100 Hi trigger efficiency curve",
+            data: nhit_100_hi_data,
+            chart_type: 'point',
+            width: $('#nhit-100-hi').width(),
+            height: 250,
+            left: 100,
+            target: '#nhit-100-hi',
+            x_accessor: 'x',
+            y_accessor: 'y',
+            x_label: 'nhit',
+            y_label: 'trigger efficiency'
+        });
+        MG.data_graphic({
+            title: "Nhit 20",
+            description: "Nhit 20 trigger efficiency curve",
+            data: nhit_20_data,
+            chart_type: 'point',
+            width: $('#nhit-20').width(),
+            height: 250,
+            left: 100,
+            target: '#nhit-20',
+            x_accessor: 'x',
+            y_accessor: 'y',
+            x_label: 'nhit',
+            y_label: 'trigger efficiency'
+        });
+        MG.data_graphic({
+            title: "Nhit 20 LB",
+            description: "Nhit 20 LB trigger efficiency curve",
+            data: nhit_20_lb_data,
+            chart_type: 'point',
+            width: $('#nhit-20-lb').width(),
+            height: 250,
+            left: 100,
+            target: '#nhit-20-lb',
+            x_accessor: 'x',
+            y_accessor: 'y',
+            x_label: 'nhit',
+            y_label: 'trigger efficiency'
+        });
+    </script>
+{% endblock %}

--- a/minard/templates/nhit_monitor_thresholds_nearline.html
+++ b/minard/templates/nhit_monitor_thresholds_nearline.html
@@ -1,0 +1,210 @@
+{% extends "layout.html" %}
+{% block title %}Nhit Monitor{% endblock %}
+{% block head %}
+    <!-- metrics-graphics stylesheet goes above super() because we want bootstrap's style
+    (which is linked in super()) to override it. -->
+    <link rel="stylesheet" type="text/css"  href="{{ url_for('static',filename='css/metricsgraphics.css') }}">
+    <link rel="stylesheet" type="text/css"  href="{{ url_for('static',filename='css/mg_line_brushing.css') }}">
+    {{ super() }}
+{% endblock %}
+{% block body %}
+    {{ super() }}
+    <div class="container">
+	{% if error %}
+	<div class="alert alert-danger" role="alert">
+	<span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+	Error: {{ error }}
+	</div>
+	{% else %}
+	<div class="row">
+	    <div class="col-md-12" id='trigger-threshold'></div>
+        </div>
+	<div class="row">
+	    <div class="col-md-12" id='trigger-efficiency-width'></div>
+        </div>
+	<div class="row">
+	    <div class="col-md-12">
+		<table class="table">
+		    <thead>
+			<tr>
+			    <th></th>
+			    <th></th>
+			    <th colspan="5">Threshold</th>
+			    <th colspan="5">Width</th>
+			</tr>
+			<tr>
+			    <th>Run</th>
+			    <th>Timestamp</th>
+			    <th>100L</th>
+			    <th>100M</th>
+			    <th>100H</th>
+			    <th>20</th>
+			    <th>20L</th>
+			    <th>100L</th>
+			    <th>100M</th>
+			    <th>100H</th>
+			    <th>20</th>
+			    <th>20L</th>
+			</tr>
+		    </thead>
+		    {% for row in results %}
+		    <tr>
+			<td><a href="{{ url_for('nhit_monitor_nearline', run=row['run']) }}">{{ row['run'] }}</a></td>
+			<td>{{ row['timestamp'].strftime("%Y-%m-%d %H:%M:%S") }}</td>
+                        <td>
+			{% if row['nhit_100_lo'] is not none %}
+			    {{ '%.2f' % row['nhit_100_lo'] }}
+			{% else %}
+			    > {{ row['max_nhit'] }}
+			{% endif %}
+                        </td>
+                        <td>
+			{% if row['nhit_100_med'] is not none %}
+			    {{ '%.2f' % row['nhit_100_med'] }}
+			{% else %}
+			    > {{ row['max_nhit'] }}
+			{% endif %}
+                        </td>
+                        <td>
+			{% if row['nhit_100_hi'] is not none %}
+			    {{ '%.2f' % row['nhit_100_hi'] }}
+			{% else %}
+			    > {{ row['max_nhit'] }}
+			{% endif %}
+                        </td>
+                        <td>
+			{% if row['nhit_20'] is not none %}
+			    {{ '%.2f' % row['nhit_20'] }}
+			{% else %}
+			    > {{ row['max_nhit'] }}
+			{% endif %}
+                        </td>
+                        <td>
+			{% if row['nhit_20_lb'] is not none %}
+			    {{ '%.2f' % row['nhit_20_lb'] }}
+			{% else %}
+			    > {{ row['max_nhit'] }}
+			{% endif %}
+                        </td>
+                        <td>
+			{% if row['nhit_100_lo_width'] is not none %}
+			    {{ '%.2f' % row['nhit_100_lo_width'] }}
+			{% else %}
+                            -
+			{% endif %}
+                        </td>
+                        <td>
+			{% if row['nhit_100_med_width'] is not none %}
+			    {{ '%.2f' % row['nhit_100_med_width'] }}
+			{% else %}
+                            -
+			{% endif %}
+                        </td>
+                        <td>
+			{% if row['nhit_100_hi_width'] is not none %}
+			    {{ '%.2f' % row['nhit_100_hi_width'] }}
+			{% else %}
+                            -
+			{% endif %}
+                        </td>
+                        <td>
+			{% if row['nhit_20_width'] is not none %}
+			    {{ '%.2f' % row['nhit_20_width'] }}
+			{% else %}
+                            -
+			{% endif %}
+                        </td>
+                        <td>
+			{% if row['nhit_20_lb_width'] is not none %}
+			    {{ '%.2f' % row['nhit_20_lb_width'] }}
+			{% else %}
+                            -
+			{% endif %}
+                        </td>
+		    </tr>
+		    {% endfor %}
+		</table>
+                <p class="text-right">
+                    {% if offset > 0 %}
+                    <a href="{{ url_for("nhit_monitor_thresholds_nearline", limit=limit, offset=offset-limit) }}">Back</a>
+                    {% endif %}
+                    <a href="{{ url_for("nhit_monitor_thresholds_nearline", limit=limit, offset=offset+limit) }}">Next</a>
+                </p>
+	    </div>
+	</div>
+	{% endif %}
+    </div>
+{% endblock %}
+{% block script %}
+    <script src="{{ url_for('static', filename='js/d3.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/moment.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/moment-timezone-with-data.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/metricsgraphics.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/mg_line_brushing.js') }}"></script>
+    <script>
+        var results = {{ results | tojson }};
+
+        var nhit_100_lo_threshold = new Array();
+        var nhit_100_med_threshold = new Array();
+        var nhit_100_hi_threshold = new Array();
+        var nhit_20_threshold = new Array();
+        var nhit_20_lb_threshold = new Array();
+
+        var nhit_100_lo_width = new Array();
+        var nhit_100_med_width = new Array();
+        var nhit_100_hi_width = new Array();
+        var nhit_20_width = new Array();
+        var nhit_20_lb_width = new Array();
+        for (var i=0; i < results.length; i++) {
+            //var date = moment(results[i]['timestamp']);
+            var date = new Date(results[i]['timestamp']);
+            nhit_100_lo_threshold.push({'date': date, 'value': results[i]['nhit_100_lo']});
+            nhit_100_med_threshold.push({'date': date, 'value': results[i]['nhit_100_med']});
+            nhit_100_hi_threshold.push({'date': date, 'value': results[i]['nhit_100_hi']});
+            nhit_20_lb_threshold.push({'date': date, 'value': results[i]['nhit_20_lb']});
+            nhit_20_threshold.push({'date': date, 'value': results[i]['nhit_20']});
+
+            nhit_100_lo_width.push({'date': date, 'value': results[i]['nhit_100_lo_width']});
+            nhit_100_med_width.push({'date': date, 'value': results[i]['nhit_100_med_width']});
+            nhit_100_hi_width.push({'date': date, 'value': results[i]['nhit_100_hi_width']});
+            nhit_20_lb_width.push({'date': date, 'value': results[i]['nhit_20_lb_width']});
+            nhit_20_width.push({'date': date, 'value': results[i]['nhit_20_width']});
+        }
+
+        MG.data_graphic({
+            title: "Trigger Thresholds",
+            description: "Trigger thresholds as a function of time",
+            data: [nhit_100_lo_threshold, nhit_100_med_threshold, nhit_100_hi_threshold, nhit_20_lb_threshold, nhit_20_threshold],
+            //chart_type: 'point',
+            width: $('#trigger-threshold').width(),
+            height: 250,
+            left: 100,
+            right: 100,
+            target: '#trigger-threshold',
+            x_accessor: 'date',
+            y_accessor: 'value',
+            x_label: 'Date',
+            y_label: 'Trigger threshold (nhit)',
+            legend: ['N100L', 'N100M', 'N100H', 'N20L', 'N20'],
+            interpolate: 'linear'
+        });
+
+        MG.data_graphic({
+            title: "Trigger Efficiency Width",
+            description: "Trigger efficiency width as a function of time",
+            data: [nhit_100_lo_width, nhit_100_med_width, nhit_100_hi_width, nhit_20_lb_width, nhit_20_width],
+            //chart_type: 'point',
+            width: $('#trigger-efficiency-width').width(),
+            height: 250,
+            left: 100,
+            right: 100,
+            target: '#trigger-efficiency-width',
+            x_accessor: 'date',
+            y_accessor: 'value',
+            x_label: 'Date',
+            y_label: 'Trigger efficiency width',
+            legend: ['N100L', 'N100M', 'N100H', 'N20L', 'N20'],
+            interpolate: 'linear'
+        });
+    </script>
+{% endblock %}

--- a/minard/templates/nhit_monitor_thresholds_nearline.html
+++ b/minard/templates/nhit_monitor_thresholds_nearline.html
@@ -33,6 +33,7 @@
 			    <th colspan="5">Width</th>
 			</tr>
 			<tr>
+                            <th>Key</th>
 			    <th>Run</th>
 			    <th>Timestamp</th>
 			    <th>100L</th>
@@ -49,7 +50,8 @@
 		    </thead>
 		    {% for row in results %}
 		    <tr>
-			<td><a href="{{ url_for('nhit_monitor_nearline', run=row['run']) }}">{{ row['run'] }}</a></td>
+			<td><a href="{{ url_for('nhit_monitor_nearline', key=row['key']) }}">{{ row['key'] }}</a></td>
+                        <td>{{ row['run'] }}</td>
 			<td>{{ row['timestamp'].strftime("%Y-%m-%d %H:%M:%S") }}</td>
                         <td>
 			{% if row['nhit_100_lo'] is not none %}

--- a/minard/views.py
+++ b/minard/views.py
@@ -523,6 +523,26 @@ def nhit_monitor(key):
 
     return render_template('nhit_monitor.html', results=results)
 
+@app.route('/nhit-monitor-thresholds-nearline')
+def nhit_monitor_thresholds_nearline():
+    limit = request.args.get("limit", 100, type=int)
+    offset = request.args.get("offset", 0, type=int)
+    results = detector_state.get_nhit_monitor_thresholds_nearline(limit, offset)
+
+    if results is None:
+	return render_template('nhit_monitor_thresholds_nearline.html', error="No nhit monitor records.")
+
+    return render_template('nhit_monitor_thresholds_nearline.html', results=results, limit=limit, offset=offset)
+
+@app.route('/nhit-monitor-nearline/<int:run>')
+def nhit_monitor_nearline(run):
+    results = detector_state.get_nhit_monitor_nearline(run)
+
+    if results is None:
+	return render_template('nhit_monitor_nearline.html', error="No nhit monitor record with key %i." % key)
+
+    return render_template('nhit_monitor_nearline.html', results=results)
+
 @app.route('/trigger')
 def trigger():
     results = detector_state.get_latest_trigger_scans()

--- a/minard/views.py
+++ b/minard/views.py
@@ -534,9 +534,9 @@ def nhit_monitor_thresholds_nearline():
 
     return render_template('nhit_monitor_thresholds_nearline.html', results=results, limit=limit, offset=offset)
 
-@app.route('/nhit-monitor-nearline/<int:run>')
-def nhit_monitor_nearline(run):
-    results = detector_state.get_nhit_monitor_nearline(run)
+@app.route('/nhit-monitor-nearline/<int:key>')
+def nhit_monitor_nearline(key):
+    results = detector_state.get_nhit_monitor_nearline(key)
 
     if results is None:
 	return render_template('nhit_monitor_nearline.html', error="No nhit monitor record with key %i." % key)


### PR DESCRIPTION
Use the nearline database for the nhit monitor page. You can go back to using the old page by removing the "nearline" in the url. 