### PR TITLE
New monitoring page for the gain of each crate using the QHS distributions

### DIFF
--- a/minard/gain_monitor.py
+++ b/minard/gain_monitor.py
@@ -1,0 +1,102 @@
+from .db import engine_nl
+from .detector_state import get_latest_run
+
+def crate_gain_monitor(limit, selected_run, run_range_low, run_range_high, gold):
+    """
+    Returns a list of runs and the QHS peak by crate for a given set of runs
+    """
+    conn = engine_nl.connect()
+
+    if not selected_run and not run_range_high:
+        latest_run = get_latest_run()
+        run = latest_run - limit
+        result = conn.execute("SELECT DISTINCT ON (run, crate) run, crate, qhs_peak, qhs_peak_error "
+                              "FROM gain_monitor WHERE run > %s ORDER BY run DESC", (run,))
+    elif run_range_high:
+        result = conn.execute("SELECT DISTINCT ON (run, crate) run, crate, qhs_peak, qhs_peak_error "
+                              "FROM gain_monitor WHERE run >= %s AND run <=%s ORDER BY run DESC", \
+                              (run_range_low, run_range_high))
+    else:
+        result = conn.execute("SELECT DISTINCT ON (run, crate) run, crate, qhs_peak, qhs_peak_error "
+                              "FROM gain_monitor WHERE run = %s", (selected_run,))
+
+    rows = result.fetchall()
+
+    runs = []
+    qhs_array = {}
+    for run, crate, qhs_peak, qhs_peak_error in rows:
+        if gold != 0 and run not in gold:
+            continue
+        if run not in runs:
+            runs.append(run)
+        qhs_peak = round(qhs_peak, 1)
+        qhs_peak_error = round(qhs_peak_error, 1)
+        qhs_array[(run, crate)] = [qhs_peak, qhs_peak_error]
+
+    return runs, qhs_array
+
+def crate_average(selected_run, run_limit):
+    """
+    Checks the gain of each crate based on the average.
+    Returns a map of [run, crate] for runs where the crate
+    QHS peak falls outside the average QHS peak
+    calculated over run_limit runs.
+    """
+    conn = engine_nl.connect()
+
+    SIGMA = 3
+    run = selected_run - run_limit
+    result = conn.execute("SELECT DISTINCT ON (run, crate) "
+                          "run, crate, qhs_peak, qhs_peak_error FROM gain_monitor "
+                          "WHERE run >= %s ORDER BY run DESC LIMIT 19*100", (run,))
+
+    rows = result.fetchall()
+
+    runs = []
+    qhs_sum = [0]*19
+    qhs_error_sum = [0]*19
+    count = [0]*19
+    qhs_run = {}
+
+    for run, crate, qhs_peak, qhs_peak_error in rows:
+        if run not in runs:
+            runs.append(run)
+        qhs_run[(run, crate)] = qhs_peak
+        qhs_sum[crate] += qhs_peak
+        qhs_error_sum[crate] += qhs_peak_error
+        count[crate] += 1
+
+    qhs_change = {}    
+
+    for run in runs:
+        for crate in range(19):
+            qhs_average = qhs_sum[crate]/count[crate]
+            qhs_average_error = qhs_error_sum[crate]/count[crate]
+            qhs_diff = abs(qhs_run[(run, crate)] - qhs_average)
+            if qhs_diff > SIGMA*qhs_average_error:
+                qhs_change[(run, crate)] = 1
+
+    return qhs_change
+
+def crate_gain_history(run_range_low, run_range_high, crate):
+    """
+    Return a list of [run, qhs peak] for a specific crate
+    and run range
+    """
+
+    conn = engine_nl.connect()
+
+    result = conn.execute("SELECT DISTINCT ON (run, crate) "
+                          "run, qhs_peak FROM gain_monitor "
+                          "WHERE run >= %s AND run <= %s AND "
+                          "crate = %s ORDER BY run DESC ", \
+                          (run_range_low, run_range_high, crate))
+
+    rows = result.fetchall()
+
+    data = []
+    for run, qhs_peak in rows:
+        data.append([int(run), qhs_peak])
+ 
+    return data
+

--- a/minard/gain_monitor.py
+++ b/minard/gain_monitor.py
@@ -83,7 +83,6 @@ def crate_gain_history(run_range_low, run_range_high, crate):
     Return a list of [run, qhs peak] for a specific crate
     and run range
     """
-
     conn = engine_nl.connect()
 
     result = conn.execute("SELECT DISTINCT ON (run, crate) "

--- a/minard/nearline_monitor.py
+++ b/minard/nearline_monitor.py
@@ -113,7 +113,7 @@ def clock_jumps_run(run):
     # This should be the best way to check if the job ran for the given run
     try:
         result.fetchone()[0]
-    except KeyError:
+    except Exception:
         clock_jumps_status[run] = -1
         return clock_jumps_status
 
@@ -166,7 +166,7 @@ def channel_flags_run(run):
     # This should be the best way to check if the job ran for the given run
     try:
         result.fetchone()[0]
-    except KeyError:
+    except Exception:
         channel_flags_status[run] = -1
         return channel_flags_status
 
@@ -227,7 +227,7 @@ def ping_crates_run(run):
             ping_crates_status[run] = 1
         elif row == 2:
             ping_crates_status[run] = 2
-    except KeyError:
+    except Exception:
         ping_crates_status[run] = -1
 
     return ping_crates_status

--- a/minard/occupancy.py
+++ b/minard/occupancy.py
@@ -7,10 +7,10 @@ def occupancy_by_trigger_limit(limit, selected_run, run_range_low, run_range_hig
     """
     conn = engine_nl.connect()
 
-    latest_run = get_latest_run()
 
     try:
         if not selected_run and not run_range_high:
+            latest_run = get_latest_run()
             result = conn.execute("SELECT DISTINCT ON (run, crate, slot) "
                                   "run, status, crate, slot "
                                   "FROM esumh_occupancy_fail WHERE run > %s "

--- a/minard/pingcratesdb.py
+++ b/minard/pingcratesdb.py
@@ -112,20 +112,18 @@ def crates_failed_messages(run):
 
 def ping_crates_list(limit, selected_run, run_range_low, run_range_high, gold):
     '''
-    Returns a list of ping crates information for runs larger
-    than the current run - limit
+    Returns a list of ping crates information
     '''
-
-    run = get_latest_run()
-
     conn = engine_nl.connect()
 
     if not selected_run and not run_range_high:
         # Get all ping crates information from the nearline database since (run - limit)
+        latest_run = get_latest_run()
+        run = latest_run - limit
         result = conn.execute("SELECT DISTINCT ON (run) timestamp, run,  n100_crates_failed, "
                               "n20_crates_failed, n100_crates_warned, n20_crates_warned, "
                               "status FROM ping_crates WHERE run > %s "
-                              "ORDER BY run, timestamp DESC", (run-limit))
+                              "ORDER BY run, timestamp DESC", (run,))
     elif run_range_high:
         # Get all ping crates information from the nearline database over run range
         result = conn.execute("SELECT DISTINCT ON (run) timestamp, run,  n100_crates_failed, "
@@ -137,7 +135,7 @@ def ping_crates_list(limit, selected_run, run_range_low, run_range_high, gold):
         result = conn.execute("SELECT DISTINCT ON (run) timestamp, run,  n100_crates_failed, "
                               "n20_crates_failed, n100_crates_warned, n20_crates_warned, "
                               "status FROM ping_crates WHERE run = %s "
-                              "ORDER BY run, timestamp DESC", selected_run)
+                              "ORDER BY run, timestamp DESC", (selected_run,))
 
 
     ping_info = []

--- a/minard/static/js/scatter_plot_gains.js
+++ b/minard/static/js/scatter_plot_gains.js
@@ -1,0 +1,142 @@
+si_format = d3.format('.3s');
+
+function my_si_format(d) {
+    if (!$.isNumeric(d))
+        return '-';
+    else
+        return si_format(d);
+}
+
+
+function history() {
+    var params = {}
+    params['crate'] = document.getElementById("crate-sel").value;
+    params['starting_run'] = document.getElementById("starting_run").value;
+    params['ending_run'] = document.getElementById("ending_run").value;
+    window.location.replace($SCRIPT_ROOT + "/crate_gain_history?" + $.param(params));
+}
+
+function draw_scatter_plot_gains(){
+    var data = window.data;
+    var start = document.getElementById("starting_run").value;
+    var end = document.getElementById("ending_run").value;
+    if( data != undefined && data != "" ){
+
+        var margin = {top: 10, right: 80, bottom: 80, left: 120}
+            ,width = $("#main").width() - margin.left - margin.right
+            ,height = 400;
+
+        // Xrange starts when the we started storing cmos data
+        var x = d3.scale.linear()
+            .domain([start, end])
+            .range([ 0, width ]);
+
+        var ymin = d3.max([0, d3.min(data, function(d) { return d[1]; })]);
+        var ypad = ymin*0.1;
+        var ymax = d3.max(data, function(d) { return d[1]; });
+        var yppad = ymax*0.1;
+
+        var y = d3.scale.linear()
+                 .domain([ymin-ypad, ymax+ypad])
+                 .range([height, 0]);
+
+        var chart = d3.select('#main')
+            .append('svg:svg')
+            .attr('width', width + margin.right + margin.left)
+            .attr('height', height + margin.top + margin.bottom)
+            .attr('class', 'chart');
+
+        var valueline = d3.svg.line()
+            .x(function(d) { return x(d[0]); })
+            .y(function(d) { return y(d[1]); });
+
+        var main = chart.append('g')
+            .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')')
+            .attr('width', width)
+            .attr('height', height)
+            .attr('class', 'main');
+
+        var div = d3.select("body").append("div")
+            .attr("class", "tooltip")
+            .style("opacity", 0);
+
+        // draw the x axis
+        var xAxis = d3.svg.axis()
+            .scale(x)
+            .orient('bottom')
+            .tickSize(6)
+            .ticks(6);
+
+        main.append('g')
+            .attr('transform', 'translate(0,' + height + ')')
+            .attr('class', 'main axis date')
+            .call(xAxis)
+            .selectAll("text")
+              .attr("x", 6)
+              .attr("dy", "1.2em");
+
+        // draw the y axis
+        var yAxis = d3.svg.axis()
+            .scale(y)
+            .orient('left')
+            .tickSize(6)
+            .ticks(8, "s");
+
+        main.append('g')
+            .attr('transform', 'translate(0,0)')
+            .attr('class', 'main axis')
+            .call(yAxis);
+
+        d3.selectAll(".tick > text")
+            .style("font-size", "18px");
+
+        var g = main.append("svg:g");
+
+        g.append("path")
+            .data([data])
+            .attr("class", "line")
+            .attr("d", valueline);
+
+        g.selectAll("scatter-dots")
+            .data(data)
+            .enter().append("svg:circle")
+                .attr("cx", function (d,i) { return x(d[0]); } )
+                .attr("cy", function (d) { return y(d[1]); } )
+                .attr("r", 8)
+                .on("mouseover", function(d) {      
+                    div.transition()        
+                        .duration(200) 
+                        .style("opacity", .9);      
+                    div .html("(" + (d[0]) + ","  + my_si_format(d[1]) + ")")  
+                        .style("left", (d3.event.pageX) + "px")
+                        .style("top", (d3.event.pageY - 28) + "px");
+                    })                  
+                .on("mouseout", function(d) {
+                    div.transition()
+                        .duration(500)
+                        .style("opacity", 0);   
+                });
+
+        chart.append("g")
+            .attr("class", "x axis")
+            .attr("transform", "translate(0," + height + ")")
+        .append("text")
+            .attr("class", "label")
+            .attr("x", width )
+            .attr("y", 80)
+            .style("text-anchor", "end")
+            .text("Run Number")
+            .style("font-size", "22px");
+
+        chart.append("g")
+            .attr("class", "y axis")
+          .append("text")
+            .attr("class", "label")
+            .attr("transform", "rotate(-90)")
+            .attr("dy", "2.0em")
+            .style("text-anchor", "end")
+            .text("QHS Peak (ADC Counts)")
+            .style("font-size", "22px");
+    }
+}
+

--- a/minard/templates/crate_gain_history.html
+++ b/minard/templates/crate_gain_history.html
@@ -1,0 +1,104 @@
+{% extends "layout.html" %}
+{% block title %}Crate Gain{% endblock %}
+{% block head %}
+<style>
+.chart {
+
+}
+.axis line, .axis path {
+    shape-rendering: crispEdges;
+    stroke: black;
+    fill: none;
+}
+.line {
+  fill: none;
+  stroke: steelblue;
+  stroke-width: 8px;
+}
+circle {
+    fill: steelblue;
+}
+h4 {
+    display: inline;
+}
+div.tooltip {   
+  position: absolute;           
+  text-align: center;           
+  width: 100px;                  
+  height: 24px;                 
+  padding: 2px;             
+  font: 12px sans-serif;        
+  background: lightsteelblue;   
+  border: 0px;      
+  border-radius: 8px;           
+  pointer-events: none;         
+}
+</style>
+<script>
+    (function () {
+        window.data = {{ data|safe }}; 
+    }());
+</script>
+    {{ super() }}
+{% endblock %}
+{% block body %}
+    {{ super() }}
+<div class="container">
+    <div class="row">
+        <div class="col-md-12">
+            <h4> Crate </h4>
+            <select id="crate-sel">
+                <option value="0">0</option>
+                <option value="1">1</option>
+                <option value="2">2</option>
+                <option value="3">3</option>
+                <option value="4">4</option>
+                <option value="5">5</option>
+                <option value="6">6</option>
+                <option value="7">7</option>
+                <option value="8">8</option>
+                <option value="9">9</option>
+                <option value="10">10</option>
+                <option value="11">11</option>
+                <option value="12">12</option>
+                <option value="13">13</option>
+                <option value="14">14</option>
+                <option value="15">15</option>
+                <option value="16">16</option>
+                <option value="17">17</option>
+                <option value="18">18</option>
+            </select>
+            <h4> Run range: </h4>
+            <input type="text" id="starting_run" value={{starting_run}} style="width:80px;">
+            <h4> - </h4>
+            <input type="text" id="ending_run" value={{ending_run}} style="width:80px;">
+            <button type=button onclick="history();">Update Plot</button>
+        </div>
+    </div>
+    <h1> </h1>
+    <div class="row">
+        <div class="col-md-12" id="main">
+            {% if not data %}
+                <h2 align="left"> No data available </h2>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}
+{% block script %}
+    <script src="{{ url_for('static', filename='js/d3.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/scatter_plot_gains.js') }}"></script>
+    <script>
+        if (url_params.crate) {
+            document.getElementById("crate-sel").value = url_params.crate;
+        }
+        if (url_params.starting_run) {
+            document.getElementById("starting_run").value = url_params.starting_run;
+        }
+        if (url_params.ending_run) {
+            document.getElementById("ending_run").value = url_params.ending_run;
+        }
+
+        draw_scatter_plot_gains();
+    </script>
+{% endblock %}

--- a/minard/templates/crate_gain_monitor.html
+++ b/minard/templates/crate_gain_monitor.html
@@ -1,0 +1,125 @@
+{% extends "layout.html" %}
+{% block title %}Crate Gain Monitor{% endblock %}
+{% block head %}
+  {{ super() }}
+  <style>
+    .btn1 {
+        background-color: #FFD700;
+        padding: 6px 6px;
+        text-align: center;
+        font-size: 14px;
+        margin: 4px 2px;
+        cursor: pointer;
+    }
+    .btn2 {
+        background-color: #228B22;
+        padding: 6px 6px;
+        color: white;
+        text-align: center;
+        font-size: 14px;
+        margin: 4px 2px;
+        cursor: pointer;
+    }
+  </style>
+{% endblock %}
+{% block body %}
+  {{ super() }}
+
+<div class="container">
+  <h2 align="left">Information For the User</h2>
+    <table class="table table-hover">
+      <tr> <th> Monitor of the PMT gains by crate. The PMT QHS distribtions are created for events with greater than 15 NHit and don't trigger ESUMH (to skip flashers and shark fins). Only hits that pass the PMTCal selector are included in the distributions. The QHS distributions are separated by crate and the peak is fit with a Gaussian. The mean of that fit is taken as the peak of the distribution and is displayed below for each run and crate. The QHS histograms for each crate are available by clicking on the associated run number. <th> <tr>
+      <tr class="success"> <th> The peak of the QHS distribution falls within 15 - 30 ADC Counts. Note the uncertainties for an hour long physics run are typically around 0.5 ADC counts. </th> </tr>
+      <tr class="danger"> <th> The peak of the QHS distribution falls outside 15 - 30 ADC Counts. </th> </tr>
+      <tr bgcolor="#FFFF66"> <th> The peak of the QHS distribution falls 3 sigma outside the mean of the QHS distributions from the last 100 runs. </th>
+  </table>
+</div>
+
+<div class="page-header">
+  <h1 align="center">Crate Gain Monitor</h1>
+</div>
+
+<div class="container">
+  <div class="col-md-12">
+    <table class="table table-hover">
+      <tr>
+        <th> Limit: </th>
+        <th> Select Run: </th>
+        <th> Run Range: </th>
+        <th> </th>
+      </tr>
+      <tr>
+        <th> <select id="limit" onchange="get_limit(this.value, 0, 0, 0, {{gold}});">
+               {% if selected_run != 0 or run_range_high != 0 %}
+                 <option selected value="-">-</option>
+               {% else %}
+                 <option selected value="{{limit}}">{{limit}}</option>
+               {% endif %}
+               {% for n in [10, 25, 50, 100, 500] %}
+                 {% if n != limit %}
+                   <option value="{{n}}">{{n}}</option>
+                 {% endif %}
+               {% endfor %}
+             </select> </th>
+
+        <th> <input style="margin-bottom: 30px; width: 80px;" type="text" id="run" value={{selected_run}} onKeyDown="if(event.keyCode==13) get_limit(0, this.value, 0, 0, {{gold}});"></input> </th>
+        <th> <input style="margin-bottom: 30px; width: 80px;" type="text" id="low" value={{run_range_low}} onKeyDown="if(event.keyCode==13) get_limit(0, 0, this.value, high.value, {{gold}});"></input>
+             - <input style="margin-bottom: 30px; width: 80px;" type="text" id="high" value={{run_range_high}} onKeyDown="if(event.keyCode==13) get_limit(0, 0, low.value, this.value, {{gold}});"></input> </th>
+        {% if not gold %}
+          <th> <button type="submit" class="btn1" onclick="get_limit(limit.value, run.value, low.value, high.value, 1)">Show Only Gold Runs</button> </th>
+        {% else %}
+          <th> <button type="submit" class="btn2" onclick="get_limit(limit.value, run.value, low.value, high.value, 0)">Show All Runs</button> </th>
+        {% endif %}
+      </tr>
+    </table>
+
+    <table class="table table-hover">
+      <thead>
+        <tr> 
+          <th> Run </th>
+        </tr>
+      </thead>
+      {% if runs %}
+        {% for run in runs %}
+          <tr>
+            <th> <a href="{{url_for('crate_gain_monitor_by_run',run_number=run)}}">{{run}}</a> </th>
+            <th> Crates: </th>
+            {% for crate in range(19) %}
+              <th> <a href="{{ url_for("crate_gain_history", crate=crate, starting_run=(run-100), ending_run=run) }}">{{crate}}</a></th>
+            {% endfor %}
+          </tr>
+          <tr>
+            <th> </th>
+            <th> QHS Peak </th>
+            {% for crate in range(19) %}
+              {% if crate_qhs[(run,crate)][0] < 15 or crate_qhs[(run,crate)][0] > 30 %}
+                <th class="danger"> {{ crate_qhs[(run,crate)][0] }} </th>
+              {% elif qhs_change[(run, crate)] == 1 %}
+                <th bgcolor="#FFFF66"> {{ crate_qhs[(run,crate)][0] }} </th>
+              {% else %} 
+                <th class="success"> {{ crate_qhs[(run,crate)][0] }} </th>
+              {% endif %}
+            {% endfor %}
+          </tr>
+        {% endfor %}
+      {% else %}
+        <th> No data found </th>
+      {% endif %}
+    </table>
+  </div>
+</div>
+{% endblock %}
+{% block script %}
+  <script>
+    function get_limit(limit, run, low, high, gold){
+      params = {};
+      params["limit"] = limit;
+      params["run"] = run;
+      params["run_range_low"] = low;
+      params["run_range_high"] = high;
+      params["gold_runs"] = gold;
+      window.location.replace($SCRIPT_ROOT + "/crate_gain_monitor?" + $.param(params));
+    }
+  </script>
+{% endblock %}
+

--- a/minard/templates/crate_gain_monitor.html
+++ b/minard/templates/crate_gain_monitor.html
@@ -31,7 +31,7 @@
       <tr> <th> Monitor of the PMT gains by crate. The PMT QHS distribtions are created for events with greater than 15 NHit and don't trigger ESUMH (to skip flashers and shark fins). Only hits that pass the PMTCal selector are included in the distributions. The QHS distributions are separated by crate and the peak is fit with a Gaussian. The mean of that fit is taken as the peak of the distribution and is displayed below for each run and crate. The QHS histograms for each crate are available by clicking on the associated run number. <th> <tr>
       <tr class="success"> <th> The peak of the QHS distribution falls within 15 - 30 ADC Counts. Note the uncertainties for an hour long physics run are typically around 0.5 ADC counts. </th> </tr>
       <tr class="danger"> <th> The peak of the QHS distribution falls outside 15 - 30 ADC Counts. </th> </tr>
-      <tr bgcolor="#FFFF66"> <th> The peak of the QHS distribution falls 3 sigma outside the mean of the QHS distributions from the last 100 runs. </th>
+      <tr class="warning"> <th> The peak of the QHS distribution falls 3 sigma outside the mean of the QHS distributions from the last 100 runs. </th>
   </table>
 </div>
 
@@ -95,7 +95,7 @@
               {% if crate_qhs[(run,crate)][0] < 15 or crate_qhs[(run,crate)][0] > 30 %}
                 <th class="danger"> {{ crate_qhs[(run,crate)][0] }} </th>
               {% elif qhs_change[(run, crate)] == 1 %}
-                <th bgcolor="#FFFF66"> {{ crate_qhs[(run,crate)][0] }} </th>
+                <th class="warning"> {{ crate_qhs[(run,crate)][0] }} </th>
               {% else %} 
                 <th class="success"> {{ crate_qhs[(run,crate)][0] }} </th>
               {% endif %}

--- a/minard/templates/crate_gain_monitor_by_run.html
+++ b/minard/templates/crate_gain_monitor_by_run.html
@@ -11,8 +11,8 @@
 
   <div class="row">
     {% for crate in range(19) %}
-      <img src="../../static/monitoring/run{{run_number}}/crate{{crate}}.png"
-        alt="Crate {{crate}} QHS" class="img-responsive col-md-6"></img>
+      <img src="{{ url_for('static', filename='gain_monitor/run'+run_number+'/crate'+run_number+'.png') }}"
+           alt="Crate {{crate}} QHS" class="img-responsive col-md-6"></img>
     {% endfor %}
   </div>
 </div>

--- a/minard/templates/crate_gain_monitor_by_run.html
+++ b/minard/templates/crate_gain_monitor_by_run.html
@@ -1,0 +1,20 @@
+{% extends "layout.html" %}
+{% block title %} Crate Gain Monitor by Run {% endblock %}
+{% block head %}
+  {{ super() }}
+{% endblock %}
+{% block body %}
+  {{ super() }}
+
+<div class="container">
+  <h1 align="center">Run {{run_number}}</h1>
+
+  <div class="row">
+    {% for crate in range(19) %}
+      <img src="../../static/monitoring/run{{run_number}}/crate{{crate}}.png"
+        alt="Crate {{crate}} QHS" class="img-responsive col-md-6"></img>
+    {% endfor %}
+  </div>
+</div>
+
+{% endblock %}

--- a/minard/templates/layout.html
+++ b/minard/templates/layout.html
@@ -79,6 +79,7 @@
                                 {{ nav_link('nearline_failures', 'Nearline Failures') }}
                                 {{ nav_link('nearline_monitoring_summary', 'Nearline Monitoring') }}
                                 {{ nav_link('pingcrates', 'Ping Crates') }}  
+                                {{ nav_link('crate_gain_monitor', 'PMT Gains by Crate') }}
                                 {{ nav_link('occupancy_by_trigger', 'Occupancy by Trigger') }}
                                 {{ nav_link('channelflags', 'Channel Flags') }}  
                                 {{ nav_link('trigger_clock_jump', 'Trigger Clock Jumps') }}

--- a/minard/templates/nearline_monitoring_summary.html
+++ b/minard/templates/nearline_monitoring_summary.html
@@ -47,11 +47,12 @@ tr:nth-child(even) {
 <div class="container">
   <div class="col-md-12">
     <table class="table table-bordered">
-      <tr> <th> Ping crates checks whether the N100/N20 trigger signals are working properly for each crate. </th> </tr>
+      <tr> <th> Ping crates checks whether the N100/N20 trigger signals are working properly for each crate. Runs only on physics runs. </th> </tr>
       <tr> <th> The clock jump check counts the number of bad clock ticks on the 10 and 50MHz clocks. </tr>
       <tr> <th> The channel flags check finds out-of-sync channels or channels dropping data.  </th> </tr>
-      <tr> <th> The occupancy check finds offline slots or crates missing ESUMH trigger signals. </th> </tr>
+      <tr> <th> The occupancy check finds offline slots or crates missing ESUMH trigger signals. Runs only on physics runs longer than 30 minutes.</th> </tr>
       <tr> <th> The muon check determines if a reasonable number of muons were flagged in the run. </th> </tr>
+      <tr> <th> The crate gain check monitors the gains of the PMTs for each crate. Runs only on physics or calibration runs longer than 10 minutes. </th> </tr>
     </table>
   </div>
   <div class="col-md-12">
@@ -105,7 +106,8 @@ tr:nth-child(even) {
           <th> <a href="{{url_for('trigger_clock_jump')}}">Clock Jumps</a> </th>
           <th> <a href="{{url_for('channelflags')}}">Channel Flags</a> </th>
           <th> <a href="{{url_for('occupancy_by_trigger')}}">Occupancy</a> </th>
-          <th> <a href="{{url_for('muon_list')}}">Muons</a></th>
+          <th> <a href="{{url_for('muon_list')}}">Muons</a> </th>
+          <th> <a href="{{url_for('crate_gain_monitor')}}">Crate Gain</a> </th>
         </tr>
       </thead>
       {% for run in runs %}
@@ -155,7 +157,15 @@ tr:nth-child(even) {
           {% elif muons[run] == 0 %}
             <th class="success"><a href="{{ url_for("muons_by_run", run_number=run) }}">Pass</a></th>
           {% else %}
-            <th class="info">Not Run</th> 
+            <th class="info">Not Run</th>
+          {% endif %}
+
+          {% if crate_gain[run] == 1 %}
+            <th class="danger"><a href="{{ url_for("crate_gain_monitor_by_run", run_number=run) }}">Fail</a></th>
+          {% elif crate_gain[run] == 0 %}
+            <th class="success"><a href="{{ url_for("crate_gain_monitor_by_run", run_number=run) }}">Pass</a></th>
+          {% else %}
+            <th class="info">Not Run</th>
           {% endif %}
         <tr>
       {% endfor %}

--- a/minard/views.py
+++ b/minard/views.py
@@ -1296,7 +1296,7 @@ def nearline_monitoring_summary():
     runTypes, runs = nearline_monitor.get_run_types(limit, selected_run, run_range_low, run_range_high, gold_runs)
 
     # Get the data for each of the nearline tools
-    clock_jumps, ping_crates, channel_flags, occupancy, muons = \
+    clock_jumps, ping_crates, channel_flags, occupancy, muons, crate_gain = \
         nearline_monitor.get_run_list(limit, selected_run, run_range_low, run_range_high, runs, gold_runs)
 
     # Allow sorting by run type
@@ -1323,7 +1323,7 @@ def nearline_monitoring_summary():
             if run in run_list:
                 displayed_runs.append(run)
 
-    return render_template('nearline_monitoring_summary.html', runs=displayed_runs, selected_run=selected_run, limit=limit, clock_jumps=clock_jumps, ping_crates=ping_crates, channel_flags=channel_flags, occupancy=occupancy, muons=muons, runTypes=runTypes, run_range_low=run_range_low, run_range_high=run_range_high, allrunTypes=allrunTypes, selectedType=selectedType, gold=gold)
+    return render_template('nearline_monitoring_summary.html', runs=displayed_runs, selected_run=selected_run, limit=limit, clock_jumps=clock_jumps, ping_crates=ping_crates, channel_flags=channel_flags, occupancy=occupancy, muons=muons, crate_gain=crate_gain, runTypes=runTypes, run_range_low=run_range_low, run_range_high=run_range_high, allrunTypes=allrunTypes, selectedType=selectedType, gold=gold)
 
 @app.route('/physicsdq')
 def physicsdq():

--- a/minard/views.py
+++ b/minard/views.py
@@ -32,6 +32,7 @@ import occupancy
 import channelflagsdb
 import dropout
 import pmtnoisedb
+import gain_monitor
 from run_list import golden_run_list
 from .polling import polling_runs, polling_info, polling_info_card, polling_check, polling_history, polling_summary
 from .channeldb import ChannelStatusForm, upload_channel_status, get_channels, get_channel_status, get_channel_status_form, get_channel_history, get_pmt_info, get_nominal_settings, get_most_recent_polling_info, get_discriminator_threshold, get_all_thresholds, get_maxed_thresholds, get_gtvalid_lengths, get_pmt_types, pmt_type_description, get_fec_db_history
@@ -1440,7 +1441,55 @@ def trigger_clock_jump():
 def trigger_clock_jump_run(run_number):
     data10, data50 = triggerclockjumpsdb.get_clock_jumps_by_run(run_number)
     return render_template('trigger_clock_jump_run.html', run_number=run_number, data10=data10, data50=data50)
- 
+
+@app.route('/crate_gain_monitor')
+def crate_gain_monitor():
+    limit = request.args.get("limit", 25, type=int)
+    selected_run = request.args.get("run", 0, type=int)
+    run_range_low = request.args.get("run_range_low", 0, type=int)
+    run_range_high = request.args.get("run_range_high", 0, type=int)
+    gold = request.args.get("gold_runs", 0, type=int)
+
+    gold_runs = 0
+    if gold:
+        gold_runs = golden_run_list()
+
+    runs, crate_qhs = gain_monitor.crate_gain_monitor(limit, selected_run, run_range_low, run_range_high, gold_runs)
+
+    lower_limit = 100
+    if selected_run:
+        run = selected_run
+    elif run_range_high:
+        run = run_range_high
+        if(run_range_low < run_range_high - lower_limit):
+            lower_limit = run_range_low
+    else:
+        run = detector_state.get_latest_run()
+
+    qhs_change = gain_monitor.crate_average(run, lower_limit)
+
+    return render_template('crate_gain_monitor.html', runs=runs, limit=limit, selected_run=selected_run, run_range_low=run_range_low, run_range_high=run_range_high, gold=gold, crate_qhs=crate_qhs, qhs_change=qhs_change)
+
+@app.route('/crate_gain_monitor_by_run/<run_number>')
+def crate_gain_monitor_by_run(run_number):
+    return render_template('crate_gain_monitor_by_run.html', run_number=run_number)
+
+@app.route('/crate_gain_history')
+def crate_gain_history():
+    crate = request.args.get('crate',0,type=int)
+    starting_run = request.args.get('starting_run',0,type=int)
+    ending_run = request.args.get('ending_run',0,type=int)
+
+    # Default to hard-coded first processed run
+    if starting_run == 0:
+        starting_run = 112621
+    # Default to current run
+    if ending_run == 0:
+        ending_run = detector_state.get_latest_run()
+
+    data = gain_monitor.crate_gain_history(starting_run, ending_run, crate)
+    return render_template('crate_gain_history.html', crate=crate, data=data, starting_run=starting_run, ending_run=ending_run)
+
 @app.route('/physicsdq/<run_number>')
 def physicsdq_run_number(run_number):
     ratdb_dict = HLDQTools.import_HLDQ_ratdb(int(run_number))


### PR DESCRIPTION
- Main page is available from nearline tab or from the nearline monitoring over view page. This shows the peak of the QHS distribution for each run/crate. 
- Clicking the run number takes you to the QHS histograms for each crate with the fit showing how the peak of the distribution was extracted.
- Clicking the crate number takes you to a scatter plot showing the QHS peaks vs. run number. 