### PR TITLE
Add a check that the event times of the

### DIFF
--- a/minard/muonsdb.py
+++ b/minard/muonsdb.py
@@ -28,7 +28,8 @@ def get_muons(limit, selected_run, run_range_low, run_range_high, gold, atm):
                                   "missed_muons AS c ON a.run=c.run WHERE array_length(a.gtids, 1) > 0 "
                                   "AND a.run >= %s ORDER BY a.run DESC", (run_range,))
         status = conn.execute("SELECT run, muon_time_in_range, missed_muon_time_in_range, "
-                              "atmospheric_time_in_range FROM time_check WHERE run >= %s", (run_range,)) 
+                              "atmospheric_time_in_range FROM time_check WHERE run >= %s "
+                              "ORDER BY run DESC", (run_range,)) 
     elif run_range_high:
         if not atm:
             result = conn.execute("SELECT DISTINCT ON (a.run) a.run, a.gtids, a.days, a.secs, a.nsecs, "
@@ -44,8 +45,8 @@ def get_muons(limit, selected_run, run_range_low, run_range_high, gold, atm):
                                   "AND a.run >= %s AND a.run <= %s ORDER BY a.run DESC", \
                                   (run_range_low, run_range_high))
         status = conn.execute("SELECT run, muon_time_in_range, missed_muon_time_in_range, "
-                              "atmospheric_time_in_range FROM time_check WHERE run >= %s AND run <= %s", \
-                              (run_range_low, run_range_high)) 
+                              "atmospheric_time_in_range FROM time_check WHERE run >= %s AND "
+                              "run <= %s ORDER BY run DESC", (run_range_low, run_range_high)) 
     else:
         result = conn.execute("SELECT DISTINCT ON (a.run) a.run, a.gtids, a.days, a.secs, a.nsecs, "
                               "array_length(b.gtids, 1), c.gtids FROM muons AS a LEFT JOIN missed_muons "

--- a/minard/templates/muon_list.html
+++ b/minard/templates/muon_list.html
@@ -97,10 +97,11 @@
           <th> Number of Atmospherics </th>
           <th> Number of Missed Muons </th>
           <th> Livetime lost to Muons (s) </th>
+          <th> Event Times OK </th>
         </tr>
       {% if mruns %}
         {% for mrun in mruns %}
-          {% if mcount[mrun] > 20 or mmcount[mrun] > 1000 %}
+          {% if mcount[mrun] > 20 or mmcount[mrun] > 1000 or time_check[mrun] == False %}
             <tr class="danger">
           {% else %}
             <tr class="success">
@@ -115,6 +116,7 @@
             <th> {{atmcount[mrun]}} </th>
             <th> {{mmcount[mrun]}} </th>
             <th> {{livetime[mrun]}} </th>
+            <th> {{time_check[mrun]}} </th>
           </tr>
         {% endfor %}
       {% else %}

--- a/minard/templates/muons_by_run.html
+++ b/minard/templates/muons_by_run.html
@@ -33,7 +33,7 @@ tr:nth-child(even) {
     <thead>
       <tr>
         <th> GTIDs </th>
-        <th> Time (UTC) </th>
+        <th> Time (EST) </th>
       </tr>
     </thead>
     {% if muon_info %}
@@ -59,7 +59,7 @@ tr:nth-child(even) {
     <thead>
       <tr>
         <th> GTIDs </th>
-        <th> Time (UTC) </th>
+        <th> Time (EST) </th>
         <th> # of Followers </th>
       </tr>
     </thead>
@@ -84,7 +84,7 @@ tr:nth-child(even) {
     <thead>
       <tr>
         <th> GTID </th>
-        <th> Time (UTC) </th>
+        <th> Time (EST) </th>
       </tr>
     </thead>
     {% if mmuon_info %}

--- a/minard/views.py
+++ b/minard/views.py
@@ -1470,9 +1470,9 @@ def muon_list():
     if gold:
         gold_runs = golden_run_list()
 
-    mruns, mcount, mmcount, atmcount, livetime, mfake = muonsdb.get_muons(limit, selected_run, run_range_low, run_range_high, gold_runs, atm)
+    mruns, mcount, mmcount, atmcount, livetime, mfake, time_check = muonsdb.get_muons(limit, selected_run, run_range_low, run_range_high, gold_runs, atm)
 
-    return render_template('muon_list.html', mruns=mruns, limit=limit, selected_run=selected_run, run_range_low=run_range_low, run_range_high=run_range_high, gold=gold, mcount=mcount, mmcount=mmcount, mfake=mfake, atmcount=atmcount, livetime=livetime, atm=atm)
+    return render_template('muon_list.html', mruns=mruns, limit=limit, selected_run=selected_run, run_range_low=run_range_low, run_range_high=run_range_high, gold=gold, mcount=mcount, mmcount=mmcount, mfake=mfake, atmcount=atmcount, livetime=livetime, atm=atm, time_check=time_check)
 
 @app.route('/muons_by_run/<run_number>')
 def muons_by_run(run_number):


### PR DESCRIPTION
muons, atmospherics, and missed muons come within the time
range defined by the stop and start times of the run tables.
This is calculated on the nearline and the time_check table
is filled with that information. This also changes the event
times to be displayed in local time (EST) for direct comparison
to the runs page.

This is in response to several old runs having issues with the
times of the muons being outside the run range, probably due
to some issue with the clock reconstruction. This will allow
run-selection to immediately pick up on such an issue.