### PR TITLE
initialize gt crate mask in detector state check

### DIFF
--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -256,6 +256,8 @@ def get_detector_state_check(run=0):
     channels = []
     messages = []
 
+    gt_crate_mask = None
+
     if mtc_key is None:
         messages.append("mtc state unknown")
     else:


### PR DESCRIPTION
GT crate mask is used in line 366, which crashes if MTC state is unknown. See run 201233.