### PR TITLE
update message for the crate gain page

### DIFF
--- a/minard/templates/crate_gain_history.html
+++ b/minard/templates/crate_gain_history.html
@@ -83,7 +83,7 @@ div.tooltip {
     <div class="row">
         <div class="col-md-12" id="main">
             {% if not data %}
-                <h2 align="left"> No data available </h2>
+                <h2 align="left"> No data available or no data in QHS range. Try adjusting run range or QHS peak range. </h2>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
There is sometimes data available by adjusting the QHS range. See: https://snopl.us/monitoring/crate_gain_history?ending_run=203329&crate=7&starting_run=203229 for example. 

Note, a fix would be to ignore screamers when calculating the QHS average for each crate, which is what causes the bad measurement. 