### PR TITLE
dynamic noise rate timeseries

### DIFF
--- a/minard/pmtnoisedb.py
+++ b/minard/pmtnoisedb.py
@@ -11,23 +11,9 @@ def dictify(rows):
         rv.append(d)
     return rv
 
-def runs_after_run(run, maxrun=None):
+def get_noise_results(limit=100, offset=0):
     conn = engine_nl.connect()
-    cmd = 'SELECT * FROM pmtnoise WHERE %d < run_number' % run
-    if maxrun:
-        rows = conn.execute('SELECT * FROM pmtnoise'
-                            ' WHERE %s < run_number AND run_number < %s'
-                            ' ORDER BY run_number DESC;', 
-                            (int(run), int(maxrun)))
-    else:
-        rows = conn.execute('SELECT * FROM pmtnoise' 
-                            ' WHERE %s < run_number'
-                            ' ORDER BY run_number DESC;', 
-                            (int(run)))
-    return dictify(rows)
-
-def get_run_by_number(run):
-    conn = engine_nl.connect()
-    rows = conn.execute('SELECT * FROM pmtnoise WHERE %s = run_number;', \
-                        (int(run)))
+    rows = conn.execute('SELECT * FROM pmtnoise '
+                        'ORDER BY run_number DESC '
+                        'LIMIT %s OFFSET %s;', (limit, offset))
     return dictify(rows)

--- a/minard/static/js/cratelevelgraphs.js
+++ b/minard/static/js/cratelevelgraphs.js
@@ -1,0 +1,128 @@
+// thanks tony ;)
+function isNumber(x)
+{
+    return !isNaN(x) && (x != null);
+}
+
+function isPlottable(pair){
+    return (isNumber(pair.run) && isNumber(pair.value))
+}
+
+function mkCrateCheckboxes(divid, pfx, manager){
+    // returns function to update the crate mask, and refresh the plot
+    // needs to be pre-defined, else crate index is ref'd after loop :(
+    function update_mask(i){
+        function rv(){
+            mask = 2<<i
+            if ($(this).is(':checked') && (manager.availmask & mask)){
+                manager.plotmask |= mask    // set bit i
+            }
+            else{
+                manager.plotmask &= ~(mask) // clear bit i
+            }
+            // update
+            manager.refresh(manager)
+        }
+        return rv
+    }
+
+    // crates arranged in a grid...
+    var nCrates = 19 
+    nCols = 2
+    nRows = Math.floor(nCrates/nCols) + 1
+    nCols += 1
+    for (var iRow = 0 ; iRow < nRows ; iRow++){
+      $('#' + divid).append("<div class=\"row\">")
+      for (var iCol = 0 ; iCol < nCols ; iCol++){
+        var i = iRow + iCol*nRows
+        if (!(i < nCrates)) continue
+        var cbid = pfx + 'crate' + i.toString()
+        var label = 'Crate ' + i.toString()
+        cbox = '<input id="' + cbid + '" type="checkbox" value="' + i + '"'
+        if (manager.plotmask & 2<<i){
+            cbox += ' checked'
+        }
+        cbox += '>'
+        label = '<label for="' + i + '">' + label + '</label>'
+
+        // add the checkbox and its label
+        $('#' + divid).append(cbox, label)
+
+        // when we check on/off, we toggle the plotting of each crate
+        $('#' + cbid).change(update_mask(i))
+      }
+      $('#' + divid).append('</br>')
+    }
+}
+
+// set up plot manager
+// makes a collection of checkboxes to control which crates are shown
+function mkPlotManager(divid, availmask, plotmask){
+    // manager just houses the container div, bitmask of which crates to show, 
+    // and the function to call to refresh the plot (passed to each checkbox)
+    mgr = {
+            // FIXME should be better...
+            'availmask': availmask,
+            'plotmask': plotmask, // a bitmask
+            'refreshers': [],
+            'refresh': function(m){
+                            cblist = m.refreshers
+                            for (var i = 0 ; i < m.refreshers.length ; i++){
+                                m.refreshers[i]()
+                            }
+                        }
+          }
+
+    mkCrateCheckboxes(divid, divid + '_checkbox_', mgr)
+
+    return mgr
+}
+
+function mkCrateLevelPlot(divid, series, manager, 
+                          thetitle, thexlabel, theylabel, ymax){
+    // first, trim out crap data points
+    for (var i = 0 ; i < series.length ; i++)
+        series[i].filter(isPlottable)
+    //
+    // when called, redraws the plot
+    manager.refreshers.push(function(){
+        var ns = 0
+        theseries = []
+        labels = []
+        for (var i = 0 ; i < 19 ; i++){
+            if (manager.plotmask & 2<<i){
+                theseries.push(series[i])
+                labels.push('Crate ' + i.toString())
+                ns += 1
+            }
+        }
+        if (ns < 1)
+            charttype = 'missing-data'
+        else
+            charttype = 'line'
+
+        MG.data_graphic({
+            title: thetitle, 
+            data: theseries,
+            width: $('#' + divid).width(),
+            height: 240, 
+            left: 100,
+            right: 100,
+            target: '#' + divid, 
+            transition_on_update: true,
+            missing_is_hidden: true,
+            x_sort: true,
+            x_accessor: 'date', 
+            x_label: thexlabel, 
+            y_label: theylabel, 
+            max_y: ymax,
+            area: false,
+            interpolate: 'linear',
+            chart_type: charttype,
+            legend: labels,
+            })
+    })
+
+    $('#' + divid).append('</br>')
+    manager.refresh(manager)
+}

--- a/minard/templates/noise.html
+++ b/minard/templates/noise.html
@@ -4,11 +4,29 @@
     {{ super() }}
 {% endblock %}
 {% block body %}
+
+<link rel="stylesheet" type="text/css"  href="{{ url_for('static',filename='css/metricsgraphics.css') }}">
+<link rel="stylesheet" type="text/css"  href="{{ url_for('static',filename='css/mg_line_brushing.css') }}">
 {{ super() }}
 
 <div class="container">
-    <img src="{{ url_for('static', filename='pmtnoise/noise-rate_time-series.png') }}" class="img-responsive" alt="Noise time-series">
-    <img src="{{ url_for('static', filename='pmtnoise/qhl-hhp_time-series.png') }}" class="img-responsive" alt="HHP time-series">
+    <div id="metricscontainer" class="container">
+      <div class="row">
+        <div class="col-md-10">
+            <div id="noise-graph"></div>
+            <div id="hhp-graph"></div>
+        </div>
+        <div class="col-md-2">
+            <div id="checkboxes"></div>
+        </div>
+      </div>
+    </div>
+    <p class="text-center">
+        <a id='backlink' href='{{ url_for("noise", limit=limit, offset=offset+limit) }}'>Back</a>
+        {% if offset > 0 %}
+        <a id='nextlink' href='{{ url_for("noise", limit=limit, offset=offset-limit) }}'>Next</a>
+        {% endif %}
+    </p>
 
     <table class="table table-hover">
       <thead>
@@ -70,4 +88,51 @@
   </table>
 </div>
 
+{% endblock %}
+
+{% block script %}
+    <script src="static/js/jquery.min.js"></script>
+    <script src="static/js/d3.js"></script>
+    <script src="static/js/moment.min.js"></script>
+    <script src="static/js/moment-timezone-with-data.min.js"></script>
+    <script src="static/js/tzscale.js"></script>
+    <script src="static/js/metricsgraphics.js"></script>
+    <script src="static/js/cratelevelgraphs.js"></script>
+    <script>
+        noisejson = {{ runs | tojson }}
+        noiseseries = []
+        qhlseries = []
+        for (var i = 0 ; i < 19 ; i++){
+            noise = []
+            qhl = []
+            for (var j = 0 ; j < noisejson.length ; j++){
+                runtime = moment(noisejson[j]['run_time'], 'X')
+                noise.push({'date':runtime.toDate(), 
+                          'value':noisejson[j]['average_noise_crate'][i]})
+                qhl.push({'date':runtime.toDate(), 
+                          'value':noisejson[j]['average_qhl_hhp_crate'][i]})
+            }
+            noiseseries.push(noise)
+            qhlseries.push(qhl)
+        }
+
+        backlinkbase = '{{ url_for("noise", limit=limit, offset=offset+limit, plotmask='plotmasktemplate') | safe }}'
+        nextlinkbase = '{{ url_for("noise", limit=limit, offset=offset-limit, plotmask='plotmasktemplate') | safe }}'
+
+        jQuery(document).ready(function($){
+            availmask = (2<<19)-1
+            // init plot manager/checkboxes
+            mgr = mkPlotManager('checkboxes', availmask, {{plotmask}})
+            mgr.refreshers.push(function(){
+                $('#backlink').attr('href', backlinkbase.replace('plotmasktemplate', mgr.plotmask))
+                $('#nextlink').attr('href', nextlinkbase.replace('plotmasktemplate', mgr.plotmask))
+            })
+            mkCrateLevelPlot('noise-graph', noiseseries, mgr,
+                             'Average Noise Rate', '', 'Noise Rate [Hz]', 
+                             1500.0)
+            mkCrateLevelPlot('hhp-graph',   qhlseries,  mgr,
+                             'Average QHL HHP', '', 'HHP [cap]',
+                             100)
+        })
+    </script>
 {% endblock %}

--- a/minard/views.py
+++ b/minard/views.py
@@ -1332,8 +1332,13 @@ def calibdq_tellie_subrun_number(run_number,subrun_number):
 
 @app.route('/noise')
 def noise():
-    runs = pmtnoisedb.runs_after_run(0)
-    return render_template('noise.html', runs=runs)
+    limit = request.args.get("limit", 336, type=int) # ~ 2 weeks
+    offset = request.args.get("offset", 0, type=int)
+    plotmask = 2097150 # all crates plotted
+    runs = pmtnoisedb.get_noise_results(limit, offset)
+    return render_template('noise.html', runs=runs,
+                            limit=limit, offset=offset,
+                            plotmask=plotmask)
 
 @app.route('/noise_run_detail/<run_number>')
 def noise_run_detail(run_number):


### PR DESCRIPTION
This PR changes the pmt noise/charge time-series from ugly root plots to the dynamic style used in other monitoring tools, and changes the abscissa from run number to a meaningful date. see below for example.

All of the logic is there, but:
  1) We probably want the crate-selection checkboxes to look a bit better than currently
  2) Showing more than a few crates at once is a bit intense, resource-wise, for the average laptop
  3) The in-plot legend falls off-screen and should be corrected

![dynamic-plots-snapshot](https://user-images.githubusercontent.com/7518185/54466874-2faeb000-473f-11e9-89fa-4f0792286844.png)
