### PR TITLE
channel flags bug fix

### DIFF
--- a/minard/channelflagsdb.py
+++ b/minard/channelflagsdb.py
@@ -171,7 +171,10 @@ def get_channel_flags_by_run(run):
             list_sync16_pr.append((crate, slot, channel, sync16_pr))
         if sync24_pr != 0 and sync24_pr is not None:
             list_sync24_pr.append((crate, slot, channel, sync24_pr))
-        missed_counts_burst = missed_burst
+        if missed_burst is not None:
+            missed_counts_burst = missed_burst
+        else:
+            missed_counts_burst = []
 
     return list_missed, list_sync16, list_sync24, list_sync16_pr, list_sync24_pr, missed_counts_burst, count_normal, count_owl, count_other
 

--- a/minard/nearline_monitor.py
+++ b/minard/nearline_monitor.py
@@ -178,16 +178,17 @@ def channel_flags_run(run):
         channel_flags_status[run] = -1
         return channel_flags_status
 
-    missed, sync16, sync24, _, _, _, burst, _, _ = get_channel_flags_by_run(run)
+    missed, sync16, sync24, _, _, burst, _, _, _ = get_channel_flags_by_run(run)
     missed = len(missed)
     sync16 = len(sync16)
     sync24 = len(sync24)
+    missed_burst = len(burst)
     if(sync16 >= OUT_OF_SYNC_2 or missed >= MISSED_COUNT_2 or \
-       burst[run] > MISSED_BURST):
+       missed_burst > MISSED_BURST):
         channel_flags_status[run] = 1
     elif((sync16 >= OUT_OF_SYNC_1 and sync16 < OUT_OF_SYNC_2) or \
          (missed >= MISSED_COUNT_1 and missed < MISSED_COUNT_2) or \
-         (burst[run] > 0 and burst[run] <= MISSED_BURST)):
+         (missed_burst > 0 and missed_burst <= MISSED_BURST)):
         channel_flags_status[run] = 2
     else:
         channel_flags_status[run] = 0

--- a/minard/views.py
+++ b/minard/views.py
@@ -1483,12 +1483,13 @@ def channelflags():
         nresyncs = {}
         missed_burst = {}
         runs = [selected_run]
-        missed_count, cmos_sync16, cgt_sync24, cmos_sync16_pr, cgt_sync24_pr, missed_burst, normal, owl, other = channelflagsdb.get_channel_flags_by_run(selected_run)
+        missed_count, cmos_sync16, cgt_sync24, cmos_sync16_pr, cgt_sync24_pr, mburst, normal, owl, other = channelflagsdb.get_channel_flags_by_run(selected_run)
         sync16s[selected_run] = len(cmos_sync16)
         sync16s_pr[selected_run] = len(cmos_sync16_pr)
         sync24s[selected_run] = len(cgt_sync24)
         sync24s_pr[selected_run] = len(cgt_sync24_pr)
         missed[selected_run] = len(missed_count)
+        missed_burst[selected_run] = len(mburst)
         nsync16[selected_run], nsync24[selected_run], nresyncs[selected_run] = channelflagsdb.get_number_of_syncs(selected_run)
     return render_template('channelflags.html', runs=runs, nsync16=nsync16, nsync24=nsync24, nresyncs=nresyncs, sync16s=sync16s, sync24s=sync24s, missed=missed, sync16s_pr=sync16s_pr, sync24s_pr=sync24s_pr, limit=limit, selected_run=selected_run, run_range_low=run_range_low, run_range_high=run_range_high, normal=normal, owl=owl, other=other, gold=gold, missed_burst=missed_burst)
 


### PR DESCRIPTION
Fix bugs related to missed burst counting when selecting by run number. See run 117912 for an example of the fix.