### PR TITLE
Fix noise times

### DIFF
--- a/minard/pmtnoisedb.py
+++ b/minard/pmtnoisedb.py
@@ -1,4 +1,9 @@
 from .db import engine_nl
+from datetime import datetime
+from .tools import total_seconds
+
+SECOND_PER_DAY = 24*60*60
+SECOND_PER_MICROSECOND = 1e-6
 
 # turn a sql result into a list of dicts
 def dictify(rows):
@@ -12,8 +17,20 @@ def dictify(rows):
     return rv
 
 def get_noise_results(limit=100, offset=0):
+    epoch = datetime(1970, 1, 1)
     conn = engine_nl.connect()
     rows = conn.execute('SELECT * FROM pmtnoise '
                         'ORDER BY run_number DESC '
                         'LIMIT %s OFFSET %s;', (limit, offset))
+    rows = dictify(rows)
+    for row in rows:
+        row['display_time'] = str(row['timestamp'])[:-6]
+        delta = (row['timestamp'].replace(tzinfo=None) - row['timestamp'].utcoffset() - epoch)
+        row['plot_time'] = total_seconds(delta)
+    return rows
+
+def get_run_by_number(run):
+    conn = engine_nl.connect()
+    rows = conn.execute('SELECT * FROM pmtnoise WHERE %s = run_number;', \
+                        (int(run)))
     return dictify(rows)

--- a/minard/static/js/cratelevelgraphs.js
+++ b/minard/static/js/cratelevelgraphs.js
@@ -8,6 +8,11 @@ function isPlottable(pair){
     return (isNumber(pair.run) && isNumber(pair.value))
 }
 
+cratelabels = ['Average']
+for (var i = 0 ; i < 19 ; i++){
+    cratelabels.push('Crate ' + i.toString())
+}
+
 function mkCrateCheckboxes(divid, pfx, manager){
     // returns function to update the crate mask, and refresh the plot
     // needs to be pre-defined, else crate index is ref'd after loop :(
@@ -27,7 +32,7 @@ function mkCrateCheckboxes(divid, pfx, manager){
     }
 
     // crates arranged in a grid...
-    var nCrates = 19 
+    var nCrates = 20
     nCols = 2
     nRows = Math.floor(nCrates/nCols) + 1
     nCols += 1
@@ -37,7 +42,7 @@ function mkCrateCheckboxes(divid, pfx, manager){
         var i = iRow + iCol*nRows
         if (!(i < nCrates)) continue
         var cbid = pfx + 'crate' + i.toString()
-        var label = 'Crate ' + i.toString()
+        var label = cratelabels[i]
         cbox = '<input id="' + cbid + '" type="checkbox" value="' + i + '"'
         if (manager.plotmask & 2<<i){
             cbox += ' checked'
@@ -89,10 +94,10 @@ function mkCrateLevelPlot(divid, series, manager,
         var ns = 0
         theseries = []
         labels = []
-        for (var i = 0 ; i < 19 ; i++){
+        for (var i = 0 ; i < 20 ; i++){
             if (manager.plotmask & 2<<i){
                 theseries.push(series[i])
-                labels.push('Crate ' + i.toString())
+                labels.push(cratelabels[i])
                 ns += 1
             }
         }
@@ -101,6 +106,7 @@ function mkCrateLevelPlot(divid, series, manager,
         else
             charttype = 'line'
 
+        console.log(theseries)
         MG.data_graphic({
             title: thetitle, 
             data: theseries,

--- a/minard/templates/noise.html
+++ b/minard/templates/noise.html
@@ -50,7 +50,7 @@
       <tr>
       {% endif %}
 	<td><a href="{{ url_for('noise_run_detail',run_number = run['run_number']) }}">{{ run["run_number"] }}</a></td>
-	<td>{{ run["run_time"]|timefmt }}</td>
+	<td>{{ run["timestamp"].strftime("%Y-%m-%d %H:%M:%S") }}</td>
 	<td>{{ "%.0f" % (run["average_noiserate"]|float) }}</td>
 	{% if "average_qhl_hhp" in run %}
 	<td>{{ "%.1f" % (run["average_qhl_hhp"]|float) }}</td>
@@ -100,27 +100,59 @@
     <script src="static/js/cratelevelgraphs.js"></script>
     <script>
         noisejson = {{ runs | tojson }}
+
+        // list times as Sudbury time
+        runtimes = []
+        for (var i = 0 ; i < noisejson.length ; i++){
+            runtime = moment(noisejson[i]['plot_time'], 'X')
+            runtime = runtime.tz('Canada/Eastern')
+            runtimes.push(runtime)
+        }
+
+        // sort the datas into a plottable representation
         noiseseries = []
         qhlseries = []
         for (var i = 0 ; i < 19 ; i++){
             noise = []
             qhl = []
             for (var j = 0 ; j < noisejson.length ; j++){
-                runtime = moment(noisejson[j]['run_time'], 'X')
-                noise.push({'date':runtime.toDate(), 
+                runtime = runtimes[j]
+                time = runtime.tz('Canada/Eastern').toDate()
+                noise.push({'date':time,
                           'value':noisejson[j]['average_noise_crate'][i]})
-                qhl.push({'date':runtime.toDate(), 
+                qhl.push({'date':time,
                           'value':noisejson[j]['average_qhl_hhp_crate'][i]})
             }
             noiseseries.push(noise)
             qhlseries.push(qhl)
         }
 
+        // average across all crates...
+        noiseavg = []
+        qhlavg = []
+        for (var i = 0 ; i < noisejson.length ; i++){
+            noisesum = 0.0
+            qhlsum = 0.0
+            for (var j = 0 ; j < 19 ; j++){
+                noisesum += noiseseries[j][i]['value']
+                qhlsum += qhlseries[j][i]['value']
+            }
+            noisesum /= 19
+            qhlsum /= 19
+
+            noiseavg.push({'date':noiseseries[0][i]['date'],
+                           'value':noisesum})
+            qhlavg.push({'date':qhlseries[0][i]['date'],
+                           'value':qhlsum})
+        }
+        noiseseries.splice(0, 0, noiseavg)
+        qhlseries.splice(0, 0, qhlavg)
+
         backlinkbase = '{{ url_for("noise", limit=limit, offset=offset+limit, plotmask='plotmasktemplate') | safe }}'
         nextlinkbase = '{{ url_for("noise", limit=limit, offset=offset-limit, plotmask='plotmasktemplate') | safe }}'
 
         jQuery(document).ready(function($){
-            availmask = (2<<19)-1
+            availmask = (2<<20)-1
             // init plot manager/checkboxes
             mgr = mkPlotManager('checkboxes', availmask, {{plotmask}})
             mgr.refreshers.push(function(){
@@ -129,7 +161,7 @@
             })
             mkCrateLevelPlot('noise-graph', noiseseries, mgr,
                              'Average Noise Rate', '', 'Noise Rate [Hz]', 
-                             1500.0)
+                             2000.0)
             mkCrateLevelPlot('hhp-graph',   qhlseries,  mgr,
                              'Average QHL HHP', '', 'HHP [cap]',
                              100)

--- a/minard/views.py
+++ b/minard/views.py
@@ -1334,7 +1334,7 @@ def calibdq_tellie_subrun_number(run_number,subrun_number):
 def noise():
     limit = request.args.get("limit", 336, type=int) # ~ 2 weeks
     offset = request.args.get("offset", 0, type=int)
-    plotmask = 2097150 # all crates plotted
+    plotmask = request.args.get("plotmask", 2, type=int)
     runs = pmtnoisedb.get_noise_results(limit, offset)
     return render_template('noise.html', runs=runs,
                             limit=limit, offset=offset,


### PR DESCRIPTION
This PR achieves two improvements:
    1) Change the time associated with each run to be more precise.
    2) By default, plot only detector-average quantities. Per-crate time-series are available.

![dynamic-better-times](https://user-images.githubusercontent.com/7518185/61160116-37931c80-a4b3-11e9-8dad-b165a72a8483.png)