### PR TITLE
update owl hv triggers check

### DIFF
--- a/minard/detector_state.py
+++ b/minard/detector_state.py
@@ -402,6 +402,14 @@ def get_detector_state_check(run=0):
             messages.append("crate %i relay settings are unknown" % crate)
 
         for slot in range(16):
+
+            # Check HV on OWL slots
+            if (crate == 3 or crate == 13 or crate == 18) and slot == 15:
+                try:
+                    hv_on = detector_state[16]['hv_b_on'] == True
+                except KeyError:
+                    hv_on = False
+
             if detector_state[crate][slot] is None:
                 messages.append("crate %i, slot %i is offline" % (crate, slot))
                 continue


### PR DESCRIPTION
Currently if crate 3/13/18 HV is OFF but the OWL HV is ON, this prints warning messages if triggers are turned on for crate 3/13/18 slot 15.