### PR TITLE
Add Pre-supernova information

### DIFF
--- a/minard/presn.py
+++ b/minard/presn.py
@@ -1,5 +1,6 @@
 import couchdb
 from . import app
+from datetime import datetime, timedelta
 
 def load_presn_runs(offset, limit):
     """
@@ -7,54 +8,48 @@ def load_presn_runs(offset, limit):
     The dummy itterator is used as key
     to keep the ordering from the couchdb query. The content of the couchdb document is 
     stored as values.
-    This loads ALL the documents in pre-supernova database, ordered by run_subrun logic.
+    This loads ALL the documents in pre-supernova database, ordered by run logic, 
+    but only documents with dates within 100 hours of the search time are shown.
     The logic to limit and split the results per page was implemented.
     """
+    now_local = datetime.now()
+    #timelimit = timedelta(days=7)
+    timelimit = timedelta(hours=100)
     server = couchdb.Server("http://snoplus:"+app.config["COUCHDB_PASSWORD"]+"@"+app.config["COUCHDB_HOSTNAME"])
     db = server["pre-supernova"]
-
     results = []
     skip = offset
-    all = db.view('_design/presn/_view/presn_by_run_only', descending=True, skip=skip)
+    all = db.view('_design/presn/_view/presn_by_date_run', descending=True, skip=skip)
     total = all.total_rows
     offset = all.offset
-    for row in db.view('_design/presn/_view/presn_by_run_only', descending=True, limit=limit, skip=skip):
-        run = row.key
+    for row in db.view('_design/presn/_view/presn_by_date_run', descending=True, limit=limit, skip=skip):
+        year = row.key[0]
+        mon = row.key[1]
+        day = row.key[2]
+        hour = row.key[3]
+        minute = row.key[4]
+        sec = row.key[5]
+        run = row.value
         run_id = row.id
-        try:
-            results.append(dict(db.get(run_id).items()))
-        except KeyError:
-            app.logger.warning("Code returned KeyError searching for presn information in the couchDB. Run Number: %d" % run)
+        runtime=datetime(year, mon, day, hour, minute, sec)
+        timediff = now_local - runtime
+        if timediff<timelimit:
+            try:
+                results.append(dict(db.get(run_id).items()))
+            except KeyError:
+                app.logger.warning("Code returned KeyError searching for presn information in the couchDB. Run Number: %d" % run)
 
     return results, total, offset, limit
-
-def presn_run_detail(run_number):
-    """
-    Returns a dictionary that is a copy of the couchdb document for a specific run.
-    """
-    server = couchdb.Server("http://snoplus:"+app.config["COUCHDB_PASSWORD"]+"@"+app.config["COUCHDB_HOSTNAME"])
-
-    db = server["pre-supernova"]
-
-    startkey = run_number
-    endkey = run_number
-    rows = db.view('_design/presn/_view/presn_by_run_only', startkey=startkey, endkey=endkey, descending=False, include_docs=True)
-    for row in rows:
-        run_id = row.id
-        try:
-            result = dict(db.get(run_id).items())
-        except KeyError:
-            app.logger.warning("Code returned KeyError searching for presn_details information in the couchDB. Run Number: %d" % run_number)
-        files = "%i" %(run_number)
-        
-    return result, files
 
 def load_presn_search(search, start, end, offset, limit):
     """
     Returns a dictionary with the pre-supernova runs loaded from couchdb.
     The returned dictionary is given by one of the search conditions on the page:
-    either by run, date or GTID which all use corresponding couchdb views.
+    either by run or date. There is a time limit such that tables for runs beyond 
+    100 hours of the current time cannot be accessed by minard.
     """
+    now_local = datetime.now()
+    timelimit = timedelta(hours=100)
     server = couchdb.Server("http://snoplus:"+app.config["COUCHDB_PASSWORD"]+"@"+app.config["COUCHDB_HOSTNAME"])
     db = server["pre-supernova"]
     
@@ -62,12 +57,11 @@ def load_presn_search(search, start, end, offset, limit):
     skip = offset
 
     if search == "run":
-        startkey = [int(start), 0, {}]
-        endkey = [int(end), {}]
-        view = '_design/presn/_view/presn_by_run'
+        startkey = [int(start)]
+        endkey = [int(end)]
+        view = '_design/presn/_view/presn_by_run_date'
 
     elif search == "date":
-
         start_year = start[0:4]
         start_month = start[5:7]
         start_day = start[8:10]
@@ -84,13 +78,35 @@ def load_presn_search(search, start, end, offset, limit):
             end_day = end_day[1]
         startkey = [int(start_year), int(start_month), int(start_day)]
         endkey = [int(end_year), int(end_month), int(end_day)]
+        view = '_design/presn/_view/presn_by_date_run'
+      
+    if search == "run":
+        try:
+            all = db.view(view, startkey=startkey, endkey=endkey, descending=False)
+            total = len(all.rows)
+            print "OK, run gives us", total
+            print all
+        except:
+            app.logger.warning("Code returned KeyError searching for presn information in the couchDB.")
 
-        view = '_design/presn/_view/presn_by_date'
-     
-    elif search == "gtid":
-        view = '_design/presn/_view/presn_by_date_GTID'
-    
-    if search == "run" or search == "date":
+        for row in db.view(view, startkey=startkey, endkey=endkey, descending=False, skip=skip, limit=limit):
+            try:
+                year = row.value[0]
+                mon = row.value[1]
+                day = row.value[2]
+                hour = row.value[3]
+                minute = row.value[4]
+                sec = row.value[5]
+                runtime=datetime(year, mon, day, hour, minute, sec)
+                timediff = now_local - runtime
+                run = row.key
+                run_id = row.id
+                if timediff<timelimit:
+                    results.append(dict(db.get(run_id).items()))
+            except KeyError:
+                app.logger.warning("Code returned KeyError searching for presn information in the couchDB. Run Number: %d" % run)
+
+    elif search == "date":
         try:
             all = db.view(view, startkey=startkey, endkey=endkey, descending=False)
             total = len(all.rows)
@@ -98,30 +114,40 @@ def load_presn_search(search, start, end, offset, limit):
             app.logger.warning("Code returned KeyError searching for presn information in the couchDB.")
 
         for row in db.view(view, startkey=startkey, endkey=endkey, descending=False, skip=skip, limit=limit):
-            if search == "run":
-                run = row.key[0]
-            elif search == "date":
-                run = row.value[0]
-            run_id = row.id
             try:
-                results.append(dict(db.get(run_id).items()))
+                year = row.key[0]
+                mon = row.key[1]
+                day = row.key[2]
+                hour = row.key[3]
+                minute = row.key[4]
+                sec = row.key[5]
+                runtime=datetime(year, mon, day, hour, minute, sec)
+                timediff = now_local - runtime
+                run = row.value
+                run_id = row.id
+                if timediff<timelimit:
+                    results.append(dict(db.get(run_id).items()))
             except KeyError:
                 app.logger.warning("Code returned KeyError searching for presn information in the couchDB. Run Number: %d" % run)
 
-        return results, total, offset, limit
+    return results, total, offset, limit
 
+def presn_run_detail(run_number):
+    """
+    Returns a dictionary that is a copy of the couchdb document for a specific run.
+    """
+    server = couchdb.Server("http://snoplus:"+app.config["COUCHDB_PASSWORD"]+"@"+app.config["COUCHDB_HOSTNAME"])
+    db = server["pre-supernova"]
 
-    elif search == "gtid":
-        promptgtid = int(start) 
-        delayedgtid = int(end) 
-        keygtid=[promptgtid, delayedgtid]
-        rows = db.view(view, key=keygtid)
-        for row in rows:
-            run_id=row.id
-            try:
-                results.append(dict(db.get(run_id).items()))
-            except KeyError:
-                app.logger.warning("Code returned KeyError searching for presn information in the couchDB. Run Number: %d" % run)
-                    
-        total = len(results)
-        return results, total, offset, limit
+    startkey = run_number
+    endkey = run_number
+    rows = db.view('_design/presn/_view/presn_by_run_only', startkey=startkey, endkey=endkey, descending=False, include_docs=True)
+    for row in rows:
+        run_id = row.id
+        try:
+            result = dict(db.get(run_id).items())
+        except KeyError:
+            app.logger.warning("Code returned KeyError searching for presn_details information in the couchDB. Run Number: %d" % run_number)
+        files = "%i" %(run_number)
+        
+    return result, files

--- a/minard/presn.py
+++ b/minard/presn.py
@@ -10,8 +10,7 @@ def load_presn_runs(offset, limit):
     This loads ALL the documents in pre-supernova database, ordered by run_subrun logic.
     The logic to limit and split the results per page was implemented.
     """
-    #server = couchdb.Server("http://snoplus:"+app.config["COUCHDB_PASSWORD"]+"@"+app.config["COUCHDB_HOSTNAME"])
-    server = couchdb.Server("http://admin:janetscouchdbpassword@127.0.0.1:5984")
+    server = couchdb.Server("http://snoplus:"+app.config["COUCHDB_PASSWORD"]+"@"+app.config["COUCHDB_HOSTNAME"])
     db = server["pre-supernova"]
 
     results = []
@@ -33,8 +32,8 @@ def presn_run_detail(run_number, subrun):
     """
     Returns a dictionary that is a copy of the couchdb document for specific run_subrun.
     """
-    #server = couchdb.Server("http://snoplus:"+app.config["COUCHDB_PASSWORD"]+"@"+app.config["COUCHDB_HOSTNAME"])
-    server = couchdb.Server("http://admin:janetscouchdbpassword@127.0.0.1:5984")
+    server = couchdb.Server("http://snoplus:"+app.config["COUCHDB_PASSWORD"]+"@"+app.config["COUCHDB_HOSTNAME"])
+
     db = server["pre-supernova"]
 
     startkey = [run_number, subrun]
@@ -56,8 +55,7 @@ def load_presn_search(search, start, end, offset, limit):
     The returned dictionary is given by one of the search conditions on the page:
     either by run, date or GTID which all use corresponding couchdb views.
     """
-    #server = couchdb.Server("http://snoplus:"+app.config["COUCHDB_PASSWORD"]+"@"+app.config["COUCHDB_HOSTNAME"])
-    server = couchdb.Server("http://admin:janetscouchdbpassword@127.0.0.1:5984")
+    server = couchdb.Server("http://snoplus:"+app.config["COUCHDB_PASSWORD"]+"@"+app.config["COUCHDB_HOSTNAME"])
     db = server["pre-supernova"]
     
     results = []

--- a/minard/presn.py
+++ b/minard/presn.py
@@ -15,11 +15,11 @@ def load_presn_runs(offset, limit):
 
     results = []
     skip = offset
-    all = db.view('_design/presn/_view/presn_by_run', descending=True, skip=skip)
+    all = db.view('_design/presn/_view/presn_by_run_only', descending=True, skip=skip)
     total = all.total_rows
     offset = all.offset
-    for row in db.view('_design/presn/_view/presn_by_run', descending=True, limit=limit, skip=skip):
-        run = row.key[0]
+    for row in db.view('_design/presn/_view/presn_by_run_only', descending=True, limit=limit, skip=skip):
+        run = row.key
         run_id = row.id
         try:
             results.append(dict(db.get(run_id).items()))
@@ -28,17 +28,17 @@ def load_presn_runs(offset, limit):
 
     return results, total, offset, limit
 
-def presn_run_detail(run_number, subrun):
+def presn_run_detail(run_number):
     """
-    Returns a dictionary that is a copy of the couchdb document for specific run_subrun.
+    Returns a dictionary that is a copy of the couchdb document for a specific run.
     """
     server = couchdb.Server("http://snoplus:"+app.config["COUCHDB_PASSWORD"]+"@"+app.config["COUCHDB_HOSTNAME"])
 
     db = server["pre-supernova"]
 
-    startkey = [run_number, subrun]
-    endkey = [run_number, subrun]
-    rows = db.view('_design/presn/_view/presn_by_run', startkey=startkey, endkey=endkey, descending=False, include_docs=True)
+    startkey = run_number
+    endkey = run_number
+    rows = db.view('_design/presn/_view/presn_by_run_only', startkey=startkey, endkey=endkey, descending=False, include_docs=True)
     for row in rows:
         run_id = row.id
         try:

--- a/minard/presn.py
+++ b/minard/presn.py
@@ -1,0 +1,148 @@
+import couchdb
+from . import app
+
+def load_presn_runs(offset, limit):
+    """
+    Returns a dictionary with the burst runs loaded from couchdb. The dummy itterator is used as key
+    to keep the ordering from the couchdb query. The content of the couchdb document is stored as values.
+    This loads ALL the documents in burst database, ordered by run_subrun_burst logic.
+    The logic to limit and split the results per page was implemented.
+    """
+    #server = couchdb.Server("http://snoplus:"+app.config["COUCHDB_PASSWORD"]+"@"+app.config["COUCHDB_HOSTNAME"])
+    server = couchdb.Server("http://admin:janetscouchdbpassword@127.0.0.1:5984")
+    #db = server["burst"]
+    db = server["pre-supernova"]
+
+    results = []
+    skip = offset
+    #all = db.view('_design/burst/_view/burst_by_run', descending=True, skip=skip)
+    all = db.view('_design/presn/_view/presn_by_run', descending=True, skip=skip)
+    total = all.total_rows
+    offset = all.offset
+    for row in db.view('_design/presn/_view/presn_by_run', descending=True, limit=limit, skip=skip):
+        run = row.key[0]
+        run_id = row.id
+        try:
+            results.append(dict(db.get(run_id).items()))
+        except KeyError:
+            app.logger.warning("Code returned KeyError searching for burst information in the couchDB. Run Number: %d" % run)
+
+    return results, total, offset, limit
+
+#def presn_run_detail(run_number, subrun, sub):
+def presn_run_detail(run_number, subrun):
+    """
+    Returns a dictionary that is a copy of the couchdb document for specific run_subrun_burst.
+    """
+    #server = couchdb.Server("http://snoplus:"+app.config["COUCHDB_PASSWORD"]+"@"+app.config["COUCHDB_HOSTNAME"])
+    #db = server["burst"]
+    server = couchdb.Server("http://admin:janetscouchdbpassword@127.0.0.1:5984")
+    db = server["pre-supernova"]
+
+    startkey = [run_number, subrun]
+    endkey = [run_number, subrun]
+    rows = db.view('_design/presn/_view/presn_by_run', startkey=startkey, endkey=endkey, descending=False, include_docs=True)
+    for row in rows:
+        run_id = row.id
+        try:
+            result = dict(db.get(run_id).items())
+        except KeyError:
+            app.logger.warning("Code returned KeyError searching for burst_details information in the couchDB. Run Number: %d" % run_number)
+        #files = "%i_%i" % (run_number,subrun)
+        files = "%i" %(run_number)
+        
+    return result, files
+
+def load_presn_search(search, start, end, offset, limit):
+    """
+    Returns a dictionary with the burst runs loaded from couchdb.
+    The returned dictionary is given by one of the search conditions on the page:
+    either by run, date or GTID which all use corresponding couchdb views.
+    """
+    #server = couchdb.Server("http://snoplus:"+app.config["COUCHDB_PASSWORD"]+"@"+app.config["COUCHDB_HOSTNAME"])
+    #db = server["burst"]
+    server = couchdb.Server("http://admin:janetscouchdbpassword@127.0.0.1:5984")
+    db = server["pre-supernova"]
+    
+    results = []
+    skip = offset
+
+    if search == "run":
+
+        startkey = [int(start), 0, {}]
+        endkey = [int(end), {}]
+
+        view = '_design/presn/_view/presn_by_run'
+
+    elif search == "date":
+
+        start_year = start[0:4]
+        start_month = start[5:7]
+        start_day = start[8:10]
+        end_year = end[0:4]
+        end_month = end[5:7]
+        end_day = end[8:10]
+        if start_month[0] == "0":
+            start_month = start_month[1]
+        if end_month[0] == "0":
+            end_month = end_month[1]
+        if start_day[0] == "0":
+            start_day = start_day[1]
+        if end_day[0] == "0":
+            end_day = end_day[1]
+        startkey = [int(start_year), int(start_month), int(start_day)]
+        endkey = [int(end_year), int(end_month), int(end_day)]
+
+        view = '_design/presn/_view/presn_by_date'
+    # Not yet implemented gtid search
+    elif search == "gtid":
+
+        view = '_design/burst/_view/burst_by_date_GTID'
+
+    if search == "run" or search == "date":
+        try:
+            all = db.view(view, startkey=startkey, endkey=endkey, descending=False)
+            total = len(all.rows)
+        except:
+            app.logger.warning("Code returned KeyError searching for burst information in the couchDB.")
+
+        for row in db.view(view, startkey=startkey, endkey=endkey, descending=False, skip=skip, limit=limit):
+            if search == "run":
+                run = row.key[0]
+            elif search == "date":
+                run = row.value[0]
+            run_id = row.id
+            try:
+                results.append(dict(db.get(run_id).items()))
+            except KeyError:
+                app.logger.warning("Code returned KeyError searching for burst information in the couchDB. Run Number: %d" % run)
+
+        return results, total, offset, limit
+    # Not yet implemented gtid for preSN
+    elif search == "gtid": ### this needs to loop through all documents (no start-end key) because we want GTID in range of start/end GTID
+
+        for row in db.view(view, descending=True, limit=1000):   ### limiting search to last 1000 entries by date
+            startgtid = int(row.value[3])
+            endgtid = int(row.value[4])
+
+            if endgtid < startgtid: ### case for gtid roll-over
+                if ( (int(start) >= startgtid) and (int(start) <= pow(2,24)) ) or ( (int(end) <= endgtid) and (int(end) >= 0 ) ):
+                    run = row.value[0]
+                    run_id = row.id
+
+                    try:
+                        results.append(dict(db.get(run_id).items()))
+                    except KeyError:
+                        app.logger.warning("Code returned KeyError searching for burst information in the couchDB. Run Number: %d" % run)
+            else:
+                if (int(start) >= startgtid) and (int(end) <= endgtid):
+                    run = row.value[0]
+                    run_id = row.id
+
+                    try:
+                        results.append(dict(db.get(run_id).items()))
+                    except KeyError:
+                        app.logger.warning("Code returned KeyError searching for burst information in the couchDB. Run Number: %d" % run)
+            total = len(results)
+
+        return results, total, 0, 100

--- a/minard/templates/layout.html
+++ b/minard/templates/layout.html
@@ -40,7 +40,7 @@
                         {{ nav_link('status', 'Status') }}
                         <!-- Dropdown L2 -->
                         <li class='dropdown'>
-			<a href='#' class='dropdown-toggle' data-toggle='dropdown'>L2 <b class='caret'></b></a>
+			<a href='#' class='dropdown-toggle' data-toggle='dropdown'>Supernova <b class='caret'></b></a>
                             <ul class='dropdown-menu'>
                                 {{ nav_link('l2', 'L2') }}
                                 {{ nav_link('burst', 'Burst Trigger') }}

--- a/minard/templates/layout.html
+++ b/minard/templates/layout.html
@@ -44,6 +44,7 @@
                             <ul class='dropdown-menu'>
                                 {{ nav_link('l2', 'L2') }}
                                 {{ nav_link('burst', 'Burst Trigger') }}
+				{{ nav_link('presn', 'Pre-Supernova') }}
                             </ul>
                         {{ nav_link('snostream', 'Stream') }}
                         <!-- Dropdown Detector -->

--- a/minard/templates/presn.html
+++ b/minard/templates/presn.html
@@ -26,7 +26,6 @@
                                   <div class="col-sm-2">
                                       <select id="search-by" name="search" class="form-control" onchange="update_search()">
                                           <option value="run">Run</option>
-                                          <option value="gtid">GTID</option>
                                           <option value="date">Date</option>
                                       </select>
                                   </div>
@@ -61,6 +60,7 @@
             </div>
 
             <h3>Details</h3>
+	    <h5>flag = 1 (good), 2 (at least 1 run not physics), 3 (bad duration search), 4 (duration less than required), 5 (bad duration), 6 (bad significance), 7 (could not retrieve data)</h5>
             <table class="table table-bordered table-condensed table-striped">
                 <thead>
                     <tr>

--- a/minard/templates/presn.html
+++ b/minard/templates/presn.html
@@ -1,0 +1,111 @@
+{% extends "layout.html" %}
+{% block title %}Pre-Supernova{% endblock %}
+{% block head %}
+  {{ super() }}
+{% endblock %}
+{% block body %}
+  {{ super() }}
+
+    <div class="container">
+      <div class="row">
+        <div class="col-md-12">
+            <h2>Pre-Supernova </h2>
+
+            <div class="row">
+                <div class="col-md-12">
+                  <div class="panel panel-default">
+                      <div class="panel-heading">
+                          Search:
+                      </div>
+                      <div class="panel-body">
+                          <form class="form-horizontal" role="form" method="get" action="{{ url_for("burst") }}" onsubmit="return validate_form()">
+                              <div class="form-group form-group-sm">
+                                  <label class="col-sm-2 control-label">
+                                      Search by:
+                                  </label>
+                                  <div class="col-sm-2">
+                                      <select id="search-by" name="search" class="form-control" onchange="update_search()">
+                                          <option value="run">Run</option>
+                                          <option value="gtid">GTID</option>
+                                          <option value="date">Date</option>
+                                      </select>
+                                  </div>
+                                  <label class="col-sm-1 control-label">
+                                      Start
+                                  </label>
+                                  <div class="col-sm-2">
+                                      <input name="start"
+                                       id="start"
+                                       type="number"
+                                       min=0
+                                       class="form-control">
+                                  </div>
+                                  <label class="col-sm-1 control-label">
+                                      End
+                                  </label>
+                                  <div class="col-sm-2">
+                                      <input name="end"
+                                       id="end"
+                                       type="number"
+                                       min=0
+                                       class="form-control">
+                                  </div>
+                                  <div class="col-sm-2">
+                                      <input type="submit" value="Go"></input>
+                                  </div>
+                              </div>
+                          </form>
+                      </div>
+                  </div>
+                </div>
+            </div>
+
+            <h3>Details</h3>
+            <table class="table table-bordered table-condensed table-striped">
+                <thead>
+                    <tr>
+                        <th>Run</th>
+                        <th>SubRun</th>
+                        <th>Date</th>
+                        <th>Time</th>
+			<th>Significance</th>
+			<th>Flag</th>
+                        <th># Events</th>
+                        <th>Duration [h]</th>
+                    </tr>
+                </thead>
+                <tbody>
+                  {% for run in data %}
+                  <tr>
+                    <td><a href="{{ url_for('presn_run_detail', run_number=run['run'], subrun=run['subrun']) }}">{{ run['run'] }}</a></td> 
+                      <td>{{  run["subrun"] }}</td>
+                      <td>{{  run["date"] }}</td>
+                      <td>{{  run["time"] }}</td>
+		      <td>{{  run["significance"] }}</td>
+		      <td>{{  run["flag"] }}</td>
+                      <td>{{  run["nevents"] }}</td>
+                      <td>{{  run["duration"] }}</td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+            </table>
+            {% if ( (offset > limit-1) and (search != null) ) %}
+              <a href="{{ url_for("presn", offset=offset-limit, limit=limit, search=search, start=start, end=end) }}">Back</a>
+            {% elif (offset > limit-1) %}
+              <a href="{{ url_for("presn", offset=offset-limit, limit=limit) }}">Back</a>
+            {% endif %}
+            {% if ( (total > offset + limit) and (search != null) ) %}
+              <a href="{{ url_for("presn", offset=offset+limit, limit=limit, search=search, start=start, end=end) }}">Next</a>
+            {% elif (total > offset + limit) %}
+              <a href="{{ url_for("presn", offset=offset+limit, limit=limit) }}">Next</a>
+            {% endif %}
+        </div>
+      </div>
+    </div>
+
+
+{% endblock %}
+{% block script %}
+    <script src="{{ url_for('static', filename='js/burst.js') }}"></script>
+    <script> window.onload = function() {fill_boxes();};</script>
+{% endblock %}

--- a/minard/templates/presn.html
+++ b/minard/templates/presn.html
@@ -77,7 +77,7 @@
                 <tbody>
                   {% for run in data %}
                   <tr>
-		      <td><a href="{{ url_for('presn_run_detail', run_number=run['run'], subrun=run['subrun']) }}">{{ run['run'] }}</a></td>
+		      <td><a href="{{ url_for('presn_run_detail', run_number=run['run']) }}">{{ run['run'] }}</a></td>
                       <td>{{  run["subrun"] }}</td>
                       <td>{{  run["date"] }}</td>
                       <td>{{  run["time"] }}</td>

--- a/minard/templates/presn.html
+++ b/minard/templates/presn.html
@@ -71,13 +71,13 @@
 			<th>Significance</th>
 			<th>Flag</th>
                         <th># Events</th>
-                        <th>Duration [h]</th>
+                        <th>Window duration [h]</th>
                     </tr>
                 </thead>
                 <tbody>
                   {% for run in data %}
                   <tr>
-                    <td><a href="{{ url_for('presn_run_detail', run_number=run['run'], subrun=run['subrun']) }}">{{ run['run'] }}</a></td> 
+		      <td><a href="{{ url_for('presn_run_detail', run_number=run['run'], subrun=run['subrun']) }}">{{ run['run'] }}</a></td>
                       <td>{{  run["subrun"] }}</td>
                       <td>{{  run["date"] }}</td>
                       <td>{{  run["time"] }}</td>

--- a/minard/templates/presn.html
+++ b/minard/templates/presn.html
@@ -18,7 +18,7 @@
                           Search:
                       </div>
                       <div class="panel-body">
-                          <form class="form-horizontal" role="form" method="get" action="{{ url_for("burst") }}" onsubmit="return validate_form()">
+			<form class="form-horizontal" role="form" method="get" action="{{ url_for("presn") }}" onsubmit="return validate_form()">
                               <div class="form-group form-group-sm">
                                   <label class="col-sm-2 control-label">
                                       Search by:
@@ -107,5 +107,6 @@
 {% endblock %}
 {% block script %}
     <script src="{{ url_for('static', filename='js/burst.js') }}"></script>
+    <!-- <script src="{{ url_for('static', filename='js/presn.js') }}"></script> -->
     <script> window.onload = function() {fill_boxes();};</script>
 {% endblock %}

--- a/minard/templates/presn_run_detail.html
+++ b/minard/templates/presn_run_detail.html
@@ -10,8 +10,6 @@
   <div class="container">
     <div class="row">
       <div class="col-md-12">
-        {{ subrun }}
-        {{ sub }}
         <h2>PreSN Run {{ data["run"] }} details</h2>
         <table class="table table-striped">
           <thead>
@@ -34,41 +32,60 @@
               <td>{{ data["significance"] }}</td>
             </tr>
 	    <tr>
-	      <td>Flag</td>
+	      <td>Pre-SN flag</td>
 	      <td>{{ data["flag"] }}</td>
 	    </tr>
 	    <tr>
-	      <td>Duration [h]</td>
+	      <td>Pre-SN window duration [h]</td>
 	      <td>{{ data["duration"] }}</td>
 	    </tr>
 	    <tr>
-	      <td># Events</td>
+	      <td># Events in window</td>
 	      <td>{{ data["nevents"] }}</td>
 	    </tr>
             <tr>
-              <td>Date</td>
+              <td>Date processed (d/m/y)</td>
               <td>{{ data["date"] }}</td>
             </tr>
             <tr>
-              <td>Time</td>
+              <td>Time processed</td>
               <td>{{ data["time"] }}</td>
             </tr>
             <tr>
-              <td>Date UTC</td>
+              <td>Date processed (UTC)</td>
               <td>{{ data["UTCdate"] }}</td>
             </tr>
             <tr>
-              <td>Time UTC</td>
+              <td>Time processed (UTC)</td>
               <td>{{ data["UTCtime"] }}</td>
             </tr>
 	    <tr>
-	      <td>Last event date</td>
+	      <td>Date of last event</td>
 	      <td>{{ data["evdate"] }}</td>
 	    </tr>
             <tr>
-              <td>Last event time</td>
+              <td>Time of last event</td>
               <td>{{ data["evtime"] }}</td>
             </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+        <h2>Cut details (run level)</h2>
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>Parameter</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>
             <tr>
               <td>Nhit delayed cut (high)</td>
               <td>{{ data["cut_NHit_d_hi"] }}</td>
@@ -86,50 +103,83 @@
               <td>{{ data["cut_NHit_p_low"] }}</td>
             </tr>
             <tr>
-              <td>Radius delayed cut</td>
+              <td>Radius delayed cut [mm]</td>
               <td>{{ data["cut_R_d"] }}</td>
             </tr>
             <tr>
-              <td>Radius prompt cut</td>
+              <td>Radius prompt cut [mm]</td>
               <td>{{ data["cut_R_p"] }}</td>
             </tr>
 	    <tr>
-              <td>dt cut (high)</td>
+              <td>dt cut (high) [ns]</td>
               <td>{{ data["cut_dt_hi"] }}</td>
             </tr>
 	    <tr>
-              <td>dt cut (low)</td>
+              <td>dt cut (low) [ns]</td>
               <td>{{ data["cut_dt_low"] }}</td>
             </tr>
             <tr>
-              <td>L3 Radius Cut</td>
+              <td>dr cut (FIX ME!) [mm]</td>
               <td>{{ data["cut_R_strict"] }}</td>
-            </tr>
-            <tr>
-              <td>L3 dt cut (high)</td>
-              <td>{{ data["cut_dt_strict"] }}</td>
-            </tr>
-            <tr>
-              <td>L3 time window Cut</td>
-              <td>{{ data["cut_timewindow"] }}</td>
-            </tr>
-            <tr>
-              <td>Assumed background rate</td>
-              <td>{{ data["bkg_rate"] }}</td>
             </tr>
           </tbody>
         </table>
       </div>
     </div>
+  </div>
 
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+        <h2>Cut details (pre-supernova level)</h2>
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>Parameter</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Pre-SN radius cut [mm]</td>
+              <td>{{ data["cut_R_strict"] }}</td>
+            </tr>
+            <tr>
+              <td>Pre-SN dt cut (high) [ns]</td>
+              <td>{{ data["cut_dt_strict"] }}</td>
+            </tr>
+            <tr>
+              <td>Pre-SN time window cut [h]</td>
+              <td>{{ data["cut_timewindow"] }}</td>
+            </tr>
+            <tr>
+              <td>Assumed background rate [/hour]</td>
+              <td>{{ data["bkg_rate"] }}</td>
+            </tr>
+	    <tr>
+	      <td>Prompt Gtids</td>
+	      <td>{{ data["promptGtids"] }}</td>
+	    </tr>
+	    <tr>
+	      <td>Delayed Gtids</td>
+	      <td>{{ data["delayedGtids"] }}</td>
+	    </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="container">
     <div class="row">
       <div class="col-md-12">
         <div class="panel panel-default">
           <div class="panel-heading">
-            <h3 class="panel-title">Time series (full window duration)</h3>
+            <h3 class="panel-title">Time series (pre-supernova level)</h3>
           </div>
           <div class="panel-body">
 		<img src="{{ url_for('static', filename="presndata/run"+files+"/h_time_"+files+".png") }}" alt="Time series" class="img-responsive center-block" >
+          </div>
         </div>
       </div>
     </div>
@@ -138,19 +188,73 @@
       <div class="col-md-12">
         <div class="panel panel-default">
           <div class="panel-heading">
-            <h3 class="panel-title">Time series (run)</h3>
+            <h3 class="panel-title">NHits (pre-supernova level)</h3>
+          </div>
+          <div class="panel-body">
+		<img src="{{ url_for('static', filename="presndata/run"+files+"/h_nhit_"+files+".png") }}" alt="Time series" class="img-responsive center-block" >
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-12">
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">Position (pre-supernova level)</h3>
+          </div>
+          <div class="panel-body">
+            <div class="row">
+              <div class="col-md-6">
+                <img src="{{ url_for('static', filename="presndata/run" + files + "/h_xy_" + files + ".png") }}" alt="xy histogram, alltime" class="img-responsive">
+              </div>
+              <div class="col-md-6">
+                <img src="{{ url_for('static', filename="presndata/run" + files + "/h_rhoz_" + files + ".png") }}" alt="rho-z histogram, alltime" class="img-responsive center-block">
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-12">
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">Coincidence separation (pre-supernova level)</h3>
+          </div>
+          <div class="panel-body">
+            <div class="row">
+              <div class="col-md-6">
+                <img src="{{ url_for('static', filename="presndata/run" + files + "/h_dt_" + files + ".png") }}" alt="Coincidence dt histogram, alltime" class="img-responsive">
+              </div>
+              <div class="col-md-6">
+                <img src="{{ url_for('static', filename="presndata/run" + files + "/h_dr_" + files + ".png") }}" alt="Coincidence dr histogram, alltime" class="img-responsive center-block">
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-12">
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">Time series (run level)</h3>
           </div>
           <div class="panel-body">
 		<img src="{{ url_for('static', filename="presndata/run"+files+"/"+files+"_t.png") }}" alt="Time series" class="img-responsive center-block" >
+          </div>
         </div>
       </div>
     </div>
-
+      
     <div class="row">
       <div class="col-md-12">
         <div class="panel panel-default">
           <div class="panel-heading">
-            <h3 class="panel-title">NHits</h3>
+            <h3 class="panel-title">NHits (run level)</h3>
           </div>
           <div class="panel-body">
             <img src="{{ url_for('static', filename="presndata/run" + files + "/" + files + "_nhits.png") }}" alt="NHits histogram" class="img-responsive center-block">
@@ -159,12 +263,11 @@
       </div>
     </div>
 
-
     <div class="row">
       <div class="col-md-12">
         <div class="panel panel-default">
           <div class="panel-heading">
-            <h3 class="panel-title">Position</h3>
+            <h3 class="panel-title">Position (run level)</h3>
           </div>
           <div class="panel-body">
             <div class="row">
@@ -179,13 +282,12 @@
         </div>
       </div>
     </div>
-  </div>
 
     <div class="row">
       <div class="col-md-12">
         <div class="panel panel-default">
           <div class="panel-heading">
-            <h3 class="panel-title">Coincidence Separation</h3>
+            <h3 class="panel-title">Coincidence separation (run level)</h3>
           </div>
           <div class="panel-body">
             <div class="row">
@@ -200,4 +302,5 @@
         </div>
       </div>
     </div>
+  </div>
 {% endblock %}

--- a/minard/templates/presn_run_detail.html
+++ b/minard/templates/presn_run_detail.html
@@ -10,7 +10,7 @@
   <div class="container">
     <div class="row">
       <div class="col-md-12">
-        <h2>PreSN Run {{ data["run"] }} details</h2>
+        <h2>PreSN run {{ data["run"] }} details</h2>
         <table class="table table-striped">
           <thead>
             <tr>
@@ -32,7 +32,7 @@
               <td>{{ data["significance"] }}</td>
             </tr>
 	    <tr>
-	      <td>Pre-SN flag</td>
+	      <td>Pre-SN flag (1=good)</td>
 	      <td>{{ data["flag"] }}</td>
 	    </tr>
 	    <tr>
@@ -60,11 +60,11 @@
               <td>{{ data["UTCtime"] }}</td>
             </tr>
 	    <tr>
-	      <td>Date of last event</td>
+	      <td>Date of last event (UTC)</td>
 	      <td>{{ data["evdate"] }}</td>
 	    </tr>
             <tr>
-              <td>Time of last event</td>
+              <td>Time of last event (UTC)</td>
               <td>{{ data["evtime"] }}</td>
             </tr>
           </tbody>
@@ -77,7 +77,7 @@
   <div class="container">
     <div class="row">
       <div class="col-md-12">
-        <h2>Cut details (run level)</h2>
+        <h2>Cut details</h2>
         <table class="table table-striped">
           <thead>
             <tr>
@@ -87,83 +87,57 @@
           </thead>
           <tbody>
             <tr>
-              <td>Nhit delayed cut (high)</td>
+              <td>L2 Nhit cut (high)</td>
+              <td>{{ data["cut_L2Nhit_hi"] }}</td>
+            </tr>
+            <tr>
+              <td>L2 Nhit cut (low)</td>
+              <td>{{ data["cut_L2Nhit_low"] }}</td>
+            </tr>
+	    <tr>
+              <td>L2 Bitmask</td>
+              <td>{{ data["cut_L2bitmask"] }}</td>
+            </tr>
+            <tr>
+              <td>L3 cleaned Nhit delayed cut (high)</td>
               <td>{{ data["cut_NHit_d_hi"] }}</td>
             </tr>
             <tr>
-              <td>Nhit delayed cut (low)</td>
+              <td>L3 cleaned Nhit delayed cut (low)</td>
               <td>{{ data["cut_NHit_d_low"] }}</td>
             </tr>
-            <tr>
-              <td>Nhit prompt cut (high)</td>
+	    <tr>
+              <td>L3 cleaned Nhit prompt cut (high)</td>
               <td>{{ data["cut_NHit_p_hi"] }}</td>
             </tr>
             <tr>
-              <td>Nhit prompt cut (low)</td>
+              <td>L3 cleaned Nhit prompt cut (low)</td>
               <td>{{ data["cut_NHit_p_low"] }}</td>
             </tr>
             <tr>
-              <td>Radius delayed cut [mm]</td>
-              <td>{{ data["cut_R_d"] }}</td>
-            </tr>
-            <tr>
-              <td>Radius prompt cut [mm]</td>
+              <td>L3 Radius cut [mm]</td>
               <td>{{ data["cut_R_p"] }}</td>
             </tr>
 	    <tr>
-              <td>dt cut (high) [ns]</td>
+              <td>L3 dt cut (high) [ns]</td>
               <td>{{ data["cut_dt_hi"] }}</td>
             </tr>
 	    <tr>
-              <td>dt cut (low) [ns]</td>
+              <td>L3 dt cut (low) [ns]</td>
               <td>{{ data["cut_dt_low"] }}</td>
             </tr>
             <tr>
-              <td>dr cut (FIX ME!) [mm]</td>
-              <td>{{ data["cut_R_strict"] }}</td>
+              <td>L3 dr cut (high) [mm]</td>
+              <td>{{ data["cut_dR"] }}</td>
             </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-
-  <div class="container">
-    <div class="row">
-      <div class="col-md-12">
-        <h2>Cut details (pre-supernova level)</h2>
-        <table class="table table-striped">
-          <thead>
-            <tr>
-              <th>Parameter</th>
-              <th>Value</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>Pre-SN radius cut [mm]</td>
-              <td>{{ data["cut_R_strict"] }}</td>
-            </tr>
-            <tr>
-              <td>Pre-SN dt cut (high) [ns]</td>
-              <td>{{ data["cut_dt_strict"] }}</td>
-            </tr>
-            <tr>
-              <td>Pre-SN time window cut [h]</td>
+	    <tr>
+              <td>L4 Pre-SN time window [h]</td>
               <td>{{ data["cut_timewindow"] }}</td>
             </tr>
-            <tr>
-              <td>Assumed background rate [/hour]</td>
+	    <tr>
+              <td>L4 Assumed background rate [/hour]</td>
               <td>{{ data["bkg_rate"] }}</td>
             </tr>
-	    <tr>
-	      <td>Prompt Gtids</td>
-	      <td>{{ data["promptGtids"] }}</td>
-	    </tr>
-	    <tr>
-	      <td>Delayed Gtids</td>
-	      <td>{{ data["delayedGtids"] }}</td>
-	    </tr>
           </tbody>
         </table>
       </div>
@@ -173,43 +147,225 @@
   <div class="container">
     <div class="row">
       <div class="col-md-12">
+	<h2>Significance over time</h2>
         <div class="panel panel-default">
           <div class="panel-heading">
-            <h3 class="panel-title">Time series (pre-supernova level)</h3>
+            <h3 class="panel-title">Significance time series</h3>
           </div>
           <div class="panel-body">
-		<img src="{{ url_for('static', filename="presndata/run"+files+"/h_time_"+files+".png") }}" alt="Time series" class="img-responsive center-block" >
+	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/sigplot.png") }}" alt="Significance time series" class="img-responsive center-block" >
           </div>
         </div>
       </div>
     </div>
+  </div>
 
+
+  <div class="container">
     <div class="row">
       <div class="col-md-12">
+	<h2>Events in Pre-supernova time window after all cuts</h2>
         <div class="panel panel-default">
           <div class="panel-heading">
-            <h3 class="panel-title">NHits (pre-supernova level)</h3>
+            <h3 class="panel-title">Time series</h3>
           </div>
           <div class="panel-body">
-		<img src="{{ url_for('static', filename="presndata/run"+files+"/h_nhit_"+files+".png") }}" alt="Time series" class="img-responsive center-block" >
+	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/h_time_"+files+".png") }}" alt="Time series" class="img-responsive center-block" >
           </div>
         </div>
+	<div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">NHits</h3>
+          </div>
+          <div class="panel-body">
+	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/h_nhit_"+files+".png") }}" alt="Nhits" class="img-responsive center-block" >
+          </div>
+	</div>
       </div>
     </div>
+  </div>
 
+
+  <div class="container">
     <div class="row">
       <div class="col-md-12">
+	<h2>Candidates in Pre-supernova time window within L2 Nhit ROI</h2>
         <div class="panel panel-default">
           <div class="panel-heading">
-            <h3 class="panel-title">Position (pre-supernova level)</h3>
+            <h3 class="panel-title">NHits</h3>
+          </div>
+          <div class="panel-body">
+	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/h_Nhit_12.png") }}" alt="Nhits" class="img-responsive center-block" >
+          </div>
+        </div>
+
+	<div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">Position</h3>
           </div>
           <div class="panel-body">
             <div class="row">
               <div class="col-md-6">
-                <img src="{{ url_for('static', filename="presndata/run" + files + "/h_xy_" + files + ".png") }}" alt="xy histogram, alltime" class="img-responsive">
+		<img src="{{ url_for('static', filename="preSNdata/run" + files + "/h_R_12.png") }}" alt="Radial position" class="img-responsive">
               </div>
               <div class="col-md-6">
-                <img src="{{ url_for('static', filename="presndata/run" + files + "/h_rhoz_" + files + ".png") }}" alt="rho-z histogram, alltime" class="img-responsive center-block">
+		<img src="{{ url_for('static', filename="preSNdata/run" + files + "/h_Z_12.png") }}" alt="Z position" class="img-responsive center-block">
+              </div>
+            </div>
+          </div>
+	</div>
+	
+      </div>
+    </div>
+  </div>
+
+
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+	<h2>Candidates in this run within L2 Nhit ROI</h2>
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">NHits</h3>
+          </div>
+          <div class="panel-body">
+	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/h_Nhit_"+files+".png") }}" alt="Nhits" class="img-responsive center-block" >
+          </div>
+        </div>
+	<div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">Position</h3>
+          </div>
+          <div class="panel-body">
+            <div class="row">
+              <div class="col-md-6">
+		<img src="{{ url_for('static', filename="preSNdata/run" + files + "/h_R_"+files+".png") }}" alt="Radial position" class="img-responsive">
+              </div>
+              <div class="col-md-6">
+		<img src="{{ url_for('static', filename="preSNdata/run" + files + "/h_Z_"+files+".png") }}" alt="Z position" class="img-responsive center-block">
+              </div>
+            </div>
+          </div>
+	</div>
+      </div>
+    </div>
+  </div>  
+
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+	<h2>Trends for candidates within L2 Nhit ROI</h2>
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">NHits</h3>
+          </div>
+          <div class="panel-body">
+	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/gr_nevents_Nhit_100.png") }}" alt="Nhit trend" class="img-responsive center-block" >
+          </div>
+        </div>
+
+	<div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">Position</h3>
+          </div>
+          <div class="panel-body">
+            <div class="row">
+              <div class="col-md-6">
+		<img src="{{ url_for('static', filename="preSNdata/run" + files + "/gr_nevents_R_100.png") }}" alt="Radial position trend" class="img-responsive">
+              </div>
+              <div class="col-md-6">
+		<img src="{{ url_for('static', filename="preSNdata/run" + files + "/gr_nevents_Z_100.png") }}" alt="Z position trend" class="img-responsive center-block">
+              </div>
+            </div>
+          </div>
+	</div>
+	
+      </div>
+    </div>
+  </div>
+
+
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+	<h2>Trends for candidates within delayed Nhit ROI</h2>
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">NHits</h3>
+          </div>
+          <div class="panel-body">
+	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/gr_nevents_Nhit_cand_100.png") }}" alt="Nhits trend" class="img-responsive center-block" >
+          </div>
+        </div>
+
+	<div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">Position</h3>
+          </div>
+          <div class="panel-body">
+            <div class="row">
+              <div class="col-md-6">
+		<img src="{{ url_for('static', filename="preSNdata/run" + files + "/gr_nevents_R_cand_100.png") }}" alt="Radial position trend" class="img-responsive">
+              </div>
+              <div class="col-md-6">
+		<img src="{{ url_for('static', filename="preSNdata/run" + files + "/gr_nevents_Z_cand_100.png") }}" alt="Z position trend" class="img-responsive center-block">
+              </div>
+            </div>
+          </div>
+	</div>
+	
+      </div>
+    </div>
+  </div>
+
+
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+	<h2>Compare prompt and delayed candidates within the Pre-SN window</h2>
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">dr between prompt candidates that pass L2 Nhit + FV cuts and delayed candidates that pass L2 Nhit + FV + L3 Nhit cuts</h3>
+          </div>
+          <div class="panel-body">
+	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/h_dr_FV55roi_12.png") }}" alt="Candidates dr" class="img-responsive center-block" >
+          </div>
+        </div>
+	<div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">dt between prompt candidates that pass dr + L2 Nhit + FV cuts and delayed candidates that pass dr + L2 Nhit + FV + L2 Nhit cuts </h3>
+          </div>
+          <div class="panel-body">
+	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/h_dt_dr2_FV55roi_12.png") }}" alt="Candidates dt" class="img-responsive center-block" >
+          </div>
+        </div>
+	<div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">Nhits of prompt candidates that pass dt + dr + L2 Nhit + FV cuts</h3>
+          </div>
+          <div class="panel-body">
+	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/h_Nhit_dt5_dr2_FV55roi_12.png") }}" alt="Prompt candidate Nhits" class="img-responsive center-block" >
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  
+
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">Event Positions (pre-supernova level)</h3>
+          </div>
+          <div class="panel-body">
+            <div class="row">
+              <div class="col-md-6">
+                <img src="{{ url_for('static', filename="preSNdata/run" + files + "/h_xy_" + files + ".png") }}" alt="xy histogram, alltime" class="img-responsive">
+              </div>
+              <div class="col-md-6">
+                <img src="{{ url_for('static', filename="preSNdata/run" + files + "/h_rhoz_" + files + ".png") }}" alt="rho-z histogram, alltime" class="img-responsive center-block">
               </div>
             </div>
           </div>
@@ -221,86 +377,21 @@
       <div class="col-md-12">
         <div class="panel panel-default">
           <div class="panel-heading">
-            <h3 class="panel-title">Coincidence separation (pre-supernova level)</h3>
+            <h3 class="panel-title">Coincidence event separation (pre-supernova level)</h3>
           </div>
           <div class="panel-body">
             <div class="row">
               <div class="col-md-6">
-                <img src="{{ url_for('static', filename="presndata/run" + files + "/h_dt_" + files + ".png") }}" alt="Coincidence dt histogram, alltime" class="img-responsive">
+                <img src="{{ url_for('static', filename="preSNdata/run" + files + "/h_dt_" + files + ".png") }}" alt="Coincidence dt histogram, alltime" class="img-responsive">
               </div>
               <div class="col-md-6">
-                <img src="{{ url_for('static', filename="presndata/run" + files + "/h_dr_" + files + ".png") }}" alt="Coincidence dr histogram, alltime" class="img-responsive center-block">
+                <img src="{{ url_for('static', filename="preSNdata/run" + files + "/h_dr_" + files + ".png") }}" alt="Coincidence dr histogram, alltime" class="img-responsive center-block">
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-
-    <div class="row">
-      <div class="col-md-12">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <h3 class="panel-title">Time series (run level)</h3>
-          </div>
-          <div class="panel-body">
-		<img src="{{ url_for('static', filename="presndata/run"+files+"/"+files+"_t.png") }}" alt="Time series" class="img-responsive center-block" >
-          </div>
-        </div>
-      </div>
-    </div>
-      
-    <div class="row">
-      <div class="col-md-12">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <h3 class="panel-title">NHits (run level)</h3>
-          </div>
-          <div class="panel-body">
-            <img src="{{ url_for('static', filename="presndata/run" + files + "/" + files + "_nhits.png") }}" alt="NHits histogram" class="img-responsive center-block">
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col-md-12">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <h3 class="panel-title">Position (run level)</h3>
-          </div>
-          <div class="panel-body">
-            <div class="row">
-              <div class="col-md-6">
-                <img src="{{ url_for('static', filename="presndata/run" + files + "/" + files + "_xy.png") }}" alt="xy histogram" class="img-responsive">
-              </div>
-              <div class="col-md-6">
-                <img src="{{ url_for('static', filename="presndata/run" + files + "/" + files + "_rhoz.png") }}" alt="rho-z histogram" class="img-responsive">
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col-md-12">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <h3 class="panel-title">Coincidence separation (run level)</h3>
-          </div>
-          <div class="panel-body">
-            <div class="row">
-              <div class="col-md-6">
-                <img src="{{ url_for('static', filename="presndata/run" + files + "/" + files + "_dt.png") }}" alt="Coincidence dt histogram" class="img-responsive">
-              </div>
-              <div class="col-md-6">
-                <img src="{{ url_for('static', filename="presndata/run" + files + "/" + files + "_dr.png") }}" alt="Coincidence dr histogram" class="img-responsive center-block">
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+    
   </div>
 {% endblock %}

--- a/minard/templates/presn_run_detail.html
+++ b/minard/templates/presn_run_detail.html
@@ -153,7 +153,7 @@
             <h3 class="panel-title">Significance time series</h3>
           </div>
           <div class="panel-body">
-	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/sigplot.png") }}" alt="Significance time series" class="img-responsive center-block" >
+	    <img src="{{ url_for('static', filename="pre-sn/run"+files+"/sigplot.png") }}" alt="Significance time series" class="img-responsive center-block" >
           </div>
         </div>
       </div>
@@ -170,7 +170,7 @@
             <h3 class="panel-title">Time series</h3>
           </div>
           <div class="panel-body">
-	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/h_time_"+files+".png") }}" alt="Time series" class="img-responsive center-block" >
+	    <img src="{{ url_for('static', filename="pre-sn/run"+files+"/h_time_"+files+".png") }}" alt="Time series" class="img-responsive center-block" >
           </div>
         </div>
 	<div class="panel panel-default">
@@ -178,7 +178,7 @@
             <h3 class="panel-title">NHits</h3>
           </div>
           <div class="panel-body">
-	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/h_nhit_"+files+".png") }}" alt="Nhits" class="img-responsive center-block" >
+	    <img src="{{ url_for('static', filename="pre-sn/run"+files+"/h_nhit_"+files+".png") }}" alt="Nhits" class="img-responsive center-block" >
           </div>
 	</div>
       </div>
@@ -195,7 +195,7 @@
             <h3 class="panel-title">NHits</h3>
           </div>
           <div class="panel-body">
-	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/h_Nhit_12.png") }}" alt="Nhits" class="img-responsive center-block" >
+	    <img src="{{ url_for('static', filename="pre-sn/run"+files+"/h_Nhit_12.png") }}" alt="Nhits" class="img-responsive center-block" >
           </div>
         </div>
 
@@ -206,10 +206,10 @@
           <div class="panel-body">
             <div class="row">
               <div class="col-md-6">
-		<img src="{{ url_for('static', filename="preSNdata/run" + files + "/h_R_12.png") }}" alt="Radial position" class="img-responsive">
+		<img src="{{ url_for('static', filename="pre-sn/run" + files + "/h_R_12.png") }}" alt="Radial position" class="img-responsive">
               </div>
               <div class="col-md-6">
-		<img src="{{ url_for('static', filename="preSNdata/run" + files + "/h_Z_12.png") }}" alt="Z position" class="img-responsive center-block">
+		<img src="{{ url_for('static', filename="pre-sn/run" + files + "/h_Z_12.png") }}" alt="Z position" class="img-responsive center-block">
               </div>
             </div>
           </div>
@@ -229,7 +229,7 @@
             <h3 class="panel-title">NHits</h3>
           </div>
           <div class="panel-body">
-	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/h_Nhit_"+files+".png") }}" alt="Nhits" class="img-responsive center-block" >
+	    <img src="{{ url_for('static', filename="pre-sn/run"+files+"/h_Nhit_"+files+".png") }}" alt="Nhits" class="img-responsive center-block" >
           </div>
         </div>
 	<div class="panel panel-default">
@@ -239,10 +239,10 @@
           <div class="panel-body">
             <div class="row">
               <div class="col-md-6">
-		<img src="{{ url_for('static', filename="preSNdata/run" + files + "/h_R_"+files+".png") }}" alt="Radial position" class="img-responsive">
+		<img src="{{ url_for('static', filename="pre-sn/run" + files + "/h_R_"+files+".png") }}" alt="Radial position" class="img-responsive">
               </div>
               <div class="col-md-6">
-		<img src="{{ url_for('static', filename="preSNdata/run" + files + "/h_Z_"+files+".png") }}" alt="Z position" class="img-responsive center-block">
+		<img src="{{ url_for('static', filename="pre-sn/run" + files + "/h_Z_"+files+".png") }}" alt="Z position" class="img-responsive center-block">
               </div>
             </div>
           </div>
@@ -260,7 +260,7 @@
             <h3 class="panel-title">NHits</h3>
           </div>
           <div class="panel-body">
-	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/gr_nevents_Nhit_100.png") }}" alt="Nhit trend" class="img-responsive center-block" >
+	    <img src="{{ url_for('static', filename="pre-sn/run"+files+"/gr_nevents_Nhit_100.png") }}" alt="Nhit trend" class="img-responsive center-block" >
           </div>
         </div>
 
@@ -271,10 +271,10 @@
           <div class="panel-body">
             <div class="row">
               <div class="col-md-6">
-		<img src="{{ url_for('static', filename="preSNdata/run" + files + "/gr_nevents_R_100.png") }}" alt="Radial position trend" class="img-responsive">
+		<img src="{{ url_for('static', filename="pre-sn/run" + files + "/gr_nevents_R_100.png") }}" alt="Radial position trend" class="img-responsive">
               </div>
               <div class="col-md-6">
-		<img src="{{ url_for('static', filename="preSNdata/run" + files + "/gr_nevents_Z_100.png") }}" alt="Z position trend" class="img-responsive center-block">
+		<img src="{{ url_for('static', filename="pre-sn/run" + files + "/gr_nevents_Z_100.png") }}" alt="Z position trend" class="img-responsive center-block">
               </div>
             </div>
           </div>
@@ -294,7 +294,7 @@
             <h3 class="panel-title">NHits</h3>
           </div>
           <div class="panel-body">
-	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/gr_nevents_Nhit_cand_100.png") }}" alt="Nhits trend" class="img-responsive center-block" >
+	    <img src="{{ url_for('static', filename="pre-sn/run"+files+"/gr_nevents_Nhit_cand_100.png") }}" alt="Nhits trend" class="img-responsive center-block" >
           </div>
         </div>
 
@@ -305,10 +305,10 @@
           <div class="panel-body">
             <div class="row">
               <div class="col-md-6">
-		<img src="{{ url_for('static', filename="preSNdata/run" + files + "/gr_nevents_R_cand_100.png") }}" alt="Radial position trend" class="img-responsive">
+		<img src="{{ url_for('static', filename="pre-sn/run" + files + "/gr_nevents_R_cand_100.png") }}" alt="Radial position trend" class="img-responsive">
               </div>
               <div class="col-md-6">
-		<img src="{{ url_for('static', filename="preSNdata/run" + files + "/gr_nevents_Z_cand_100.png") }}" alt="Z position trend" class="img-responsive center-block">
+		<img src="{{ url_for('static', filename="pre-sn/run" + files + "/gr_nevents_Z_cand_100.png") }}" alt="Z position trend" class="img-responsive center-block">
               </div>
             </div>
           </div>
@@ -328,7 +328,7 @@
             <h3 class="panel-title">dr between prompt candidates that pass L2 Nhit + FV cuts and delayed candidates that pass L2 Nhit + FV + L3 Nhit cuts</h3>
           </div>
           <div class="panel-body">
-	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/h_dr_FV55roi_12.png") }}" alt="Candidates dr" class="img-responsive center-block" >
+	    <img src="{{ url_for('static', filename="pre-sn/run"+files+"/h_dr_FV55roi_12.png") }}" alt="Candidates dr" class="img-responsive center-block" >
           </div>
         </div>
 	<div class="panel panel-default">
@@ -336,7 +336,7 @@
             <h3 class="panel-title">dt between prompt candidates that pass dr + L2 Nhit + FV cuts and delayed candidates that pass dr + L2 Nhit + FV + L2 Nhit cuts </h3>
           </div>
           <div class="panel-body">
-	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/h_dt_dr2_FV55roi_12.png") }}" alt="Candidates dt" class="img-responsive center-block" >
+	    <img src="{{ url_for('static', filename="pre-sn/run"+files+"/h_dt_dr2_FV55roi_12.png") }}" alt="Candidates dt" class="img-responsive center-block" >
           </div>
         </div>
 	<div class="panel panel-default">
@@ -344,7 +344,7 @@
             <h3 class="panel-title">Nhits of prompt candidates that pass dt + dr + L2 Nhit + FV cuts</h3>
           </div>
           <div class="panel-body">
-	    <img src="{{ url_for('static', filename="preSNdata/run"+files+"/h_Nhit_dt5_dr2_FV55roi_12.png") }}" alt="Prompt candidate Nhits" class="img-responsive center-block" >
+	    <img src="{{ url_for('static', filename="pre-sn/run"+files+"/h_Nhit_dt5_dr2_FV55roi_12.png") }}" alt="Prompt candidate Nhits" class="img-responsive center-block" >
           </div>
         </div>
       </div>
@@ -362,10 +362,10 @@
           <div class="panel-body">
             <div class="row">
               <div class="col-md-6">
-                <img src="{{ url_for('static', filename="preSNdata/run" + files + "/h_xy_" + files + ".png") }}" alt="xy histogram, alltime" class="img-responsive">
+                <img src="{{ url_for('static', filename="pre-sn/run" + files + "/h_xy_" + files + ".png") }}" alt="xy histogram, alltime" class="img-responsive">
               </div>
               <div class="col-md-6">
-                <img src="{{ url_for('static', filename="preSNdata/run" + files + "/h_rhoz_" + files + ".png") }}" alt="rho-z histogram, alltime" class="img-responsive center-block">
+                <img src="{{ url_for('static', filename="pre-sn/run" + files + "/h_rhoz_" + files + ".png") }}" alt="rho-z histogram, alltime" class="img-responsive center-block">
               </div>
             </div>
           </div>
@@ -382,10 +382,10 @@
           <div class="panel-body">
             <div class="row">
               <div class="col-md-6">
-                <img src="{{ url_for('static', filename="preSNdata/run" + files + "/h_dt_" + files + ".png") }}" alt="Coincidence dt histogram, alltime" class="img-responsive">
+                <img src="{{ url_for('static', filename="pre-sn/run" + files + "/h_dt_" + files + ".png") }}" alt="Coincidence dt histogram, alltime" class="img-responsive">
               </div>
               <div class="col-md-6">
-                <img src="{{ url_for('static', filename="preSNdata/run" + files + "/h_dr_" + files + ".png") }}" alt="Coincidence dr histogram, alltime" class="img-responsive center-block">
+                <img src="{{ url_for('static', filename="pre-sn/run" + files + "/h_dr_" + files + ".png") }}" alt="Coincidence dr histogram, alltime" class="img-responsive center-block">
               </div>
             </div>
           </div>

--- a/minard/templates/presn_run_detail.html
+++ b/minard/templates/presn_run_detail.html
@@ -1,0 +1,203 @@
+{% extends "layout.html" %}
+{% block title %}Pre-SN Run Detail{% endblock %}
+{% block head %}
+  {{ super() }}
+  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/pca.css') }}" media="screen">
+{% endblock %}
+{% block body %}
+  {{ super() }}
+
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12">
+        {{ subrun }}
+        {{ sub }}
+        <h2>PreSN Run {{ data["run"] }} details</h2>
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>Parameter</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Run</td>
+              <td>{{ data["run"] }}</td>
+            </tr>
+            <tr>
+              <td>SubRun</td>
+              <td>{{ data["subrun"] }}</td>
+            </tr>
+	    <tr>
+              <td>Significance</td>
+              <td>{{ data["significance"] }}</td>
+            </tr>
+	    <tr>
+	      <td>Flag</td>
+	      <td>{{ data["flag"] }}</td>
+	    </tr>
+	    <tr>
+	      <td>Duration [h]</td>
+	      <td>{{ data["duration"] }}</td>
+	    </tr>
+	    <tr>
+	      <td># Events</td>
+	      <td>{{ data["nevents"] }}</td>
+	    </tr>
+            <tr>
+              <td>Date</td>
+              <td>{{ data["date"] }}</td>
+            </tr>
+            <tr>
+              <td>Time</td>
+              <td>{{ data["time"] }}</td>
+            </tr>
+            <tr>
+              <td>Date UTC</td>
+              <td>{{ data["UTCdate"] }}</td>
+            </tr>
+            <tr>
+              <td>Time UTC</td>
+              <td>{{ data["UTCtime"] }}</td>
+            </tr>
+	    <tr>
+	      <td>Last event date</td>
+	      <td>{{ data["evdate"] }}</td>
+	    </tr>
+            <tr>
+              <td>Last event time</td>
+              <td>{{ data["evtime"] }}</td>
+            </tr>
+            <tr>
+              <td>Nhit delayed cut (high)</td>
+              <td>{{ data["cut_NHit_d_hi"] }}</td>
+            </tr>
+            <tr>
+              <td>Nhit delayed cut (low)</td>
+              <td>{{ data["cut_NHit_d_low"] }}</td>
+            </tr>
+            <tr>
+              <td>Nhit prompt cut (high)</td>
+              <td>{{ data["cut_NHit_p_hi"] }}</td>
+            </tr>
+            <tr>
+              <td>Nhit prompt cut (low)</td>
+              <td>{{ data["cut_NHit_p_low"] }}</td>
+            </tr>
+            <tr>
+              <td>Radius delayed cut</td>
+              <td>{{ data["cut_R_d"] }}</td>
+            </tr>
+            <tr>
+              <td>Radius prompt cut</td>
+              <td>{{ data["cut_R_p"] }}</td>
+            </tr>
+	    <tr>
+              <td>dt cut (high)</td>
+              <td>{{ data["cut_dt_hi"] }}</td>
+            </tr>
+	    <tr>
+              <td>dt cut (low)</td>
+              <td>{{ data["cut_dt_low"] }}</td>
+            </tr>
+            <tr>
+              <td>L3 Radius Cut</td>
+              <td>{{ data["cut_R_strict"] }}</td>
+            </tr>
+            <tr>
+              <td>L3 dt cut (high)</td>
+              <td>{{ data["cut_dt_strict"] }}</td>
+            </tr>
+            <tr>
+              <td>L3 time window Cut</td>
+              <td>{{ data["cut_timewindow"] }}</td>
+            </tr>
+            <tr>
+              <td>Assumed background rate</td>
+              <td>{{ data["bkg_rate"] }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-12">
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">Time series (full window duration)</h3>
+          </div>
+          <div class="panel-body">
+		<img src="{{ url_for('static', filename="presndata/run"+files+"/h_time_"+files+".png") }}" alt="Time series" class="img-responsive center-block" >
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-12">
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">Time series (run)</h3>
+          </div>
+          <div class="panel-body">
+		<img src="{{ url_for('static', filename="presndata/run"+files+"/"+files+"_t.png") }}" alt="Time series" class="img-responsive center-block" >
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-12">
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">NHits</h3>
+          </div>
+          <div class="panel-body">
+            <img src="{{ url_for('static', filename="presndata/run" + files + "/" + files + "_nhits.png") }}" alt="NHits histogram" class="img-responsive center-block">
+          </div>
+        </div>
+      </div>
+    </div>
+
+
+    <div class="row">
+      <div class="col-md-12">
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">Position</h3>
+          </div>
+          <div class="panel-body">
+            <div class="row">
+              <div class="col-md-6">
+                <img src="{{ url_for('static', filename="presndata/run" + files + "/" + files + "_xy.png") }}" alt="xy histogram" class="img-responsive">
+              </div>
+              <div class="col-md-6">
+                <img src="{{ url_for('static', filename="presndata/run" + files + "/" + files + "_rhoz.png") }}" alt="rho-z histogram" class="img-responsive">
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+    <div class="row">
+      <div class="col-md-12">
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">Coincidence Separation</h3>
+          </div>
+          <div class="panel-body">
+            <div class="row">
+              <div class="col-md-6">
+                <img src="{{ url_for('static', filename="presndata/run" + files + "/" + files + "_dt.png") }}" alt="Coincidence dt histogram" class="img-responsive">
+              </div>
+              <div class="col-md-6">
+                <img src="{{ url_for('static', filename="presndata/run" + files + "/" + files + "_dr.png") }}" alt="Coincidence dr histogram" class="img-responsive center-block">
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+{% endblock %}

--- a/minard/views.py
+++ b/minard/views.py
@@ -566,9 +566,6 @@ def burst():
     data, total, offset, limit = burst_f.load_burst_runs(offset, limit)
     return render_template( 'burst.html', data=data, total=total, offset=offset, limit=limit )
 
-
-
-
 @app.route('/presn')
 def presn(): # Can we call it the same??
     offset = request.args.get('offset',type=int)
@@ -578,14 +575,13 @@ def presn(): # Can we call it the same??
         start = request.args.get('start')
         end = request.args.get('end')
         if offset == None:
-            return redirect("burst?limit=%i&offset=0&search=%s&start=%s&end=%s" % (limit, search, start, end))
-        data, total, offset, limit = presn_f.load_bursts_search(search, start, end, offset, limit)
-        return render_template( 'burst.html', data=data, total=total, offset=offset, limit=limit, search=search, start=start, end=end)
+            return redirect("presn?limit=%i&offset=0&search=%s&start=%s&end=%s" % (limit, search, start, end))
+        data, total, offset, limit = presn_f.load_presn_search(search, start, end, offset, limit)
+        return render_template( 'presn.html', data=data, total=total, offset=offset, limit=limit, search=search, start=start, end=end)
     if offset == None:
-        return redirect("burst?limit=25&offset=0")
-    data, total, offset, limit = burst_f.load_burst_runs(offset, limit)
-    return render_template( 'burst.html', data=data, total=total, offset=offset, limit=limit )
-
+        return redirect("presn?limit=25&offset=0")
+    data, total, offset, limit = presn_f.load_presn_runs(offset, limit)
+    return render_template( 'presn.html', data=data, total=total, offset=offset, limit=limit )
 
 @app.route('/orca-session-logs')
 def orca_session_logs():
@@ -1354,6 +1350,11 @@ def pca_run_detail(run_number):
 @app.route('/burst_run_detail/<int:run_number>/<int:subrun>/<int:sub>')
 def burst_run_detail(run_number, subrun, sub):
     return render_template('burst_run_detail.html', data=burst_f.burst_run_detail(run_number, subrun, sub)[0], files=burst_f.burst_run_detail(run_number, subrun, sub)[1])
+
+#@app.route('/presn_run_detail/<int:run_number>/<int:subrun>/<int:sub>')
+@app.route('/presn_run_detail/<int:run_number>/<int:subrun>')
+def presn_run_detail(run_number, subrun):
+    return render_template('presn_run_detail.html', data=presn_f.presn_run_detail(run_number, subrun)[0], files=presn_f.presn_run_detail(run_number, subrun)[1])
 
 @app.route('/calibdq')
 def calibdq():

--- a/minard/views.py
+++ b/minard/views.py
@@ -1412,10 +1412,9 @@ def burst_form():
     burst_f.burst_form_upload(run_number, subrun, sub, tick, summary, note, name)
     return render_template('burst_run_detail_l3.html', data=burst_f.burst_run_detail(run_number, subrun, sub, 3)[0], files=burst_f.burst_run_detail(run_number, subrun, sub, 3)[1])
 
-
-@app.route('/presn_run_detail/<int:run_number>/<int:subrun>')
-def presn_run_detail(run_number, subrun):
-    return render_template('presn_run_detail.html', data=presn_f.presn_run_detail(run_number, subrun)[0], files=presn_f.presn_run_detail(run_number, subrun)[1])
+@app.route('/presn_run_detail/<int:run_number>')
+def presn_run_detail(run_number):
+    return render_template('presn_run_detail.html', data=presn_f.presn_run_detail(run_number)[0], files=presn_f.presn_run_detail(run_number)[1])
 
 
 @app.route('/calibdq')

--- a/minard/views.py
+++ b/minard/views.py
@@ -567,7 +567,7 @@ def burst():
     return render_template( 'burst.html', data=data, total=total, offset=offset, limit=limit )
 
 @app.route('/presn')
-def presn(): # Can we call it the same??
+def presn():
     offset = request.args.get('offset',type=int)
     limit = request.args.get('limit',default=25,type=int)
     search = request.args.get('search',type=str)
@@ -1351,7 +1351,6 @@ def pca_run_detail(run_number):
 def burst_run_detail(run_number, subrun, sub):
     return render_template('burst_run_detail.html', data=burst_f.burst_run_detail(run_number, subrun, sub)[0], files=burst_f.burst_run_detail(run_number, subrun, sub)[1])
 
-#@app.route('/presn_run_detail/<int:run_number>/<int:subrun>/<int:sub>')
 @app.route('/presn_run_detail/<int:run_number>/<int:subrun>')
 def presn_run_detail(run_number, subrun):
     return render_template('presn_run_detail.html', data=presn_f.presn_run_detail(run_number, subrun)[0], files=presn_f.presn_run_detail(run_number, subrun)[1])

--- a/minard/views.py
+++ b/minard/views.py
@@ -37,6 +37,7 @@ import gain_monitor
 import activity
 import scintillator_level
 import burst as burst_f
+import presn as presn_f
 from shifter_information import get_shifter_information, set_shifter_information, ShifterInfoForm, get_experts
 from run_list import golden_run_list
 from .polling import polling_runs, polling_info, polling_info_card, polling_check, get_cmos_rate_history, polling_summary, get_most_recent_polling_info, get_vmon, get_base_current_history, get_vmon_history
@@ -564,6 +565,27 @@ def burst():
         return redirect("burst?limit=25&offset=0")
     data, total, offset, limit = burst_f.load_burst_runs(offset, limit)
     return render_template( 'burst.html', data=data, total=total, offset=offset, limit=limit )
+
+
+
+
+@app.route('/presn')
+def presn(): # Can we call it the same??
+    offset = request.args.get('offset',type=int)
+    limit = request.args.get('limit',default=25,type=int)
+    search = request.args.get('search',type=str)
+    if search is not None:
+        start = request.args.get('start')
+        end = request.args.get('end')
+        if offset == None:
+            return redirect("burst?limit=%i&offset=0&search=%s&start=%s&end=%s" % (limit, search, start, end))
+        data, total, offset, limit = presn_f.load_bursts_search(search, start, end, offset, limit)
+        return render_template( 'burst.html', data=data, total=total, offset=offset, limit=limit, search=search, start=start, end=end)
+    if offset == None:
+        return redirect("burst?limit=25&offset=0")
+    data, total, offset, limit = burst_f.load_burst_runs(offset, limit)
+    return render_template( 'burst.html', data=data, total=total, offset=offset, limit=limit )
+
 
 @app.route('/orca-session-logs')
 def orca_session_logs():


### PR DESCRIPTION
Pre-supernova information is visible with this update:
- Pre-Supernova tab added in the "Supernova" drop-down menu
- This tab leads to an overview page of pre-SN information grabbed from couchdb, that includes:
   - Pre-supernova information for the past 100 h, shown in table format
   - A search bar allows searches of data by run or date, data must fall within the 100 h time limit to be shown
- Clicking on a run number for any pre-SN data in the overview page leads to a detailed view page, that includes:
   - Information specific to the run, and to a pre-defined pre-supernova time window
   - Data in tables comes from couchdb files
   - Plots are loaded from a directory mounted to the minard server