### PR TITLE
SN burt trigger: added SN alarm related data

### DIFF
--- a/minard/templates/burst_run_detail_l3.html
+++ b/minard/templates/burst_run_detail_l3.html
@@ -132,6 +132,16 @@
                       {% endif %}
                       <td># of clean high NHit events, % of surviving events</td>
                     </tr>
+                    <tr>
+                      <td>Time of first HN event</td>
+                      <td>{{ data["firstHighUTC"] }}</td>
+                      <td>Time of first event above high NHit threshold (SN alarm)</td>
+                    </tr>
+                    <tr>
+                      <td>Nanoseconds of first HN event</td>
+                      <td>{{ data["nanos"] }}</td>
+                      <td>Nanoseconds (SN alarm)</td>
+                    </tr>
                   </tbody>
                 </table>
               </div>


### PR DESCRIPTION
Just a small update for the Supernova Burst trigger monitoring page. Specifically, the burst detail page for L3 burst now includes data relating to the supernova alarm: the time of the first high NHit event and the nanoseconds associated with the time.