### PR TITLE
Run-Selection Page Fixes and Improvements

### DIFF
--- a/minard/RSTools.py
+++ b/minard/RSTools.py
@@ -29,6 +29,22 @@ def file_list_form_builder(formobj, runlists, data):
     else:
         return FileListForm()
 
+def file_pass_form_builder(formobj, display_info):
+    class FilePassForm(Form):
+        pass
+
+    for (i, criteria) in enumerate(display_info.keys()):
+
+        setattr(FilePassForm, 'name', StringField('Name', [validators.Length(min=1), validators.InputRequired(), validators.Regexp('[A-Za-z0-9\s]{1,}', message='First and second name required.')]))
+        setattr(FilePassForm, 'comment', StringField('Comment', [validators.InputRequired()]))
+        setattr(FilePassForm, 'password', PasswordField('Password', [validators.InputRequired()]))
+
+    if formobj != -1:
+        return FilePassForm(formobj)
+    else:
+        return FilePassForm()
+
+
 def get_current_lists_run(run):
     conn = engine.connect()
     result = conn.execute("SELECT list FROM evaluated_runs WHERE run=%s" % (run,))
@@ -114,8 +130,6 @@ def decide_replace_table(first_table, second_table, version=None):
     number, then on timestamp'''
 
     if second_table['meta_data']['version'] == first_table['meta_data']['version']:
-        first_time = first_table['timestamp']
-        second_time = second_table['timestamp']
         dt = second_table['timestamp'] - first_table['timestamp']
         dt_seconds = dt.days*3600*12 + dt.seconds
 
@@ -162,8 +176,10 @@ def get_RS_reports(criteria=None, run_min=None, run_max=None, limit=None):
     if limit is not None:
         query += " LIMIT %d" % (limit)
 
+    c = False
     try:
         conn = engine_nl.connect()
+        c = True
         resultQuery = conn.execute(query)
 
         rs_tables_list = []
@@ -204,7 +220,8 @@ def get_RS_reports(criteria=None, run_min=None, run_max=None, limit=None):
         return False
     
     finally:
-        conn.close()
+        if c:
+            conn.close()
 
 def get_filtered_RS_tables(run_min, run_max, min_runTime, max_runTime, offset, limit, result, criteria):
     '''Download run-selection tables in range, and keep only ones with desired result'''
@@ -545,8 +562,10 @@ def get_neighbouring_runs(runNum):
 
     run_neighbours = [False, False]
 
+    c = False
     try:
         conn = engine_nl.connect()
+        c = True
 
         resultQuery_prev = conn.execute(query_prev)
         for row in resultQuery_prev.fetchall():
@@ -562,7 +581,8 @@ def get_neighbouring_runs(runNum):
         return run_neighbours
     
     finally:
-        conn.close()
+        if c:
+            conn.close()
     
 
 def format_data(runNum):

--- a/minard/RSTools.py
+++ b/minard/RSTools.py
@@ -493,11 +493,10 @@ def format_rs_results(rs_tables, crit_tables):
                     elif isinstance(notes[check], dict):
                         display_info[criteria]['rs_modules'][rs_module]['checks'][check]['Value'] = OrderedDict()
                         for subcheck in notes[check]:
-                            string = subcheck
                             if isinstance(notes[check][subcheck], float):
-                                string += (': %.2f' % notes[check][subcheck])
+                                string = ('%.2f' % notes[check][subcheck])
                             else:
-                                string += (': %s' % (notes[check][subcheck]))
+                                string = notes[check][subcheck]
                             display_info[criteria]['rs_modules'][rs_module]['checks'][check]['Value'][subcheck] = string
                     else:
                         display_info[criteria]['rs_modules'][rs_module]['checks'][check]['Value'] = notes[check]

--- a/minard/RSTools.py
+++ b/minard/RSTools.py
@@ -369,6 +369,8 @@ def get_criteria_tables(runNum, crit_version):
     return crit_tables
 
 def format_general_info(rs_tables, criteria_list):
+    '''Collect information for "General Information" section of the page'''
+
     general_info = OrderedDict()
     first_table = rs_tables[criteria_list[0]]  # Take first table for general information (no particular reason)
 
@@ -399,7 +401,40 @@ def format_general_info(rs_tables, criteria_list):
 
     return general_info
 
+def result_logic(obj):
+    '''
+    Return result (True, False, None) of object.
+    Checks inside object recursively.
+    If any element is False, return False,
+    else if any any element is None, return None,
+    else return True (i.e. if all are True).
+    '''
+
+    result = True
+    if isinstance(obj, list):
+        for sub_obj in obj:
+            res = result_logic(sub_obj)
+            if res == False:
+                return False
+            elif res == None:
+                result = None
+    elif isinstance(obj, dict):
+        for key in obj:
+            res = result_logic(obj[key])
+            if res == False:
+                return False
+            elif res == None:
+                result = None
+    elif obj == True or obj == False:
+        result = obj
+    else:
+        result = None
+
+    return result
+
 def format_rs_results(rs_tables, crit_tables):
+    '''Collect information for the "Run Selection Results" section of the page'''
+
     display_info = OrderedDict()
     for criteria in rs_tables:
         # A collapsable header for each criteria tag
@@ -439,9 +474,10 @@ def format_rs_results(rs_tables, crit_tables):
                     display_info[criteria]['rs_modules'][rs_module]['checks'][check] = OrderedDict()
                     # Get check and overall result
                     display_info[criteria]['rs_modules'][rs_module]['checks'][check]['Check'] = check
-                    if results[check] == True:
+                    overall_res = result_logic(results[check])
+                    if overall_res == True:
                         display_info[criteria]['rs_modules'][rs_module]['checks'][check]['Result'] = "Pass"
-                    elif results[check] == False:
+                    elif overall_res == False:
                         display_info[criteria]['rs_modules'][rs_module]['checks'][check]['Result'] = "Fail"
                     else:
                         display_info[criteria]['rs_modules'][rs_module]['checks'][check]['Result'] = "Purgatory"

--- a/minard/templates/runselection.html
+++ b/minard/templates/runselection.html
@@ -29,13 +29,14 @@
                 <th> Limit: </th>
                 <th> Select Run: </th>
                 <th> Run Range: </th>
+                <th> Date Range (yyyy-mm-dd): </th>
                 <th> Result: </th>
                 <th> Criteria: </th>
                 <th> </th>
             </tr>
             <tr>
                 <!-- Number of displayed runs drop-down -->
-                <th> <select id="lim" onchange="get_limit(this.value, {{offset}}, crit.value, res.value, run.value, low.value, high.value);">
+                <th> <select id="lim" onchange="get_limit(this.value, {{offset}}, crit.value, res.value, run.value, low.value, high.value, y_low.value, m_low.value, d_low.value, y_high.value, m_high.value, d_high.value);">
                         <option selected value="{{limit}}">{{limit}}</option>
                         {% for n in [10, 25, 50, 100, 500] %}
                             {% if n != limit %}
@@ -46,13 +47,22 @@
                 </th>
                 
                 <!-- Run number inputs -->
-                <th> <input style="margin-bottom: 30px; width: 80px;" type="text" id="run" value={{selected_run}} onKeyDown="if(event.keyCode==13) get_limit(lim.value, 0, crit.value, res.value, this.value, low.value, high.value);"></input> </th>
-                <th> <input style="margin-bottom: 30px; width: 80px;" type="text" id="low" value={{run_range_low}} onKeyDown="if(event.keyCode==13) get_limit(lim.value, 0, crit.value, res.value, run.value, this.value, high.value);"></input>
-                    - <input style="margin-bottom: 30px; width: 80px;" type="text" id="high" value={{run_range_high}} onKeyDown="if(event.keyCode==13) get_limit(lim.value, 0, crit.value, res.value, run.value, low.value, this.value);"></input></th>
+                <th> <input style="margin-bottom: 30px; width: 80px;" type="text" id="run" value={{selected_run}} onKeyDown="if(event.keyCode==13) get_limit(lim.value, 0, crit.value, res.value, this.value, low.value, high.value, y_low.value, m_low.value, d_low.value, y_high.value, m_high.value, d_high.value);"></input> </th>
+                <th> <input style="margin-bottom: 30px; width: 80px;" type="text" id="low" value={{run_range_low}} onKeyDown="if(event.keyCode==13) get_limit(lim.value, 0, crit.value, res.value, run.value, this.value, high.value, y_low.value, m_low.value, d_low.value, y_high.value, m_high.value, d_high.value);"></input>
+                    - <input style="margin-bottom: 30px; width: 80px;" type="text" id="high" value={{run_range_high}} onKeyDown="if(event.keyCode==13) get_limit(lim.value, 0, crit.value, res.value, run.value, low.value, this.value, y_low.value, m_low.value, d_low.value, y_high.value, m_high.value, d_high.value);"></input></th>
+                <th>
+                    <input style="margin-bottom: 30px; width: 40px;" type="text" id="y_low" value={{year_low}} onKeyDown="if(event.keyCode==13) get_limit(lim.value, 0, crit.value, res.value, run.value, low.value, high.value, this.value, m_low.value, d_low.value, y_high.value, m_high.value, d_high.value);"></input>
+                    <input style="margin-bottom: 30px; width: 25px;" type="text" id="m_low" value={{month_low}} onKeyDown="if(event.keyCode==13) get_limit(lim.value, 0, crit.value, res.value, run.value, low.value, high.value, y_low.value, this.value, d_low.value, y_high.value, m_high.value, d_high.value);"></input>
+                    <input style="margin-bottom: 30px; width: 25px;" type="text" id="d_low" value={{day_low}} onKeyDown="if(event.keyCode==13) get_limit(lim.value, 0, crit.value, res.value, run.value, low.value, high.value, y_low.value, m_low.value, this.value, y_high.value, m_high.value, d_high.value);"></input>
+                    -
+                    <input style="margin-bottom: 30px; width: 40px;" type="text" id="y_high" value={{year_high}} onKeyDown="if(event.keyCode==13) get_limit(lim.value, 0, crit.value, res.value, run.value, low.value, high.value, y_low.value, m_low.value, d_low.value, this.value, m_high.value, d_high.value);"></input>
+                    <input style="margin-bottom: 30px; width: 25px;" type="text" id="m_high" value={{month_high}} onKeyDown="if(event.keyCode==13) get_limit(lim.value, 0, crit.value, res.value, run.value, low.value, high.value, y_low.value, m_low.value, d_low.value, y_high.value, this.value, d_high.value);"></input>
+                    <input style="margin-bottom: 30px; width: 25px;" type="text" id="d_high" value={{day_high}} onKeyDown="if(event.keyCode==13) get_limit(lim.value, 0, crit.value, res.value, run.value, low.value, high.value, y_low.value, m_low.value, d_low.value, y_high.value, m_high.value, this.value);"></input>
+                </th>
 
                 <!-- Run-selection outcome drop-down -->
                 <th>
-                    <select id="res" onchange="get_limit(lim.value, {{offset}}, crit.value, this.value, run.value, low.value, high.value);">
+                    <select id="res" onchange="get_limit(lim.value, {{offset}}, crit.value, this.value, run.value, low.value, high.value, y_low.value, m_low.value, d_low.value, y_high.value, m_high.value, d_high.value);">
                     <option selected value="{{result}}">{{result}}</option>
                     {% for n in ["All", "Pass", "Fail", "Purgatory"] %}
                         {% if n != result %}
@@ -64,7 +74,7 @@
 
                 <!-- Criteria drop-down -->
                 <th>
-                    <select id="crit" onchange="get_limit(lim.value, {{offset}}, this.value, res.value, run.value, low.value, high.value);">
+                    <select id="crit" onchange="get_limit(lim.value, {{offset}}, this.value, res.value, run.value, low.value, high.value, y_low.value, m_low.value, d_low.value, y_high.value, m_high.value, d_high.value);">
                     <option selected value="{{criteria}}">{{criteria}}</option>
                     {% for n in ["scintillator", "partial_fill_antinu", "partial_fill", "water"] %}  <!-- FIXME: make this dynamic !-->
                         {% if n != criteria %}
@@ -77,14 +87,14 @@
                 <!-- Back and Next buttons -->
                 {% if offset == 0 %}
                     <th> <button type="submit" class="btn2" disabled>Back</button> </th>
-                    <th> <button type="submit" class="btn2" onclick="get_limit(lim.value, lim.value, crit.value, res.value, run.value, low.value, high.value)">Next</button> </th>
+                    <th> <button type="submit" class="btn2" onclick="get_limit(lim.value, lim.value, crit.value, res.value, run.value, low.value, high.value, y_low.value, m_low.value, d_low.value, y_high.value, m_high.value, d_high.value)">Next</button> </th>
                 {% else %}
                     {% if limit > offset %}
                         <th> <button type="submit" class="btn2" disabled>Back</button> </th>
                     {% else %}
-                        <th> <button type="submit" class="btn2" onclick="get_limit(lim.value, {{offset - limit}}, crit.value, res.value, run.value, low.value, high.value)">Back</button> </th>
+                        <th> <button type="submit" class="btn2" onclick="get_limit(lim.value, {{offset - limit}}, crit.value, res.value, run.value, low.value, high.value, y_low.value, m_low.value, d_low.value, y_high.value, m_high.value, d_high.value)">Back</button> </th>
                     {% endif %}
-                    <th> <button type="submit" class="btn2" onclick="get_limit(lim.value, {{offset + limit}}, crit.value, res.value, run.value, low.value, high.value)">Next</button> </th>
+                    <th> <button type="submit" class="btn2" onclick="get_limit(lim.value, {{offset + limit}}, crit.value, res.value, run.value, low.value, high.value, y_low.value, m_low.value, d_low.value, y_high.value, m_high.value, d_high.value)">Next</button> </th>
                 {% endif %}
             </tr>
             </table>
@@ -97,6 +107,7 @@
                         <th>Result</th>
                         <th>Criteria</th>
                         <th>Overlord</th>
+                        <th>Run Start</th>
                         <th>Last review</th>
                     </tr>
                 </thead>
@@ -123,6 +134,7 @@
                                 {% endif %}
                                 <td>{{ run_info[run_number][criteria]["meta_data"]["index"] }}</td>
                                 <td>{{ run_info[run_number][criteria]["name"] }}</td>
+                                <td>{{ run_info[run_number][criteria]["run_start"] }}</td>
                                 <td>{{ run_info[run_number][criteria]["timestamp"] }}</td>
                             </tr> 
                         {% endfor %}
@@ -134,7 +146,8 @@
 {% endblock %}
 {% block script %}
   <script>
-    function get_limit(limit, offset, criteria, result, selected_run, run_range_low, run_range_high){
+    function get_limit(limit, offset, criteria, result, selected_run, run_range_low, run_range_high,
+                       year_low, month_low, day_low, year_high, month_high, day_high) {
       params = {};
       params["limit"] = limit;
       params["offset"] = offset;
@@ -143,6 +156,12 @@
       params["selected_run"] = selected_run;
       params["run_range_low"] = run_range_low;
       params["run_range_high"] = run_range_high;
+      params["year_low"] = year_low;
+      params["month_low"] = month_low;
+      params["day_low"] = day_low;
+      params["year_high"] = year_high;
+      params["month_high"] = month_high;
+      params["day_high"] = day_high;
       window.location.replace($SCRIPT_ROOT + "/runselection?" + $.param(params));
     }
   </script>

--- a/minard/templates/runselection.html
+++ b/minard/templates/runselection.html
@@ -107,8 +107,8 @@
                         <th>Result</th>
                         <th>Criteria</th>
                         <th>Overlord</th>
-                        <th>Run Start</th>
-                        <th>Last review</th>
+                        <th>Run Start (ET)</th>
+                        <th>Last review (ET)</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/minard/templates/runselection_run.html
+++ b/minard/templates/runselection_run.html
@@ -13,6 +13,11 @@
         margin: 4px 2px;
         cursor: pointer;
     }
+    .right_align {
+      float: right;
+      vertical-align: top;
+      margin-left: 5px;
+    }
   </style>
 {% endblock %}
 {% block body %}
@@ -109,18 +114,28 @@
                 <!-- Collapsable header title for criteria tag -->
                 <div class="panel-heading">
                   <h4 id="title-{{criteria}}" class="panel-title">
-                    <a data-toggle="collapse" href="#collapse{{criteria}}">
-                      {% if display_info[criteria]["criteria_result"] == true %}
-                        <b><font color="green">{{ criteria }}</font></b>
-                      {% elif display_info[criteria]["criteria_result"] == false %}
-                        <b><font color="red">{{ criteria }}</font></b>
-                      {% else %}
-                        <b>{{ criteria }}</b>
-                      {% endif %}
-                    </a>
+                    <div>
+                      <a data-toggle="collapse" href="#collapse{{criteria}}">
+                        {% if display_info[criteria]["criteria_result"] == true %}
+                          <b><font color="green">{{ criteria }}</font></b>
+                        {% elif display_info[criteria]["criteria_result"] == false %}
+                          <b><font color="red">{{ criteria }}</font></b>
+                        {% else %}
+                          <b>{{ criteria }}</b>
+                        {% endif %}
+                      </a>
+                      <!-- Add button to pass run manually: opens pop-up window (coded at the end to the Body block) -->
+                      <div class="right_align">
+                        {% if display_info[criteria]["criteria_result"] == true %}
+                          <button type="button" class="btn btn-info btn-sm" data-toggle="modal" disabled>Pass</button>
+                        {% else %}
+                          <button type="button" class="btn btn-info btn-sm" data-toggle="modal" data-target="#myOutput{{ criteria }}">Pass</button>
+                        {% endif %}
+                      </div>
+                    </div>
                   </h4>
                 </div>
-      
+
                 <!-- Collapsable body for criteria tag -->
                 <div id="collapse{{criteria}}" class="panel-collapse collapse out">
                   <div class="panel-body" id="{{criteria}}">
@@ -292,54 +307,54 @@
           <div class="col-md-6">
             {% for i in range((lists|length/2)|round|int) %}
             <tr>
-              {{ form_checkbox(form[lists[i]]) }}
+              {{ form_checkbox(list_form[lists[i]]) }}
             </tr>
             {% endfor %}
           </div>
           <div class="col-md-6">
             {% for i in range((lists|length/2)|round|int, lists|length) %}
             <tr>
-              {{ form_checkbox(form[lists[i]]) }}
+              {{ form_checkbox(list_form[lists[i]]) }}
             </tr>
             {% endfor %}
           </div>
           <div class="col-md-12">
-            {% if form.name.errors %}
+            {% if list_form.name.errors %}
               <div class="form-group has-error">
             {% else %}
               <div class="form-group">
             {% endif %}
-            <label for="name">{{ form.name.label }}</label>
-            <input type="text" class="form-control" name="{{ form.name.name }}" placeholder="Dr P. L. Ace Holder" {% if form.name.data %}value="{{ form.name.data }}"{% endif %}></input>
-            {% if form.name.errors %}
-              {% for error in form.name.errors %}
+            <label for="name">{{ list_form.name.label }}</label>
+            <input type="text" class="form-control" name="{{ list_form.name.name }}" placeholder="Dr P. L. Ace Holder" {% if list_form.name.data %}value="{{ list_form.name.data }}"{% endif %}></input>
+            {% if list_form.name.errors %}
+              {% for error in list_form.name.errors %}
                   <span class="help-block">{{ error }}</span>
               {% endfor %}
             {% endif %}
           </div>
           <div>
-            {% if form.comment.errors %}
+            {% if list_form.comment.errors %}
               <div class="form-group has-error">
             {% else %}
               <div class="form-group">
             {% endif %}
-            <label for="comment">{{ form.comment.label }}</label>
-            <input type="text" class="form-control" name="{{ form.comment.name }}" placeholder="Comment (apostrophes and quotation marks are removed)" {% if form.comment.data %}value="{{ form.comment.data }}"{% endif %}></input>
-            {% if form.comment.errors %}
-              {% for error in form.comment.errors %}
+            <label for="comment">{{ list_form.comment.label }}</label>
+            <input type="text" class="form-control" name="{{ list_form.comment.name }}" placeholder="Comment (apostrophes and quotation marks are removed)" {% if list_form.comment.data %}value="{{ list_form.comment.data }}"{% endif %}></input>
+            {% if list_form.comment.errors %}
+              {% for error in list_form.comment.errors %}
                   <span class="help-block">{{ error }}</span>
               {% endfor %}
             {% endif %}
           </div>
-          {% if form.password.errors %}
+          {% if list_form.password.errors %}
             <div class="form-group has-error">
           {% else %}
             <div class="form-group">
           {% endif %}
-          <label for="info">{{ form.password.label }}</label>
-          <input type="password" class="form-control" name="{{ form.password.name }}" placeholder="Password"></input>
-          {% if form.password.errors %}
-              {% for error in form.password.errors %}
+          <label for="info">{{ list_form.password.label }}</label>
+          <input type="password" class="form-control" name="{{ list_form.password.name }}" placeholder="Password"></input>
+          {% if list_form.password.errors %}
+              {% for error in list_form.password.errors %}
                   <span class="help-block">{{ error }}</span>
               {% endfor %}
           {% endif %}
@@ -353,7 +368,38 @@
       <div class="col-md-12">
       </div>
     </div>
-  {% endblock %}
+
+  <!-- Write pop-up window to pass run -->
+  {% for criteria in display_info.keys() %}
+    <!-- Modal -->
+    <div class="modal fade" id="myOutput{{ criteria }}" role="dialog">
+      <div class="modal-dialog modal-lg">
+  
+        <!-- Modal content-->
+        <div class="modal-content">
+
+          <!-- Window title -->
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal">&times;</button>
+            <h4 class="modal-title">Pass Run for {{ criteria }} Criteria </h4>
+          </div>
+
+          <!-- Window body -->
+          <div class="modal-body">
+            <!-- <form action="{{ url_for('runselection_run', run_number=run_number)}}" method="POST" role="form" id="">
+
+            </form> -->
+          </div>
+
+          <!-- <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+          </div> -->
+        </div>
+  
+      </div>
+    </div>
+  {% endfor %}
+{% endblock %}
 
 {% block script %}
   <script src="{{ url_for('static', filename='js/burst_form.js') }}"></script>

--- a/minard/templates/runselection_run.html
+++ b/minard/templates/runselection_run.html
@@ -3,12 +3,35 @@
 {% block head %}
   {{ super() }}
   <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/pca.css') }}" media="screen">
+  <style>
+    .btn2 {
+        background-color: #228B22;
+        padding: 6px 6px;
+        color: white;
+        text-align: center;
+        font-size: 14px;
+        margin: 4px 2px;
+        cursor: pointer;
+    }
+  </style>
 {% endblock %}
 {% block body %}
   {{ super() }}
 
   <!-- Start Page -->
   <div class="container">
+    <th>
+      {% if run_prev_next[0] == False %}
+        <button type="submit" class="btn2" disabled>Back</button>
+      {% else %}
+        <button type="submit" class="btn2" onclick="change_page({{run_prev_next[0]}})">Back</button>
+      {% endif %}
+      {% if run_prev_next[1] == False %}
+        <button type="submit" class="btn2" disabled>Next</button>
+      {% else %}
+        <button type="submit" class="btn2" onclick="change_page({{run_prev_next[1]}})">Next</button>
+      {% endif %}
+    </th>
 
     <!-- Page Title -->
     <div class="row">
@@ -334,4 +357,9 @@
 
 {% block script %}
   <script src="{{ url_for('static', filename='js/burst_form.js') }}"></script>
+  <script>
+    function change_page(run_num) {
+      window.location.replace($SCRIPT_ROOT + "/runselection_run/" + String(run_num));
+    }
+  </script>
 {% endblock %}

--- a/minard/templates/runselection_run.html
+++ b/minard/templates/runselection_run.html
@@ -121,15 +121,20 @@
                         {% elif display_info[criteria]["criteria_result"] == false %}
                           <b><font color="red">{{ criteria }}</font></b>
                         {% else %}
-                          <b>{{ criteria }}</b>
+                          <b><font color="black">{{ criteria }}</font></b>
                         {% endif %}
                       </a>
                       <!-- Add button to pass run manually: opens pop-up window (coded at the end to the Body block) -->
                       <div class="right_align">
                         {% if display_info[criteria]["criteria_result"] == true %}
-                          <button type="button" class="btn btn-info btn-sm" data-toggle="modal" disabled>Pass</button>
+                          <button type="button" class="btn btn-success btn-sm" data-toggle="modal" disabled>Pass</button>
+                          <button type="button" class="btn btn-danger btn-sm" data-toggle="modal" data-target="#window{{ criteria-}}-fail">Fail</button>
+                        {% elif display_info[criteria]["criteria_result"] == false %}
+                          <button type="button" class="btn btn-success btn-sm" data-toggle="modal" data-target="#window{{ criteria-}}-pass">Pass</button>
+                          <button type="button" class="btn btn-danger btn-sm" data-toggle="modal" disabled>Fail</button>
                         {% else %}
-                          <button type="button" class="btn btn-info btn-sm" data-toggle="modal" data-target="#myOutput{{ criteria }}">Pass</button>
+                          <button type="button" class="btn btn-success btn-sm" data-toggle="modal" data-target="#window{{ criteria-}}-pass">Pass</button>
+                          <button type="button" class="btn btn-danger btn-sm" data-toggle="modal" data-target="#window{{ criteria }}-fail">Fail</button>
                         {% endif %}
                       </div>
                     </div>
@@ -152,7 +157,12 @@
                                     {% if display_info[criteria]["rs_modules"][rs_module]["module_result"] == true %}
                                       <font color="green">{{ rs_module }}</font>
                                     {% elif display_info[criteria]["rs_modules"][rs_module]["module_result"] == false %}
-                                      <font color="red">{{ rs_module }}</font>
+                                      <!-- If overall run result is purgatory, show failed module results as purgatory too -->
+                                      {% if display_info[criteria]["criteria_result"] == None %}
+                                        {{ rs_module }}
+                                      {% else %}
+                                        <font color="red">{{ rs_module }}</font>
+                                      {% endif %}
                                     {% else %}
                                       {{ rs_module }}
                                     {% endif %}
@@ -187,7 +197,12 @@
                                             {% if display_info[criteria]["rs_modules"][rs_module]["checks"][check]["Result"] == "Pass" %}
                                               <tr class="bg-success">
                                             {% elif display_info[criteria]["rs_modules"][rs_module]["checks"][check]["Result"] == "Fail" %}
-                                              <tr class="bg-danger">
+                                              <!-- If overall run result is purgatory, show failed checks as purgatory too -->
+                                              {% if display_info[criteria]["criteria_result"] == None %}
+                                                <tr>
+                                              {% else %}
+                                                <tr class="bg-danger">
+                                              {% endif %}
                                             {% else %}
                                               <tr>
                                             {% endif %}
@@ -380,90 +395,109 @@
   <!-- Write pop-up window to pass run -->
   {% if display_info != False %}
     {% for criteria in display_info.keys() %}
-      <!-- Modal -->
-      <div class="modal fade" id="myOutput{{ criteria }}" role="dialog">
-        <div class="modal-dialog modal-lg">
-    
-          <!-- Modal content-->
-          <div class="modal-content">
+      {% for action in ['pass', 'fail'] %}
+        <!-- Modal -->
+        <div class="modal fade" id="window{{ criteria }}-{{action}}" role="dialog">
+          <div class="modal-dialog modal-lg">
+      
+            <!-- Modal content-->
+            <div class="modal-content">
 
-            <!-- Window title -->
-            <div class="modal-header">
-              <button type="button" class="close" data-dismiss="modal">&times;</button>
-              <h4 class="modal-title">Manually Pass Run for {{ criteria }} Criteria </h4>
-            </div>
+              <!-- Window title -->
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                <h4 class="modal-title">Manually Pass Run for {{ criteria }} Criteria </h4>
+              </div>
 
-            <!-- Window body -->
-            <div class="modal-body">
-              <form action="{{ url_for('runselection_run', run_number=run_number)}}" method="POST" role="form">
-                  <!-- Name entry -->
-                  {% if pass_form.name.errors %}
-                    <div class="form-group has-error">
-                  {% else %}
-                    <div class="form-group">
-                  {% endif %}
-                    <label for="name">{{ pass_form.name.label }}</label>
-                    <input type="text" class="form-control" name="{{ pass_form.name.name }}" placeholder="Dr P. L. Ace Holder" {% if pass_form.name.data %}value="{{ pass_form.name.data }}"{% endif %}></input>
-                  {% if pass_form.name.errors %}
-                    {% for error in pass_form.name.errors %}
-                        <span class="help-block">{{ error }}</span>
-                    {% endfor %}
-                  {% endif %}
-                    </div>
-                  <!-- Comment entry -->
-                  {% if pass_form.comment.errors %}
-                    <div class="form-group has-error">
-                  {% else %}
-                    <div class="form-group">
-                  {% endif %}
-                    <label for="comment">{{ pass_form.comment.label }}</label>
-                    <input type="text" class="form-control" name="{{ pass_form.comment.name }}" placeholder="Comment (apostrophes and quotation marks are removed)" {% if pass_form.comment.data %}value="{{ pass_form.comment.data }}"{% endif %}></input>
-                  {% if pass_form.comment.errors %}
-                    {% for error in pass_form.comment.errors %}
-                        <span class="help-block">{{ error }}</span>
-                    {% endfor %}
-                  {% endif %}
-                    </div>
-                  <!-- Criteria -->
-                  {% if pass_form.criteria.errors %}
-                    <div class="form-group has-error">
-                  {% else %}
-                    <div class="form-group">
-                  {% endif %}
-                    <label for="criteria">{{ pass_form.criteria.label }}</label>
-                    <input type="text" class="form-control" name="{{ pass_form.criteria.name }}" placeholder="{{ criteria }}" {% if pass_form.criteria.data %}value="{{ pass_form.criteria.data }}"{% endif %}></input>
-                  {% if pass_form.criteria.errors %}
-                    {% for error in pass_form.criteria.errors %}
-                        <span class="help-block">{{ error }}</span>
-                    {% endfor %}
-                  {% endif %}
-                    </div>
-                  <!-- Password entry -->
-                  {% if pass_form.password.errors %}
-                    <div class="form-group has-error">
-                  {% else %}
-                    <div class="form-group">
-                  {% endif %}
-                    <label for="info">{{ pass_form.password.label }}</label>
-                    <input type="password" class="form-control" name="{{ pass_form.password.name }}" placeholder="Password"></input>
-                  {% if pass_form.password.errors %}
-                      {% for error in pass_form.password.errors %}
+              <!-- Window body -->
+              <div class="modal-body">
+                <form action="{{ url_for('runselection_run', run_number=run_number)}}" method="POST" role="form">
+                    <!-- Name entry -->
+                    {% if pass_form.name.errors %}
+                      <div class="form-group has-error">
+                    {% else %}
+                      <div class="form-group">
+                    {% endif %}
+                      <label for="name">{{ pass_form.name.label }}</label>
+                      <input type="text" class="form-control" name="{{ pass_form.name.name }}" placeholder="Dr P. L. Ace Holder" {% if pass_form.name.data %}value="{{ pass_form.name.data }}"{% endif %}></input>
+                    {% if pass_form.name.errors %}
+                      {% for error in pass_form.name.errors %}
                           <span class="help-block">{{ error }}</span>
                       {% endfor %}
-                  {% endif %}
+                    {% endif %}
+                      </div>
+                    <!-- Comment entry -->
+                    {% if pass_form.comment.errors %}
+                      <div class="form-group has-error">
+                    {% else %}
+                      <div class="form-group">
+                    {% endif %}
+                      <label for="comment">{{ pass_form.comment.label }}</label>
+                      <input type="text" class="form-control" name="{{ pass_form.comment.name }}" placeholder="Comment (apostrophes and quotation marks are removed)" {% if pass_form.comment.data %}value="{{ pass_form.comment.data }}"{% endif %}></input>
+                    {% if pass_form.comment.errors %}
+                      {% for error in pass_form.comment.errors %}
+                          <span class="help-block">{{ error }}</span>
+                      {% endfor %}
+                    {% endif %}
+                      </div>
+                    <!-- Criteria -->
+                    {% if pass_form.criteria.errors %}
+                      <div class="form-group has-error">
+                    {% else %}
+                      <div class="form-group">
+                    {% endif %}
+                      <label for="criteria">{{ pass_form.criteria.label }}</label>
+                      <input type="text" class="form-control" name="{{ pass_form.criteria.name }}" placeholder="{{ criteria }}" {% if pass_form.criteria.data %}value="{{ pass_form.criteria.data }}"{% endif %}></input>
+                    {% if pass_form.criteria.errors %}
+                      {% for error in pass_form.criteria.errors %}
+                          <span class="help-block">{{ error }}</span>
+                      {% endfor %}
+                    {% endif %}
+                      </div>
+                    <!-- Password entry -->
+                    {% if pass_form.password.errors %}
+                      <div class="form-group has-error">
+                    {% else %}
+                      <div class="form-group">
+                    {% endif %}
+                      <label for="info">{{ pass_form.password.label }}</label>
+                      <input type="password" class="form-control" name="{{ pass_form.password.name }}" placeholder="Password"></input>
+                    {% if pass_form.password.errors %}
+                        {% for error in pass_form.password.errors %}
+                            <span class="help-block">{{ error }}</span>
+                        {% endfor %}
+                    {% endif %}
+                      </div>
+                    <!-- Pass or Fail checkbox section -->
+                    <div class="checkbox">
+                      <div class="col-md-6">
+                        {% if display_info[criteria]["criteria_result"] == true %}
+                          <label class="active"><input type="checkbox" name="{{ pass_form.pass_run.name }}" disabled>Pass</input></label>
+                        {% else %}
+                          <label class="active"><input type="checkbox" name="{{ pass_form.pass_run.name }}" {% if action=='pass' %}checked="checked"{% endif %}>Pass</input></label>
+                        {% endif %}
+                      </div>
+                      <div class="col-md-6">
+                        {% if display_info[criteria]["criteria_result"] == false %}
+                          <label class="active"><input type="checkbox" name="{{ pass_form.fail_run.name }}" disabled>Fail</input></label>
+                        {% else %}
+                          <label class="active"><input type="checkbox" name="{{ pass_form.fail_run.name }}" {% if action=='fail' %}checked="checked"{% endif %}>Fail</input></label>
+                        {% endif %}
+                      </div>
                     </div>
-                  <!-- Submit button  -->
-                  <button type="submit" class="btn btn-success">Submit</button>
-              </form>
-            </div>
+                    <!-- Submit button  -->
+                    <button type="submit" class="btn btn-success">Submit</button>
+                </form>
+              </div>
 
-            <!-- <div class="modal-footer">
-              <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-            </div> -->
+              <!-- <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+              </div> -->
+            </div>
+      
           </div>
-    
         </div>
-      </div>
+      {% endfor %}
     {% endfor %}
   {% endif %}
 {% endblock %}

--- a/minard/templates/runselection_run.html
+++ b/minard/templates/runselection_run.html
@@ -252,36 +252,40 @@
     <!-- Run List History Table -->
     <div class="row">
       <div class="col-md-12">
-        <table class="table table-striped">
-          <thead>
-            <tr>
-              <th width="20.0%">Date</th>
-              <th width="20.0%">List added</th>
-              <th width="20.0%">List removed</th>
-              <th width="20.0%">Comment</th>
-              <th width="20.0%">Name</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for pass in list_history.keys() %}
+        {% if list_history == False %}
+          <h1 style="text-align:center"><font color="red">NO DATA</font></h1>
+        {% else %}
+          <table class="table table-striped">
+            <thead>
               <tr>
-                <td> {{ list_history[pass]["timestamp"].split(" ",1)[0] }} </td>
-                {% if list_history[pass]["list_added"] == "None" %}
-                  <td>  </td>
-                {% else %}
-                  <td> {{ list_history[pass]["list_added"] }} </td>
-                {% endif %}
-                {% if list_history[pass]["list_removed"] == "None" %}
-                  <td>  </td>
-                {% else %}
-                  <td> {{ list_history[pass]["list_removed"] }} </td>
-                {% endif %}
-                <td> {{ list_history[pass]["comment"] }} </td>
-                <td> {{ list_history[pass]["name"] }} </td>
+                <th width="20.0%">Date</th>
+                <th width="20.0%">List added</th>
+                <th width="20.0%">List removed</th>
+                <th width="20.0%">Comment</th>
+                <th width="20.0%">Name</th>
               </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {% for pass in list_history.keys() %}
+                <tr>
+                  <td> {{ list_history[pass]["timestamp"].split(" ",1)[0] }} </td>
+                  {% if list_history[pass]["list_added"] == "None" %}
+                    <td>  </td>
+                  {% else %}
+                    <td> {{ list_history[pass]["list_added"] }} </td>
+                  {% endif %}
+                  {% if list_history[pass]["list_removed"] == "None" %}
+                    <td>  </td>
+                  {% else %}
+                    <td> {{ list_history[pass]["list_removed"] }} </td>
+                  {% endif %}
+                  <td> {{ list_history[pass]["comment"] }} </td>
+                  <td> {{ list_history[pass]["name"] }} </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        {% endif %}
       </div>
     </div>
 
@@ -295,73 +299,77 @@
     <!-- Run List Control Section -->
     <div class="row">
       <div class="col-md-12">
-        <form action="{{ url_for('runselection_run', run_number=run_number)}}" method="POST" role="form">
-          {% macro form_checkbox(field) -%}
-              <div class="checkbox">
-                  <label class="active"><input type="checkbox" name="{{ field.name }}" {% if field.data %}checked="checked"{% endif %}>{{ field.label.text }}</input></label>
-              </div>
-          {%- endmacro %}
-          <div class="alert alert-info">
-              <p>Note: When you press Submit, the run lists will be updated. Please ensure the boxes checked are the correct lists for this run!
-          </div>
-          <div class="col-md-6">
-            {% for i in range((lists|length/2)|round|int) %}
-            <tr>
-              {{ form_checkbox(list_form[lists[i]]) }}
-            </tr>
-            {% endfor %}
-          </div>
-          <div class="col-md-6">
-            {% for i in range((lists|length/2)|round|int, lists|length) %}
-            <tr>
-              {{ form_checkbox(list_form[lists[i]]) }}
-            </tr>
-            {% endfor %}
-          </div>
-          <div class="col-md-12">
-            {% if list_form.name.errors %}
+        {% if lists == False %}
+          <h1 style="text-align:center"><font color="red">NO DATA</font></h1>
+        {% else %}
+          <form action="{{ url_for('runselection_run', run_number=run_number)}}" method="POST" role="form">
+            {% macro form_checkbox(field) -%}
+                <div class="checkbox">
+                    <label class="active"><input type="checkbox" name="{{ field.name }}" {% if field.data %}checked="checked"{% endif %}>{{ field.label.text }}</input></label>
+                </div>
+            {%- endmacro %}
+            <div class="alert alert-info">
+                <p>Note: When you press Submit, the run lists will be updated. Please ensure the boxes checked are the correct lists for this run!
+            </div>
+            <div class="col-md-6">
+              {% for i in range((lists|length/2)|round|int) %}
+              <tr>
+                {{ form_checkbox(list_form[lists[i]]) }}
+              </tr>
+              {% endfor %}
+            </div>
+            <div class="col-md-6">
+              {% for i in range((lists|length/2)|round|int, lists|length) %}
+              <tr>
+                {{ form_checkbox(list_form[lists[i]]) }}
+              </tr>
+              {% endfor %}
+            </div>
+            <div class="col-md-12">
+              {% if list_form.name.errors %}
+                <div class="form-group has-error">
+              {% else %}
+                <div class="form-group">
+              {% endif %}
+              <label for="name">{{ list_form.name.label }}</label>
+              <input type="text" class="form-control" name="{{ list_form.name.name }}" placeholder="Dr P. L. Ace Holder" {% if list_form.name.data %}value="{{ list_form.name.data }}"{% endif %}></input>
+              {% if list_form.name.errors %}
+                {% for error in list_form.name.errors %}
+                    <span class="help-block">{{ error }}</span>
+                {% endfor %}
+              {% endif %}
+            </div>
+            <div>
+              {% if list_form.comment.errors %}
+                <div class="form-group has-error">
+              {% else %}
+                <div class="form-group">
+              {% endif %}
+              <label for="comment">{{ list_form.comment.label }}</label>
+              <input type="text" class="form-control" name="{{ list_form.comment.name }}" placeholder="Comment (apostrophes and quotation marks are removed)" {% if list_form.comment.data %}value="{{ list_form.comment.data }}"{% endif %}></input>
+              {% if list_form.comment.errors %}
+                {% for error in list_form.comment.errors %}
+                    <span class="help-block">{{ error }}</span>
+                {% endfor %}
+              {% endif %}
+            </div>
+            {% if list_form.password.errors %}
               <div class="form-group has-error">
             {% else %}
               <div class="form-group">
             {% endif %}
-            <label for="name">{{ list_form.name.label }}</label>
-            <input type="text" class="form-control" name="{{ list_form.name.name }}" placeholder="Dr P. L. Ace Holder" {% if list_form.name.data %}value="{{ list_form.name.data }}"{% endif %}></input>
-            {% if list_form.name.errors %}
-              {% for error in list_form.name.errors %}
-                  <span class="help-block">{{ error }}</span>
-              {% endfor %}
+            <label for="info">{{ list_form.password.label }}</label>
+            <input type="password" class="form-control" name="{{ list_form.password.name }}" placeholder="Password"></input>
+            {% if list_form.password.errors %}
+                {% for error in list_form.password.errors %}
+                    <span class="help-block">{{ error }}</span>
+                {% endfor %}
             {% endif %}
+            </div>
+            <button type="submit" class="btn btn-success">Submit</button>
+            </form>
           </div>
-          <div>
-            {% if list_form.comment.errors %}
-              <div class="form-group has-error">
-            {% else %}
-              <div class="form-group">
-            {% endif %}
-            <label for="comment">{{ list_form.comment.label }}</label>
-            <input type="text" class="form-control" name="{{ list_form.comment.name }}" placeholder="Comment (apostrophes and quotation marks are removed)" {% if list_form.comment.data %}value="{{ list_form.comment.data }}"{% endif %}></input>
-            {% if list_form.comment.errors %}
-              {% for error in list_form.comment.errors %}
-                  <span class="help-block">{{ error }}</span>
-              {% endfor %}
-            {% endif %}
-          </div>
-          {% if list_form.password.errors %}
-            <div class="form-group has-error">
-          {% else %}
-            <div class="form-group">
-          {% endif %}
-          <label for="info">{{ list_form.password.label }}</label>
-          <input type="password" class="form-control" name="{{ list_form.password.name }}" placeholder="Password"></input>
-          {% if list_form.password.errors %}
-              {% for error in list_form.password.errors %}
-                  <span class="help-block">{{ error }}</span>
-              {% endfor %}
-          {% endif %}
-          </div>
-          <button type="submit" class="btn btn-success">Submit</button>
-          </form>
-        </div>
+        {% endif %}
       </div>
     </div>
     <div class="row">
@@ -370,92 +378,94 @@
     </div>
 
   <!-- Write pop-up window to pass run -->
-  {% for criteria in display_info.keys() %}
-    <!-- Modal -->
-    <div class="modal fade" id="myOutput{{ criteria }}" role="dialog">
-      <div class="modal-dialog modal-lg">
-  
-        <!-- Modal content-->
-        <div class="modal-content">
+  {% if display_info != False %}
+    {% for criteria in display_info.keys() %}
+      <!-- Modal -->
+      <div class="modal fade" id="myOutput{{ criteria }}" role="dialog">
+        <div class="modal-dialog modal-lg">
+    
+          <!-- Modal content-->
+          <div class="modal-content">
 
-          <!-- Window title -->
-          <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal">&times;</button>
-            <h4 class="modal-title">Manually Pass Run for {{ criteria }} Criteria </h4>
-          </div>
+            <!-- Window title -->
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal">&times;</button>
+              <h4 class="modal-title">Manually Pass Run for {{ criteria }} Criteria </h4>
+            </div>
 
-          <!-- Window body -->
-          <div class="modal-body">
-            <form action="{{ url_for('runselection_run', run_number=run_number)}}" method="POST" role="form">
-                <!-- Name entry -->
-                {% if pass_form.name.errors %}
-                  <div class="form-group has-error">
-                {% else %}
-                  <div class="form-group">
-                {% endif %}
-                  <label for="name">{{ pass_form.name.label }}</label>
-                  <input type="text" class="form-control" name="{{ pass_form.name.name }}" placeholder="Dr P. L. Ace Holder" {% if pass_form.name.data %}value="{{ pass_form.name.data }}"{% endif %}></input>
-                {% if pass_form.name.errors %}
-                  {% for error in pass_form.name.errors %}
-                      <span class="help-block">{{ error }}</span>
-                  {% endfor %}
-                {% endif %}
-                  </div>
-                <!-- Comment entry -->
-                {% if pass_form.comment.errors %}
-                  <div class="form-group has-error">
-                {% else %}
-                  <div class="form-group">
-                {% endif %}
-                  <label for="comment">{{ pass_form.comment.label }}</label>
-                  <input type="text" class="form-control" name="{{ pass_form.comment.name }}" placeholder="Comment (apostrophes and quotation marks are removed)" {% if pass_form.comment.data %}value="{{ pass_form.comment.data }}"{% endif %}></input>
-                {% if pass_form.comment.errors %}
-                  {% for error in pass_form.comment.errors %}
-                      <span class="help-block">{{ error }}</span>
-                  {% endfor %}
-                {% endif %}
-                  </div>
-                <!-- Criteria -->
-                {% if pass_form.comment.errors %}
-                  <div class="form-group has-error">
-                {% else %}
-                  <div class="form-group">
-                {% endif %}
-                  <label for="criteria">{{ pass_form.criteria.label }}</label>
-                  <input type="text" class="form-control" name="{{ pass_form.criteria.name }}" placeholder="{{ criteria }}" value="{{ criteria }}" disabled></input>
-                {% if pass_form.criteria.errors %}
-                  {% for error in pass_form.criteria.errors %}
-                      <span class="help-block">{{ error }}</span>
-                  {% endfor %}
-                {% endif %}
-                  </div>
-                <!-- Password entry -->
-                {% if pass_form.password.errors %}
-                  <div class="form-group has-error">
-                {% else %}
-                  <div class="form-group">
-                {% endif %}
-                  <label for="info">{{ pass_form.password.label }}</label>
-                  <input type="password" class="form-control" name="{{ pass_form.password.name }}" placeholder="Password"></input>
-                {% if pass_form.password.errors %}
-                    {% for error in pass_form.password.errors %}
+            <!-- Window body -->
+            <div class="modal-body">
+              <form action="{{ url_for('runselection_run', run_number=run_number)}}" method="POST" role="form">
+                  <!-- Name entry -->
+                  {% if pass_form.name.errors %}
+                    <div class="form-group has-error">
+                  {% else %}
+                    <div class="form-group">
+                  {% endif %}
+                    <label for="name">{{ pass_form.name.label }}</label>
+                    <input type="text" class="form-control" name="{{ pass_form.name.name }}" placeholder="Dr P. L. Ace Holder" {% if pass_form.name.data %}value="{{ pass_form.name.data }}"{% endif %}></input>
+                  {% if pass_form.name.errors %}
+                    {% for error in pass_form.name.errors %}
                         <span class="help-block">{{ error }}</span>
                     {% endfor %}
-                {% endif %}
-                  </div>
-                <!-- Submit button  -->
-                <button type="submit" class="btn btn-success">Submit</button>
-            </form>
-          </div>
+                  {% endif %}
+                    </div>
+                  <!-- Comment entry -->
+                  {% if pass_form.comment.errors %}
+                    <div class="form-group has-error">
+                  {% else %}
+                    <div class="form-group">
+                  {% endif %}
+                    <label for="comment">{{ pass_form.comment.label }}</label>
+                    <input type="text" class="form-control" name="{{ pass_form.comment.name }}" placeholder="Comment (apostrophes and quotation marks are removed)" {% if pass_form.comment.data %}value="{{ pass_form.comment.data }}"{% endif %}></input>
+                  {% if pass_form.comment.errors %}
+                    {% for error in pass_form.comment.errors %}
+                        <span class="help-block">{{ error }}</span>
+                    {% endfor %}
+                  {% endif %}
+                    </div>
+                  <!-- Criteria -->
+                  {% if pass_form.criteria.errors %}
+                    <div class="form-group has-error">
+                  {% else %}
+                    <div class="form-group">
+                  {% endif %}
+                    <label for="criteria">{{ pass_form.criteria.label }}</label>
+                    <input type="text" class="form-control" name="{{ pass_form.criteria.name }}" placeholder="{{ criteria }}" {% if pass_form.criteria.data %}value="{{ pass_form.criteria.data }}"{% endif %}></input>
+                  {% if pass_form.criteria.errors %}
+                    {% for error in pass_form.criteria.errors %}
+                        <span class="help-block">{{ error }}</span>
+                    {% endfor %}
+                  {% endif %}
+                    </div>
+                  <!-- Password entry -->
+                  {% if pass_form.password.errors %}
+                    <div class="form-group has-error">
+                  {% else %}
+                    <div class="form-group">
+                  {% endif %}
+                    <label for="info">{{ pass_form.password.label }}</label>
+                    <input type="password" class="form-control" name="{{ pass_form.password.name }}" placeholder="Password"></input>
+                  {% if pass_form.password.errors %}
+                      {% for error in pass_form.password.errors %}
+                          <span class="help-block">{{ error }}</span>
+                      {% endfor %}
+                  {% endif %}
+                    </div>
+                  <!-- Submit button  -->
+                  <button type="submit" class="btn btn-success">Submit</button>
+              </form>
+            </div>
 
-          <!-- <div class="modal-footer">
-            <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-          </div> -->
+            <!-- <div class="modal-footer">
+              <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            </div> -->
+          </div>
+    
         </div>
-  
       </div>
-    </div>
-  {% endfor %}
+    {% endfor %}
+  {% endif %}
 {% endblock %}
 
 {% block script %}

--- a/minard/templates/runselection_run.html
+++ b/minard/templates/runselection_run.html
@@ -381,14 +381,71 @@
           <!-- Window title -->
           <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal">&times;</button>
-            <h4 class="modal-title">Pass Run for {{ criteria }} Criteria </h4>
+            <h4 class="modal-title">Manually Pass Run for {{ criteria }} Criteria </h4>
           </div>
 
           <!-- Window body -->
           <div class="modal-body">
-            <!-- <form action="{{ url_for('runselection_run', run_number=run_number)}}" method="POST" role="form" id="">
-
-            </form> -->
+            <form action="{{ url_for('runselection_run', run_number=run_number)}}" method="POST" role="form">
+                <!-- Name entry -->
+                {% if pass_form.name.errors %}
+                  <div class="form-group has-error">
+                {% else %}
+                  <div class="form-group">
+                {% endif %}
+                  <label for="name">{{ pass_form.name.label }}</label>
+                  <input type="text" class="form-control" name="{{ pass_form.name.name }}" placeholder="Dr P. L. Ace Holder" {% if pass_form.name.data %}value="{{ pass_form.name.data }}"{% endif %}></input>
+                {% if pass_form.name.errors %}
+                  {% for error in pass_form.name.errors %}
+                      <span class="help-block">{{ error }}</span>
+                  {% endfor %}
+                {% endif %}
+                  </div>
+                <!-- Comment entry -->
+                {% if pass_form.comment.errors %}
+                  <div class="form-group has-error">
+                {% else %}
+                  <div class="form-group">
+                {% endif %}
+                  <label for="comment">{{ pass_form.comment.label }}</label>
+                  <input type="text" class="form-control" name="{{ pass_form.comment.name }}" placeholder="Comment (apostrophes and quotation marks are removed)" {% if pass_form.comment.data %}value="{{ pass_form.comment.data }}"{% endif %}></input>
+                {% if pass_form.comment.errors %}
+                  {% for error in pass_form.comment.errors %}
+                      <span class="help-block">{{ error }}</span>
+                  {% endfor %}
+                {% endif %}
+                  </div>
+                <!-- Criteria -->
+                {% if pass_form.comment.errors %}
+                  <div class="form-group has-error">
+                {% else %}
+                  <div class="form-group">
+                {% endif %}
+                  <label for="criteria">{{ pass_form.criteria.label }}</label>
+                  <input type="text" class="form-control" name="{{ pass_form.criteria.name }}" placeholder="{{ criteria }}" value="{{ criteria }}" disabled></input>
+                {% if pass_form.criteria.errors %}
+                  {% for error in pass_form.criteria.errors %}
+                      <span class="help-block">{{ error }}</span>
+                  {% endfor %}
+                {% endif %}
+                  </div>
+                <!-- Password entry -->
+                {% if pass_form.password.errors %}
+                  <div class="form-group has-error">
+                {% else %}
+                  <div class="form-group">
+                {% endif %}
+                  <label for="info">{{ pass_form.password.label }}</label>
+                  <input type="password" class="form-control" name="{{ pass_form.password.name }}" placeholder="Password"></input>
+                {% if pass_form.password.errors %}
+                    {% for error in pass_form.password.errors %}
+                        <span class="help-block">{{ error }}</span>
+                    {% endfor %}
+                {% endif %}
+                  </div>
+                <!-- Submit button  -->
+                <button type="submit" class="btn btn-success">Submit</button>
+            </form>
           </div>
 
           <!-- <div class="modal-footer">

--- a/minard/views.py
+++ b/minard/views.py
@@ -1925,14 +1925,27 @@ def runselection_run(run_number):
     lists = RSTools.get_run_lists()
     list_data = RSTools.get_current_lists_run(run_number)
     if request.form:
-        form = RSTools.file_list_form_builder(request.form, lists, list_data)
+        # Find out which form is being used: run_list or pass
+        # (run_list has more elements than just: name, comment, password)
+        is_list_form = False
+        for key in request.form.keys():
+            if key not in ['name', 'comment', 'password']:
+                is_list_form = True
+                break
+
+        # Update relenvent form
+        if is_list_form:
+            list_form = RSTools.file_list_form_builder(request.form, lists, list_data)
+        else:
+            pass_form = RSTools.file_list_form_builder(request.form, display_info)
     else:
-        form = RSTools.file_list_form_builder(-1, lists, list_data)
+        list_form = RSTools.file_list_form_builder(-1, lists, list_data)
+        pass_form = RSTools.file_pass_form_builder(-1, display_info)
 
     if request.method == 'POST':
-        if form.validate():
+        if list_form.validate():
             try:
-                RSTools.update_run_lists(form, run_number, lists, list_data)
+                RSTools.update_run_lists(list_form, run_number, lists, list_data)
             except Exception as e:
                 flash(str(e), 'danger')
                 return redirect(url_for('runselection_run', run_number=run_number))
@@ -1941,7 +1954,7 @@ def runselection_run(run_number):
         else:
             flash("Unsuccessful: error submitting form", 'danger')
 
-    return render_template('runselection_run.html', run_number=run_number, general_info=general_info, display_info=display_info, list_history=list_history, lists=lists.keys(), form=form, run_prev_next=run_prev_next)
+    return render_template('runselection_run.html', run_number=run_number, general_info=general_info, display_info=display_info, list_history=list_history, lists=lists.keys(), list_form=list_form, run_prev_next=run_prev_next)
 
 
 @app.route('/light_level')

--- a/minard/views.py
+++ b/minard/views.py
@@ -1893,6 +1893,7 @@ def scint_level():
 
 @app.route('/runselection')
 def runselection():
+    # Get variable info from webpage (with defaults defined)
     limit = request.args.get("limit", 25, type=int)
     offset = request.args.get("offset", 0, type=int)
     result = request.args.get("result", "All", type=str)
@@ -1900,8 +1901,21 @@ def runselection():
     selected_run = request.args.get("selected_run", 0, type=int)
     run_range_low = request.args.get("run_range_low", 0, type=int)
     run_range_high = request.args.get("run_range_high", 0, type=int)
-    run_info = RSTools.list_runs_info(limit, offset, result, criteria, selected_run, run_range_low, run_range_high)
-    return render_template('runselection.html', run_info=run_info, criteria=criteria, limit=limit, offset=offset, result=result, selected_run=selected_run, run_range_low=run_range_low, run_range_high=run_range_high)
+    year_low = request.args.get("year_low", 0, type=int)
+    month_low = request.args.get("month_low", 0, type=int)
+    day_low = request.args.get("day_low", 0, type=int)
+    year_high = request.args.get("year_high", 0, type=int)
+    month_high = request.args.get("month_high", 0, type=int)
+    day_high = request.args.get("day_high", 0, type=int)
+
+    # Use this to get run info from databases, to display in list
+    run_range = [run_range_low, run_range_high]
+    date_range = [[year_low, month_low, day_low], [year_high, month_high, day_high]]
+    run_info = RSTools.list_runs_info(limit, offset, result, criteria, selected_run, run_range, date_range)
+
+    # Return info to webpage
+    return render_template('runselection.html', run_info=run_info, criteria=criteria, limit=limit, offset=offset, result=result, selected_run=selected_run, run_range_low=run_range_low, run_range_high=run_range_high,
+                           year_low=year_low, month_low=month_low, day_low=day_low, year_high=year_high, month_high=month_high, day_high=day_high)
 
 @app.route('/runselection_run/<int:run_number>', methods=['GET', 'POST'])
 def runselection_run(run_number):

--- a/minard/views.py
+++ b/minard/views.py
@@ -1955,7 +1955,7 @@ def runselection_run(run_number):
             if 'criteria' in request.form.keys():
                 # Passing run form
                 if pass_form.validate():
-                    result, error_msg = RSTools.pass_run(pass_form, run_number)
+                    result, error_msg = RSTools.pass_fail_run(pass_form, run_number)
                     if not result:
                         succeeded = False
                 else:

--- a/minard/views.py
+++ b/minard/views.py
@@ -1920,7 +1920,7 @@ def runselection():
 @app.route('/runselection_run/<int:run_number>', methods=['GET', 'POST'])
 def runselection_run(run_number):
     # run_info, criteria_info = RSTools.import_RS_ratdb(run_number, 'All', 0, 0)
-    general_info, display_info = RSTools.format_data(run_number)
+    general_info, display_info, run_prev_next = RSTools.format_data(run_number)
     list_history = RSTools.get_list_history(run_number)
     lists = RSTools.get_run_lists()
     list_data = RSTools.get_current_lists_run(run_number)
@@ -1941,7 +1941,7 @@ def runselection_run(run_number):
         else:
             flash("Unsuccessful: error submitting form", 'danger')
 
-    return render_template('runselection_run.html', run_number=run_number, general_info=general_info, display_info=display_info, list_history=list_history, lists=lists.keys(), form=form)
+    return render_template('runselection_run.html', run_number=run_number, general_info=general_info, display_info=display_info, list_history=list_history, lists=lists.keys(), form=form, run_prev_next=run_prev_next)
 
 
 @app.route('/light_level')

--- a/minard/views.py
+++ b/minard/views.py
@@ -1924,20 +1924,19 @@ def runselection_run(run_number):
     list_history = RSTools.get_list_history(run_number)
     lists = RSTools.get_run_lists()
     list_data = RSTools.get_current_lists_run(run_number)
+
+    is_pass_form = False
     if request.form:
         # Find out which form is being used: run_list or pass
         # (run_list has more elements than just: name, comment, password)
-        is_list_form = False
-        for key in request.form.keys():
-            if key not in ['name', 'comment', 'password']:
-                is_list_form = True
-                break
+        if 'criteria' in request.form.keys():
+            is_pass_form = True
 
         # Update relenvent form
-        if is_list_form:
-            list_form = RSTools.file_list_form_builder(request.form, lists, list_data)
-        else:
+        if is_pass_form:
             pass_form = RSTools.file_list_form_builder(request.form, display_info)
+        else:
+            list_form = RSTools.file_list_form_builder(request.form, lists, list_data)
     else:
         list_form = RSTools.file_list_form_builder(-1, lists, list_data)
         pass_form = RSTools.file_pass_form_builder(-1, display_info)
@@ -1945,7 +1944,10 @@ def runselection_run(run_number):
     if request.method == 'POST':
         if list_form.validate():
             try:
-                RSTools.update_run_lists(list_form, run_number, lists, list_data)
+                if is_pass_form:
+                    RSTools.pass_run(pass_form, run_number)
+                else:
+                    RSTools.update_run_lists(list_form, run_number, lists, list_data)
             except Exception as e:
                 flash(str(e), 'danger')
                 return redirect(url_for('runselection_run', run_number=run_number))
@@ -1954,7 +1956,7 @@ def runselection_run(run_number):
         else:
             flash("Unsuccessful: error submitting form", 'danger')
 
-    return render_template('runselection_run.html', run_number=run_number, general_info=general_info, display_info=display_info, list_history=list_history, lists=lists.keys(), list_form=list_form, run_prev_next=run_prev_next)
+    return render_template('runselection_run.html', run_number=run_number, general_info=general_info, display_info=display_info, list_history=list_history, lists=lists.keys(), list_form=list_form, pass_form=pass_form, run_prev_next=run_prev_next)
 
 
 @app.route('/light_level')


### PR DESCRIPTION
Fixed the following issues (from run-selection git-issues):

- [x ] Add "search by date" to main page functionality, for run time not run review time?
- [x ] back/next buttons on individual run pages
- [x ] some failed processors show as purgatory, see run 307719 for example
- [x ] run has failed because DQHL failed, but really DQHL purgatoried. see run 307906, the minard page is misreading the .json file  ->  Duplicate issue
- [x ] The value column shouldn't have the threshold label. This is pulled from the json, which should be corrected.
- [x ] Add a button that changes a purgatory run to pass or fail by creating a new version of the .json file. (also allows failing of passed run, or passing of failed run).
- [x ] Add column with timestamp for when run was taken.
- [x ] Currently the minard page preferentially displays criteria from a criteria table whose version number matches the version number of the RS table (in the run-specific page). However, the run-selection code does not do this (it merely takes the criteria table with the latest version number), and in fact the RS and criteria table version number have nothing to with each-other. So the incorrect criteria table is sometimes used.
To make sure the correct criteria table is displayed (i.e. the one that was used to make the RS table), the minard page should take the criteria table with the latest version number, that existed at the time the RS table was made. This way, the page replicates the RS code logic exactly, at the time it was run. The timestamp in the RS table, and the upload timestamp of the criteria tables can be used for this.
- [x ] Searching for "rare" results like Purgatory works either takes ages, or doesn't return enough runs.


Along some small formatting and error handling improvements. Has undergone testing on my laptop using python 2.7.
