### PR TITLE
Drop-down menu and password change

### DIFF
--- a/README
+++ b/README
@@ -44,6 +44,13 @@ add:
     COUCHDB_HOSTNAME=[hostname]
     COUCHDB_PASSWORD=[password]
 
+If you are testing the run-selection pages, you will also need to add:
+
+    DROP_DOWN_MENU_CRITS=['scintillator', 'scintillator_silver', 'scintillator_bronze', 'directionality_analysis']
+    RS_EXPERT_PASS=[password]
+
+(DROP_DOWN_MENU_CRITS can be any list of criteria, this is a standard example)
+
 Now, export the environment variable MINARD_SETTINGS to point to the
 configuration file:
 

--- a/minard/RSTools.py
+++ b/minard/RSTools.py
@@ -52,7 +52,7 @@ def file_pass_form_builder(formobj, display_info):
             setattr(FilePassForm, 'pass_run', BooleanField(label='Pass'))
             setattr(FilePassForm, 'fail_run', BooleanField(label='Fail'))
         setattr(FilePassForm, 'name', StringField('Name', [validators.Length(min=1), validators.InputRequired(), validators.Regexp('[A-Za-z0-9\s]{1,}', message='First and second name required.')]))
-        setattr(FilePassForm, 'criteria', StringField('criteria', [validators.Optional()], default=criteria))
+        setattr(FilePassForm, 'criteria', StringField('Criteria', [validators.InputRequired()], default=criteria))
         setattr(FilePassForm, 'comment', StringField('Comment', [validators.InputRequired()]))
         setattr(FilePassForm, 'password', PasswordField('Password', [validators.InputRequired()]))
 
@@ -130,6 +130,11 @@ def update_run_lists(form, run, lists, data):
     # Remove troublesome characters from entries
     name = str(form.name.data).replace("'", '').replace('"', '')
     comment = str(form.comment.data).replace("'", '').replace('"', '')
+    password = str(form.password.data)
+
+    # Check password
+    if password != app.config['RS_EXPERT_PASS']:
+        return False, 'WARNING: wrong password'
 
     c = False
     c_nl = False
@@ -138,7 +143,7 @@ def update_run_lists(form, run, lists, data):
         conn = psycopg2.connect(dbname=app.config['DB_NAME'],
                                 user=app.config['DB_OPERATOR'],
                                 host=app.config['DB_HOST'],
-                                password=form.password.data)
+                                password=app.config['DB_OPERATOR_PASS'])
         c = True
         conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
 
@@ -163,7 +168,7 @@ def update_run_lists(form, run, lists, data):
         conn_nl = psycopg2.connect(dbname=app.config['DB_NAME_NEARLINE'],
                                 user=app.config['DB_OPERATOR'],
                                 host=app.config['DB_HOST_NEARLINE'],
-                                password=form.password.data,
+                                password=app.config['DB_OPERATOR_PASS'],
                                 port=app.config['DB_PORT_NEARLINE'])
         c_nl = True
         conn_nl.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
@@ -190,6 +195,11 @@ def pass_fail_run(form, run_number):
     name = str(form.name.data).replace("'", '').replace('"', '')
     comment = str(form.comment.data).replace("'", '').replace('"', '')
     criteria = str(form.criteria.data).replace("'", '').replace('"', '')
+    password = str(form.password.data)
+
+    # Check password
+    if password != app.config['RS_EXPERT_PASS']:
+        return False, 'WARNING: wrong password'
 
     # Get RS table
     RS_report = get_RS_reports(criteria=criteria, run_min=run_number, run_max=run_number)[run_number][criteria]['meta_data']
@@ -217,7 +227,7 @@ def pass_fail_run(form, run_number):
         conn_nl = psycopg2.connect(dbname=app.config['DB_NAME_NEARLINE'],
                                 user=app.config['DB_OPERATOR'],
                                 host=app.config['DB_HOST_NEARLINE'],
-                                password=form.password.data,
+                                password=app.config['DB_OPERATOR_PASS'],
                                 port=app.config['DB_PORT_NEARLINE'])
         conn_nl.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
         c_nl = True
@@ -238,7 +248,7 @@ def pass_fail_run(form, run_number):
             conn = psycopg2.connect(dbname=app.config['DB_NAME'],
                                     user=app.config['DB_OPERATOR'],
                                     host=app.config['DB_HOST'],
-                                    password=form.password.data)
+                                    password=app.config['DB_OPERATOR_PASS'])
             conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
             c = True
             cursor = conn.cursor()

--- a/minard/RSTools.py
+++ b/minard/RSTools.py
@@ -279,7 +279,7 @@ def decide_replace_table(first_table, second_table):
 
     if second_table['meta_data']['version'] == first_table['meta_data']['version']:
         dt = second_table['timestamp'] - first_table['timestamp']
-        dt_seconds = dt.days*3600*12 + dt.seconds
+        dt_seconds = dt.days*3600*24 + dt.seconds
 
         if dt_seconds > 0:
             return True

--- a/minard/RSTools.py
+++ b/minard/RSTools.py
@@ -485,7 +485,10 @@ def list_runs_info(limit, offset, result, criteria, selected_run, run_range, dat
         if i < len(run_numbers):
             final_rs_tables[run_numbers[i]] = filtered_rs_tables[run_numbers[i]]
 
-    return final_rs_tables
+    # Get list of criteria to put in drop-down menu (in order)
+    drop_down_crits = app.config['DROP_DOWN_MENU_CRITS']
+
+    return final_rs_tables, drop_down_crits
 
 ############ RUNSELECTION_RUN PAGE FUNCTIONS ############
 

--- a/minard/templates/runselection.html
+++ b/minard/templates/runselection.html
@@ -76,7 +76,7 @@
                 <th>
                     <select id="crit" onchange="get_limit(lim.value, {{offset}}, this.value, res.value, run.value, low.value, high.value, y_low.value, m_low.value, d_low.value, y_high.value, m_high.value, d_high.value);">
                     <option selected value="{{criteria}}">{{criteria}}</option>
-                    {% for n in ["scintillator", "partial_fill_antinu", "partial_fill", "water"] %}  <!-- FIXME: make this dynamic !-->
+                    {% for n in ["scintillator", "scintillator_silver", "scintillator_bronze", "directionality_analysis"] %}  <!-- FIXME: make this dynamic ?-->
                         {% if n != criteria %}
                             <option value="{{n}}">{{n}}</option>
                         {% endif %}

--- a/minard/templates/runselection.html
+++ b/minard/templates/runselection.html
@@ -76,7 +76,7 @@
                 <th>
                     <select id="crit" onchange="get_limit(lim.value, {{offset}}, this.value, res.value, run.value, low.value, high.value, y_low.value, m_low.value, d_low.value, y_high.value, m_high.value, d_high.value);">
                     <option selected value="{{criteria}}">{{criteria}}</option>
-                    {% for n in ["scintillator", "scintillator_silver", "scintillator_bronze", "directionality_analysis"] %}  <!-- FIXME: make this dynamic ?-->
+                    {% for n in drop_down_crits %}
                         {% if n != criteria %}
                             <option value="{{n}}">{{n}}</option>
                         {% endif %}

--- a/minard/templates/runselection_run.html
+++ b/minard/templates/runselection_run.html
@@ -447,7 +447,7 @@
                       <div class="form-group">
                     {% endif %}
                       <label for="criteria">{{ pass_form.criteria.label }}</label>
-                      <input type="text" class="form-control" name="{{ pass_form.criteria.name }}" placeholder="{{ criteria }}" {% if pass_form.criteria.data %}value="{{ pass_form.criteria.data }}"{% endif %}></input>
+                      <input type="text" class="form-control" name="{{ pass_form.criteria.name }}" placeholder="{{ criteria }}" {% if pass_form.criteria.data %}value="{{ criteria }}"{% endif %}></input>
                     {% if pass_form.criteria.errors %}
                       {% for error in pass_form.criteria.errors %}
                           <span class="help-block">{{ error }}</span>

--- a/minard/views.py
+++ b/minard/views.py
@@ -1924,10 +1924,10 @@ def runselection():
     # Use this to get run info from databases, to display in list
     run_range = [run_range_low, run_range_high]
     date_range = [[year_low, month_low, day_low], [year_high, month_high, day_high]]
-    run_info = RSTools.list_runs_info(limit, offset, result, criteria, selected_run, run_range, date_range)
+    run_info, drop_down_crits = RSTools.list_runs_info(limit, offset, result, criteria, selected_run, run_range, date_range)
 
     # Return info to webpage
-    return render_template('runselection.html', run_info=run_info, criteria=criteria, limit=limit, offset=offset, result=result, selected_run=selected_run, run_range_low=run_range_low, run_range_high=run_range_high,
+    return render_template('runselection.html', run_info=run_info, drop_down_crits=drop_down_crits, criteria=criteria, limit=limit, offset=offset, result=result, selected_run=selected_run, run_range_low=run_range_low, run_range_high=run_range_high,
                            year_low=year_low, month_low=month_low, day_low=day_low, year_high=year_high, month_high=month_high, day_high=day_high)
 
 @app.route('/runselection_run/<int:run_number>', methods=['GET', 'POST'])


### PR DESCRIPTION
A few small changes:
- Modified drop down menu of criteria in run page.
- Fixed small bug with auto-filled criteria in pass/fail form.
- Made run-selection action use new RS_EXPERT password, instead of detectorDB password.

Tested locally, and it works.

NOTE:
Needs a new entry called `RS_EXPERT_PASS='placeholder'` added to the settings.conf file when this is moved to the minard machine, to define the RS_EXPERT password.