### PR TITLE
update dropdown link to onsite pmtcal instance

### DIFF
--- a/minard/templates/layout.html
+++ b/minard/templates/layout.html
@@ -86,7 +86,7 @@
                         <li class='dropdown'>
 			<a href='#' class='dropdown-toggle' data-toggle='dropdown'>PMTcal <b class='caret'></b></a>
                             <ul class='dropdown-menu'>
-                                <li> <a href="https://snopluspmts.physics.berkeley.edu/">Overview</a></li>
+                                <li> <a href="https://snopl.us/pmtcal/">Overview</a></li>
                                 {{ nav_link('eca', 'ECA') }}
                                 {{ nav_link('pcatellie', 'PCA Tellie') }}
                                 {{ nav_link('pcatellie_processing', 'PCA Tellie Processing') }}


### PR DESCRIPTION
Correct a rotten link on minard, which should point to the pmtcal page running on site as opposed to the old site running at Berkeley.