### PR TITLE
Fix issue with run selection plots

### DIFF
--- a/minard/RSTools.py
+++ b/minard/RSTools.py
@@ -788,27 +788,8 @@ def format_data(runNum):
 def pass_fail_plot_info(criteria, date_range):
     ''' calculates the cumulative number of days of physics, passed, failed and purgatory runs 
         based on input criteria and date range '''
+    # list of values we want to plot
     data = []
-    # Get list of criteria to put in drop-down menu (in order)
-    drop_down_crits = app.config['DROP_DOWN_MENU_CRITS']
-    # Get date limits
-    min_runTime = None
-    max_runTime = None
-    if 0 not in date_range[0]:
-        try:
-            min_runTime = datetime.date(date_range[0][0], date_range[0][1], date_range[0][2])
-        except:
-            return False, drop_down_crits
-    if 0 not in date_range[1]:
-        try:
-            max_runTime = datetime.date(date_range[1][0], date_range[1][1], date_range[1][2])
-        except:
-            return False, drop_down_crits
-    # download physics runs in given date range
-    rs_tables = get_RS_reports_date_range(criteria=criteria)
-    if rs_tables is False:
-        return False, drop_down_crits
-    # Loop through RS tables and sum up the cumulative number of days of each result
     phys = 0
     physrun = 0
     passed = 0
@@ -817,51 +798,87 @@ def pass_fail_plot_info(criteria, date_range):
     failrun = 0
     purg = 0
     purgrun = 0
-    for run_number in rs_tables.keys():
-        # check run duration was found and if it was convert into days, skip if not
-        if rs_tables[run_number][criteria]['run_duration'] == 'No Data':
-            continue
-        # Get run time and put into specific format
-        run_start_time = str(rs_tables[run_number][criteria]['run_start']).replace(' ', 'T')
-        # get the run date to apply date range to
-        run_start_lst = rs_tables[run_number][criteria]['run_start'].split(' ')[0].split('-')
-        run_start_date = datetime.date(int(run_start_lst[0]), int(run_start_lst[1]), int(run_start_lst[2]))
-        # if no date conditions were given, skip the filter
-        if not min_runTime is None:
-            if run_start_date < min_runTime:
+    # Get list of criteria to put in drop-down menu (in order)
+    drop_down_crits = app.config['DROP_DOWN_MENU_CRITS']
+    # Get date limits
+    min_runTime = None
+    max_runTime = None
+    if 0 not in date_range[0]:
+        try:
+            min_runTime = datetime.date(date_range[0][0], date_range[0][1], date_range[0][2])
+            print(min_runTime)
+        except:
+            return False, drop_down_crits
+    if 0 not in date_range[1]:
+        try:
+            max_runTime = datetime.date(date_range[1][0], date_range[1][1], date_range[1][2])
+        except:
+            return False, drop_down_crits
+    # download physics runs in given date range - do this 1000 runs at a time until all the runs in the date range have been downloaded
+    min_dl_time = max_runTime  # the minimum time that has been dowloaded to compare with the minimum time we want to download
+    final_run_num = None
+    attempt = 1
+    while min_dl_time > min_runTime:
+        print('attempt: ' + str(attempt))
+        rs_tables = get_RS_reports_date_range(criteria=criteria, run_max=final_run_num)
+        if rs_tables is False:
+            return False, drop_down_crits
+        # Loop through RS tables and sum up the cumulative number of days of each result
+        for run_number in rs_tables.keys():
+            # check run duration was found and if it was convert into days, skip if not
+            if rs_tables[run_number][criteria]['run_duration'] == 'No Data':
                 continue
-        if not max_runTime is None:
-            if run_start_date > max_runTime:
-                continue
-        run_length = rs_tables[run_number][criteria]['run_duration']/(60**2*24)
-        # get result (pass=True, fail=False, purgatory=None)
-        result = rs_tables[run_number][criteria]['result']
-        # add number of days to cumulative sum
-        phys += run_length
-        physrun += 1
-        if result == True:
-            passed += run_length
-            passrun += 1
-        if result == False:
-            failed += run_length
-            failrun += 1
-        if result == None:
-            purg += run_length
-            purgrun += 1
-        rs_result = {}
-        rs_result['timestamp'] = run_start_time
-        rs_result['phys_total'] = phys
-        rs_result['phys_runs'] = physrun
-        rs_result['pass_total'] = passed
-        rs_result['pass_runs'] = passrun
-        rs_result['fail_total'] = failed
-        rs_result['fail_runs'] = failrun
-        rs_result['purg_total'] = purg
-        rs_result['purg_runs'] = purgrun
-        data.append(rs_result)
+            # Get run time and put into specific format
+            run_start_time = str(rs_tables[run_number][criteria]['run_start']).replace(' ', 'T')
+            # get the run date to apply date range to
+            run_start_lst = rs_tables[run_number][criteria]['run_start'].split(' ')[0].split('-')
+            run_start_date = datetime.date(int(run_start_lst[0]), int(run_start_lst[1]), int(run_start_lst[2]))
+            # if no date conditions were given, skip the filter
+            if not min_runTime is None:
+                if run_start_date < min_runTime:
+                    continue
+            if not max_runTime is None:
+                if run_start_date > max_runTime:
+                    continue
+            run_length = rs_tables[run_number][criteria]['run_duration']/(60**2*24)
+            # get result (pass=True, fail=False, purgatory=None)
+            result = rs_tables[run_number][criteria]['result']
+            # add number of days to cumulative sum
+            phys += run_length
+            physrun += 1
+            if result == True:
+                passed += run_length
+                passrun += 1
+            if result == False:
+                failed += run_length
+                failrun += 1
+            if result == None:
+                purg += run_length
+                purgrun += 1
+            rs_result = {}
+            rs_result['timestamp'] = run_start_time
+            rs_result['phys_total'] = phys
+            rs_result['phys_runs'] = physrun
+            rs_result['pass_total'] = passed
+            rs_result['pass_runs'] = passrun
+            rs_result['fail_total'] = failed
+            rs_result['fail_runs'] = failrun
+            rs_result['purg_total'] = purg
+            rs_result['purg_runs'] = purgrun
+            print(phys)
+            data.append(rs_result)
+        # get final run number and date of final run to check if more runs need to be downloaded
+        len_rs_tables = len(rs_tables)
+        final_run_num = rs_tables.keys()[len_rs_tables-1]
+        last_run_start = rs_tables[final_run_num][criteria]['run_start'].split(' ')[0].split('-')
+        min_dl_time = datetime.date(int(last_run_start[0]), int(last_run_start[1]), int(last_run_start[2]))
+        attempt += 1
+    print('done')
+
+    
     return data, drop_down_crits
 
-def get_RS_reports_date_range(criteria=None, min_runTime=None, max_runTime=None):
+def get_RS_reports_date_range(criteria=None, run_max=None):
     '''Get run-selection tables in a run range. If duplicate tables, only keeps one
     (takes one with latest version, and if they have the same version, the one with
     the latest timestamp).'''
@@ -870,10 +887,15 @@ def get_RS_reports_date_range(criteria=None, min_runTime=None, max_runTime=None)
     conditions = []
     if criteria is not None:
         conditions.append("criteria = '%s'" % str(criteria))
+    if run_max is not None:
+        conditions.append("run_max < %d" % int(run_max))
     if len(conditions) > 0:
         for i in range(0, len(conditions)):
             query += " AND " + conditions[i]
-    query += " ORDER BY run_min ASC"
+    query += " ORDER BY run_min DESC"
+    # to speed things up, only download 100 runs at a time
+    query += " LIMIT 100"
+    print(query)
     c = False
     try:
         conn = engine_nl.connect()

--- a/minard/RSTools.py
+++ b/minard/RSTools.py
@@ -806,7 +806,6 @@ def pass_fail_plot_info(criteria, date_range):
     if 0 not in date_range[0]:
         try:
             min_runTime = datetime.date(date_range[0][0], date_range[0][1], date_range[0][2])
-            print(min_runTime)
         except:
             return False, drop_down_crits
     if 0 not in date_range[1]:
@@ -819,7 +818,6 @@ def pass_fail_plot_info(criteria, date_range):
     final_run_num = None
     attempt = 1
     while min_dl_time > min_runTime:
-        print('attempt: ' + str(attempt))
         rs_tables = get_RS_reports_date_range(criteria=criteria, run_max=final_run_num)
         if rs_tables is False:
             return False, drop_down_crits
@@ -865,7 +863,6 @@ def pass_fail_plot_info(criteria, date_range):
             rs_result['fail_runs'] = failrun
             rs_result['purg_total'] = purg
             rs_result['purg_runs'] = purgrun
-            print(phys)
             data.append(rs_result)
         # get final run number and date of final run to check if more runs need to be downloaded
         len_rs_tables = len(rs_tables)
@@ -873,9 +870,6 @@ def pass_fail_plot_info(criteria, date_range):
         last_run_start = rs_tables[final_run_num][criteria]['run_start'].split(' ')[0].split('-')
         min_dl_time = datetime.date(int(last_run_start[0]), int(last_run_start[1]), int(last_run_start[2]))
         attempt += 1
-    print('done')
-
-    
     return data, drop_down_crits
 
 def get_RS_reports_date_range(criteria=None, run_max=None):
@@ -895,7 +889,6 @@ def get_RS_reports_date_range(criteria=None, run_max=None):
     query += " ORDER BY run_min DESC"
     # to speed things up, only download 100 runs at a time
     query += " LIMIT 100"
-    print(query)
     c = False
     try:
         conn = engine_nl.connect()

--- a/minard/templates/runselection_plots.html
+++ b/minard/templates/runselection_plots.html
@@ -130,10 +130,10 @@
         {
             date_ = moment(rs_plot_data[i]['timestamp']).toDate();
             dates.push(date_);
-            phys.push({'date': date_, 'value': rs_plot_data[i]['phys_total']});
-            pass.push({'date': date_, 'value': rs_plot_data[i]['pass_total']});
-            fail.push({'date': date_, 'value': rs_plot_data[i]['fail_total']});
-            purg.push({'date': date_, 'value': rs_plot_data[i]['purg_total']});
+            phys.push({'date': date_, 'value': rs_plot_data[rs_plot_data.length - 1]['phys_total'] - rs_plot_data[i]['phys_total']});
+            pass.push({'date': date_, 'value': rs_plot_data[rs_plot_data.length - 1]['pass_total'] - rs_plot_data[i]['pass_total']});
+            fail.push({'date': date_, 'value': rs_plot_data[rs_plot_data.length - 1]['fail_total'] - rs_plot_data[i]['fail_total']});
+            purg.push({'date': date_, 'value': rs_plot_data[rs_plot_data.length - 1]['purg_total'] - rs_plot_data[i]['purg_total']});
         }
         var cscale = tzscale().domain(dates).zone('America/Toronto');
 

--- a/minard/views.py
+++ b/minard/views.py
@@ -2125,7 +2125,7 @@ def radon_monitor():
 @app.route('/runselection_plots')
 def runselection_plots():
     datehigh = datetime.now()
-    datelow = datehigh - timedelta(days=7)
+    datelow = datehigh - timedelta(days=6)
     # Get variable info from webpage (with defaults defined)
     criteria = request.args.get("criteria", "scintillator_silver", type=str)
     year_low = request.args.get("year_low", datelow.year, type=int)


### PR DESCRIPTION
The run selction plots page has recently stopped working. This coincides with the recent additions to the bronze and silver lists which suggests that the issue is due to this. Before, the code would download every run table for the user specified criteria and then filter through them using the user specified date range. The reason for downloading all the run tbales is because the date range can't be applied at the db query level. The newly added runs means that more run tables need to be downloaded and I think the page is just crashing at this point. To speed this up and prevent it from crashing, the code now downloads 100 runs at a time until the user specified date range has been satisfied.

A future PR will be to add the ability to use a run range. Run ranges can be applied when querying the db which would help speed things up in the case where the user wants to look at older runs. For now, this should be enough to get the page running again.

@mmdepatie