### PR TITLE
Implement slow control data plotting page 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ dist
 minard.egg-info
 minard/static/docs
 settings.conf
+nohup.out
+kill_minard.sh
+start_minard.sh
+.vscode/settings.json

--- a/minard/slowcontrol_data.py
+++ b/minard/slowcontrol_data.py
@@ -25,9 +25,13 @@ def get_data_from_view(db, viewName, startkey=0, endkey=999999999999, limit=500,
         return [[r['key'] for r in viewData], [r["value"] for r in viewData]] #array of keys, array of values
 
 def get_data_from_view_http(viewName, server="http://192.168.80.89:5984", startkey=0, endkey=999999999999, limit=MAX_LIMIT, sanitize=False):
-    opts = "limit=" + str(limit) + "&startkey=" + str(startkey) + "&endkey=" + str(endkey)    
-    tic = datetime.datetime.now()
-    r = requests.get(server+'/slowcontrol-data-5sec/_design/slowcontrol-data-5sec/_view/'+viewName+'?'+opts, auth=("admin", "pass"))
+    ops = {
+        "startkey": startkey,
+        "endkey": endkey,
+        "limit": limit,
+        "stale": "refresh_after"
+    }
+    r = requests.get(server+"/slowcontrol-data-5sec/_design/slowcontrol-data-5sec/_view/", auth=("admin", "pass"), params=opts)
     if r.status_code == 200:
         print(str(len(r.json()['rows'])) + " rows returned in " + str(datetime.datetime.now()-tic))
         if sanitize: return json.dumps(r.json()['rows']) # really dumb... but sanitizes unicode (u'(whatever...)')
@@ -42,7 +46,7 @@ def get_rack_supply_voltage_view_name(rack, voltage, httpStr=False):
     RACKS = list(range(1, 11+1)) + ["timing"]
     VOLTAGES = [24, -24, 8, 5, -5]
     CARDS = ['A', 'B', 'C', 'D']
-    ios = 1
+    ios = 2
 
     if rack not in RACKS: return None
     if voltage not in VOLTAGES: return None
@@ -65,7 +69,7 @@ def get_crate_baseline_voltage_view_name(crate, trigger):
     CRATES = range(0, 18+1)
     TRIGGERS = [100, 20]
     CARDS = ['A', 'B', 'C', 'D']
-    ios = 3
+    ios = 4
 
     if crate not in CRATES: return None
     if trigger not in TRIGGERS: return None

--- a/minard/slowcontrol_data.py
+++ b/minard/slowcontrol_data.py
@@ -101,13 +101,13 @@ def get_supply_data_http(datelow, datehigh, rack, voltage):
     
     try: #verify rack is int OR the string "timing"
         rack = int(rack)
-        friendlyViewName = "Rack " + str(rack) + " - " + voltage + "V supply"
+        friendlyViewName = "Rack " + str(rack) + ": " + voltage + "V supply"
     except ValueError:
         if rack == "timing":
             if voltage == "mtcd":
                 friendlyViewName = "MTCD -2V Supply"
             else: 
-                friendlyViewName = "Timing Rack - " + voltage + "V supply"
+                friendlyViewName = "Timing Rack: " + voltage + "V supply"
         else:
             raise Exception("Rack was invalid.")
 
@@ -134,7 +134,7 @@ def get_baseline_data_http(datelow, datehigh, crate, trigger):
     try: #verify crate, trigger is int - this SUCKS prob just returns string always anyways
         crate = int(crate)
         trigger = int(trigger)
-        friendlyViewName = "Crate " + str(crate) + " - N" + str(trigger) + "_BL"
+        friendlyViewName = "Crate " + str(crate) + ": N" + str(trigger) + "_BL"
     except ValueError:
         print("Crate (" + str(crate) + ") or trigger (" + str(trigger) + ") was invalid.")
         return None, None

--- a/minard/slowcontrol_data.py
+++ b/minard/slowcontrol_data.py
@@ -1,0 +1,63 @@
+import couchdb
+from . import app
+
+BATCH_SIZE = 1
+
+def connect(user=None, pw=None, server="localhost", port=5984):
+    if user is None and pw is None:
+        import couchcreds
+        user = couchcreds.user
+        pw = couchcreds.pw
+    return couchdb.Server(f"http://{user}:{pw}@{server}:{port}")
+
+def get_data_from_view(db, view, startkey=0, endkey=999999999999, limit=500):
+    viewData = db.view(view, limit=limit, startkey=startkey, endkey=endkey)
+    return [(r["key"], r["value"]) for r in viewData] #time value pairs
+
+def get_rack_supply_voltage_view_name(rack, voltage):
+    '''Gets the view name for a specified rack and voltage channel.
+        Valid racks: Integers from 1 to 11 or "timing".
+        Valid voltage channels: 24, -24, 8, 5, -5.'''
+    RACKS = list(range(1, 11+1)) + ["timing"]
+    VOLTAGES = [24, -24, 8, 5, -5]
+    CARDS = ['A', 'B', 'C', 'D']
+    ios = 1
+
+    if rack not in RACKS: return None
+    if voltage not in VOLTAGES: return None
+
+    if rack == "timing":
+        card = 'D'
+        channel = VOLTAGES.index(voltage) 
+    else:
+        raw_channel = 5 * RACKS.index(rack) + VOLTAGES.index(voltage)
+        card = CARDS[raw_channel // 20]
+        channel = raw_channel % 20
+    
+    return f"slowcontrol-data-5sec/{ios}_{card}_{channel}"
+
+def get_crate_baseline_voltage_view_name(crate, trigger):
+    '''Gets the view name for a specified crate and trigger baseline voltage.
+        Valid crates: Integers from 0 to 18.
+        Valid triggers: Integers 100, 20. (N100_BL, N20_BL)'''
+    CRATES = range(0, 18+1)
+    TRIGGERS = [100, 20]
+    CARDS = ['A', 'B', 'C', 'D']
+    ios = 3
+
+    if crate not in CRATES: return None
+    if trigger not in TRIGGERS: return None
+
+    card = CARDS[crate // 6]
+    channel = (crate % 6) * 3 + TRIGGERS.index(trigger)
+    if channel >= 12: channel += 1
+
+    return f"slowcontrol-data-5sec/{ios}_{card}_{channel}"
+
+if __name__ == "__main__":
+    couch = connect(user=app.config[COUCHDB_USER], pw=app.config[COUCHDB_PASS])
+    db = couch['slowcontrol-data-5sec']
+    viewname = get_rack_supply_voltage_view_name(rack=1, voltage=24)
+    data = get_data_from_view(db, viewname, limit=99999999999999)
+
+    print(len(data))

--- a/minard/slowcontrol_data.py
+++ b/minard/slowcontrol_data.py
@@ -4,6 +4,10 @@ import requests
 import json
 
 BATCH_SIZE = 1
+MAX_LIMIT = 268435456 #couchdb rules
+
+def getTimestamp(targetTime):
+    return targetTime.strftime("%s") #python2 doesn't support unix ts, but somehow this method does... on unix only
 
 def connect(user=None, pw=None, server="localhost", port=5984):
     if user is None and pw is None:
@@ -20,12 +24,16 @@ def get_data_from_view(db, viewName, startkey=0, endkey=999999999999, limit=500,
     else:
         return [[r['key'] for r in viewData], [r["value"] for r in viewData]] #array of keys, array of values
 
-def get_data_from_view_http(viewName, server="http://192.168.80.89:5984", startkey=0, endkey=999999999999, limit=500):
+def get_data_from_view_http(viewName, server="http://192.168.80.89:5984", startkey=0, endkey=999999999999, limit=MAX_LIMIT, sanitize=False):
     opts = "limit=" + str(limit) + "&startkey=" + str(startkey) + "&endkey=" + str(endkey)    
     tic = datetime.datetime.now()
     r = requests.get(server+'/slowcontrol-data-5sec/_design/slowcontrol-data-5sec/_view/'+viewName+'?'+opts, auth=("admin", "pass"))
-    print("Data returned in " + str(datetime.datetime.now()-tic))
-    return json.dumps(r.json()['rows']) # really dumb... but sanitizes unicode (u'(whatever...)')
+    if r.status_code == 200:
+        print(str(len(r.json()['rows'])) + " rows returned in " + str(datetime.datetime.now()-tic))
+        if sanitize: return json.dumps(r.json()['rows']) # really dumb... but sanitizes unicode (u'(whatever...)')
+        else: return r.json()['rows']
+    else:
+        raise Exception
 
 def get_rack_supply_voltage_view_name(rack, voltage, httpStr=False):
     '''Gets the view name for a specified rack and voltage channel.
@@ -69,6 +77,59 @@ def get_crate_baseline_voltage_view_name(crate, trigger):
     viewStr = str(ios) + "_" + str(card) + "_" + str(channel)
     return viewStr
 
+def get_supply_data_http(datelow, datehigh, rack, voltage):
+    db = connect(user="admin", pw="pass", server="192.168.80.89")['slowcontrol-data-5sec']
+    startkey = getTimestamp(datelow)
+    endkey = getTimestamp(datehigh)
+    
+    try: #verify rack is int OR the string "timing"
+        rack = int(rack)
+        friendlyViewName = "Rack " + str(rack) + " - " + voltage + "V supply"
+    except ValueError:
+        if rack == "timing":
+            return None
+        else:
+            friendlyViewName = "Timing Rack - " + voltage + "V supply"
+
+    try: 
+        voltage = int(voltage)
+    except ValueError:
+        return None
+    
+    viewName = get_rack_supply_voltage_view_name(rack=rack, voltage=voltage)
+    data = get_data_from_view_http(viewName, startkey=startkey, endkey=endkey)
+
+    x = len(data)
+    if x > 5000:
+        crushFactor = int(x/5000) #cap rows at 5000
+        data = data[crushFactor::crushFactor]
+    
+    return json.dumps(data), friendlyViewName
+
+def get_baseline_data_http(datelow, datehigh, crate, trigger):
+    db = connect(user="admin", pw="pass", server="192.168.80.89")['slowcontrol-data-5sec']
+    startkey = getTimestamp(datelow)
+    endkey = getTimestamp(datehigh)
+    
+    # try: #verify crate is int
+    crate = int(crate)
+    friendlyViewName = "Crate " + str(crate) + " - N" + trigger + "BL"
+    # except ValueError:
+    #     if crate == "timing":
+    #         return None
+    #     else:
+    #         friendlyViewName = "Timing Rack - " + voltage + "V supply"
+    
+    viewName = get_crate_baseline_voltage_view_name(crate=crate, trigger=trigger)
+    data = get_data_from_view_http(viewName, startkey=startkey, endkey=endkey)
+    
+    if len(data) > 10000:
+        crushFactor = max(1, int(0.02*(len(data))**(1/2))) #0.02 * sqrt(len)
+        del data[crushFactor-1::crushFactor]
+    
+    return data, friendlyViewName
+
+
 def get_plot_data(startDate, endDate, dataName=str(datetime.datetime.now().microsecond), collate=False, limit=1000):
     '''Test function for now'''
     db = connect(user="admin", pw="pass", server="192.168.80.89")['slowcontrol-data-5sec']
@@ -90,3 +151,4 @@ if __name__ == "__main__":
     couch = connect(user="admin", pw="pass", server="192.168.80.89")
     db = couch['slowcontrol-data-5sec']
     viewname = get_rack_supply_voltage_view_name(rack=1, voltage=24)
+    pass

--- a/minard/slowcontrol_data.py
+++ b/minard/slowcontrol_data.py
@@ -9,7 +9,7 @@ def getTimestamp(targetTime):
     return int(targetTime.strftime("%s")) #python2 doesn't support unix ts, but somehow this method does... on unix only
 
 class SlowDataObject():
-    def get_data_from_view_http_threaded(self, threadCount=20, server="http://couch.snopl.us", auth=(app.config['COUCH_USER'], app.config['COUCH_PASS'])):
+    def get_data_from_view_http_threaded(self, threadCount=10, server="http://couch.snopl.us", auth=(app.config['COUCH_USER'], app.config['COUCH_PASS'])):
         '''Makes a multithreaded request to the CouchDB server for data from an echolocator view.
             Returns a list of dicts with schema `{"_id": str, "key": int, "value": int}`.
             `_id` is the internal CouchDB document ID.

--- a/minard/slowcontrol_data.py
+++ b/minard/slowcontrol_data.py
@@ -46,7 +46,7 @@ class SlowDataObject():
 
         #next, use grequests to submit all requests concurrently
         callList = (grequests.get(server+"/slowcontrol-data-5sec/_design/echolocator/_view/"+self.viewName,
-            params=params) for params in threadParamsList) #define the requests
+            auth=auth, params=params) for params in threadParamsList) #define the requests
         responses = grequests.map(callList) #submit all requests
         responseTime = datetime.datetime.now()
         print("{0} threads returned in {1}s".format(len(responses), responseTime-startTime))
@@ -105,7 +105,7 @@ class SupplyDataObject(SlowDataObject):
             :param int|str voltage: Voltage value valid for that rack.'''
         try: #verify rack is int OR the string "timing"
             rack = int(rack)
-            self.caption = "Rack {0}: {1}V".format(voltage, rack)
+            self.caption = "Rack {0}: {1}V".format(rack, voltage)
         except ValueError:
             if rack == "timing":
                 if voltage == "mtcd":
@@ -190,7 +190,7 @@ class BaselineDataObject(SlowDataObject):
             raise Exception("Trigger ({0}) was invalid.".format(trigger))
 
         self.baseline = 0 #TODO? is this correct?       
-        self.caption = "Crate {0}: N{1}_BL".format(trigger, crate)
+        self.caption = "Crate {0}: N{1}_BL".format(crate, trigger)
 
     def calc_view_name(self):
         '''Gets the view name for a specified crate and trigger baseline voltage.

--- a/minard/slowcontrol_data.py
+++ b/minard/slowcontrol_data.py
@@ -146,6 +146,8 @@ def get_baseline_data_http(datelow, datehigh, crate, trigger):
     if x > MAX_ROWS_RETURNED:
         crushFactor = int(x/MAX_ROWS_RETURNED) #cap rows
         data = data[crushFactor::crushFactor]
+
+    print("View name returned from baseline: " + friendlyViewName)
     
     return json.dumps(data), friendlyViewName
 

--- a/minard/slowcontrol_data.py
+++ b/minard/slowcontrol_data.py
@@ -5,168 +5,190 @@ from . import app
 
 MAX_ROWS_RETURNED = 2000
 
-class CouchException(Exception):
-    def __init__(self, message):
-        self.message = message
-
 def getTimestamp(targetTime):
-    return targetTime.strftime("%s") #python2 doesn't support unix ts, but somehow this method does... on unix only
+    return int(targetTime.strftime("%s")) #python2 doesn't support unix ts, but somehow this method does... on unix only
 
-def get_data_from_view_http_threaded(viewName, startkey, endkey, threadCount=20, server="http://couch.snopl.us", stable='true', update='lazy'):
-    startkey = int(startkey)
-    endkey = int(endkey)
+class SlowDataObject():
+    def get_data_from_view_http_threaded(self, threadCount=20, server="http://couch.snopl.us", stable='true', update='lazy'):
+        interval = (self.endkey-self.startkey)//threadCount #the range of keys in each request
+        intervalList = range(self.startkey, self.endkey, interval) #the breakpoints
 
-    interval = (endkey-startkey)//threadCount #the range of keys in each request
-    intervalList = range(startkey, endkey, interval) #the breakpoints
+        #the template of parameters we will pass to the request
+        #we will insert the startkey and endkey in the next step
+        baseThreadParams = {
+            "stable": stable,
+            "update": update,
+            "inclusive_end": "true",
+            "sorted": "false", #faster to sort on our end with concurrent requests
+        }
 
-    #the template of parameters we will pass to the request
-    #we will insert the startkey and endkey in the next step
-    baseThreadParams = {
-        "stable": stable,
-        "update": update,
-        "inclusive_end": "true",
-        "sorted": "false", #faster to sort on our end with concurrent requests
-    }
+        threadParamsList = []
 
-    threadParamsList = []
+        #first, create many parameter dicts, with evenly-spaced start and stop keys
+        for step in intervalList:
+            newThreadParams = baseThreadParams.copy() #shallow copy, ie. copy by value
+            newThreadParams["startkey"] = str(step)
+            newThreadParams["endkey"] = str(step + interval)
+            threadParamsList.append(newThreadParams)
+        
+        startTime = datetime.datetime.now()
 
-    #first, create many parameter dicts, with evenly-spaced start and stop keys
-    for step in intervalList:
-        newThreadParams = baseThreadParams.copy() #shallow copy, ie. copy by value
-        newThreadParams["startkey"] = str(step)
-        newThreadParams["endkey"] = str(step + interval)
-        threadParamsList.append(newThreadParams)
+        #next, use grequests to submit all requests concurrently
+        callList = (grequests.get(server+"/slowcontrol-data-5sec/_design/echolocator/_view/"+self.viewName, 
+            auth=(app.config['COUCH_USER'], app.config['COUCH_PASS']), params=params) for params in threadParamsList) #define the requests
+        responses = grequests.map(callList) #submit all requests
+        responseTime = datetime.datetime.now()
+        print("{0} threads returned in {1}s".format(len(responses), responseTime-startTime))
+
+        #extract the list of "rows" from each response (the actual data)
+        data = map(lambda response: response.json()['rows'], responses)
+        unpackingTime = datetime.datetime.now()
+        print("Unpacked threads in {0}s".format(unpackingTime-responseTime))
+        
+        #this is a bit tricky - the map() applies the *sort lambda* to each list in data
+        #the sort lambda sorts each list of dicts by key INDIVIDUALLY of the others
+        #since grequests keeps the requests in order, the data is now completely sorted
+        data = map(lambda response: sorted(response, key=lambda point: point['key']), data)
+        sortingTime = datetime.datetime.now()
+        print("Sorted threads in {0}s".format(sortingTime-unpackingTime))
+
+        #finally, merge each list with a reduce()
+        data = reduce(lambda a, b: a+b, data)
+        mergingTime = datetime.datetime.now()
+        print("Merged threads in {0}s".format(mergingTime-unpackingTime))
+
+        print("{0} rows returned in {1}s total ({2}x threaded)".format(len(data), mergingTime-startTime, threadCount))
+        self.data = data
+
+    def build_view_name(self):
+        self.viewName = str(self.ios) + "_" + str(self.card) + "_" + str(self.channel)
+
+class SupplyDataObject(SlowDataObject):
+    def __init__(self, datelow, datehigh, rack, voltage):
+        #TODO: more docstrings
+        self.startkey = getTimestamp(datelow)
+        self.endkey = getTimestamp(datehigh)
+
+        self.handle_input_channel(rack, voltage)
+        
+        self.calc_view_name()
+        self.get_data_from_view_http_threaded()
+
+        self.points = len(self.data)
+        if self.points > MAX_ROWS_RETURNED:
+            crushFactor = int(self.points/MAX_ROWS_RETURNED) #cap rows
+            self.data = [self.data[0]] + self.data[crushFactor::crushFactor] + [self.data[-1]]
+        
+        # return json.dumps(data), friendlyViewName, baseRange
     
-    startTime = datetime.datetime.now()
+    def handle_input_channel(self, rack, voltage):
+        try: #verify rack is int OR the string "timing"
+            rack = int(rack)
+            self.caption = "Rack " + str(rack) + ": " + str(voltage) + "V"
+        except ValueError:
+            if rack == "timing":
+                if voltage == "mtcd":
+                    self.caption = "MTCD -2V"
+                else: 
+                    self.caption = "Timing Rack: " + str(voltage) + "V"
+            else:
+                raise Exception("Rack " + str(rack) + "was invalid.")
 
-    #next, use grequests to submit all requests concurrently
-    callList = (grequests.get(server+"/slowcontrol-data-5sec/_design/echolocator/_view/"+viewName, 
-        auth=(app.config['COUCH_USER'], app.config['COUCH_PASS']), params=params) for params in threadParamsList) #define the requests
-    responses = grequests.map(callList) #submit all requests
-    responseTime = datetime.datetime.now()
-    print("{0} threads returned in {1}s".format(len(responses), responseTime-startTime))
-
-    #extract the list of "rows" from each response (the actual data)
-    data = map(lambda response: response.json()['rows'], responses)
-    unpackingTime = datetime.datetime.now()
-    print("Unpacked threads in {0}s".format(unpackingTime-responseTime))
+        try: 
+            voltage = int(voltage)
+            self.baseline = voltage
+        except ValueError:
+            if voltage != "mtcd":
+                raise Exception("Voltage " + str(voltage) + "was invalid.")
+            self.baseline = -2
+        
+        self.rack = rack
+        self.voltage = voltage
     
-    #this is a bit tricky - the map() applies the *sort lambda* to each list in data
-    #the sort lambda sorts each list of dicts by key INDIVIDUALLY of the others
-    #since grequests keeps the requests in order, the data is now completely sorted
-    data = map(lambda response: sorted(response, key=lambda point: point['key']), data)
-    sortingTime = datetime.datetime.now()
-    print("Sorted threads in {0}s".format(sortingTime-unpackingTime))
+    def calc_view_name(self):
+        '''Gets the view name for a specified rack and voltage channel.
+            :param int|str self.rack: Integer from 1 to 11 or "timing".
+            :param int self.voltage: Valid voltage channels: 24, -24, 8, 5, -5.'''
+        RACKS = list(range(1, 11+1)) + ["timing"]
+        VOLTAGES = [24, -24, 8, 5, -5]
+        VOLTAGES_TIMING = [24, -24, 5, -5, 6, "mtcd"]
+        CARDS = ['A', 'B', 'C', 'D']
+        rack = self.rack
+        voltage = self.voltage
+        ios = 2
 
-    #finally, merge each list with a reduce()
-    data = reduce(lambda a, b: a+b, data)
-    mergingTime = datetime.datetime.now()
-    print("Merged threads in {0}s".format(mergingTime-unpackingTime))
+        if rack not in RACKS:
+            raise Exception("Rack " + str(rack) + " is invalid.")
+        if voltage not in VOLTAGES + VOLTAGES_TIMING: 
+            raise Exception("Voltage " + str(voltage) + " is invalid.")
 
-    print("{0} rows returned in {1}s total ({2}x threaded)".format(len(data), mergingTime-startTime, threadCount))
-    return data
-    
-def get_rack_supply_voltage_view_name(rack, voltage, httpStr=False):
-    '''Gets the view name for a specified rack and voltage channel.
-        :param int|str rack: Integer from 1 to 11 or "timing".
-        :param int voltage: Valid voltage channels: 24, -24, 8, 5, -5.'''
-    RACKS = list(range(1, 11+1)) + ["timing"]
-    VOLTAGES = [24, -24, 8, 5, -5]
-    VOLTAGES_TIMING = [24, -24, 5, -5, 6, 'mtcd']
-    CARDS = ['A', 'B', 'C', 'D']
-    ios = 2
-
-    if rack not in RACKS:
-        raise CouchException("Rack " + str(rack) + " is invalid.")
-    if voltage not in VOLTAGES + VOLTAGES_TIMING: 
-        raise CouchException("Voltage " + str(voltage) + " is invalid.")
-
-    if rack == "timing":
-        card = 'D'
-        channel = VOLTAGES_TIMING.index(voltage)
-        if voltage == 'mtcd':
-            channel = 7
-    else:
-        raw_channel = 5 * RACKS.index(rack) + VOLTAGES.index(voltage)
-        card = CARDS[raw_channel // 20]
-        channel = raw_channel % 20
-    
-    viewStr = str(ios) + "_" + str(card) + "_" + str(channel)
-    return viewStr
-
-def get_crate_baseline_voltage_view_name(crate, trigger):
-    '''Gets the view name for a specified crate and trigger baseline voltage.
-        :param int crate: Integer from 0 to 18.
-        :param int trigger: Integers 100, 20. (N100_BL, N20_BL)'''
-    CRATES = range(0, 18+1)
-    TRIGGERS = [100, 20]
-    CARDS = ['A', 'B', 'C', 'D']
-    ios = 4
-
-    if crate not in CRATES: raise CouchException("Crate " + str(crate) + " is invalid.")
-    if trigger not in TRIGGERS: raise CouchException("Trigger " + str(trigger) + " is invalid.")
-
-    card = CARDS[crate // 6]
-    channel = (crate % 6) * 3 + TRIGGERS.index(trigger)
-    if channel >= 12: channel += 1
-
-    viewStr = str(ios) + "_" + str(card) + "_" + str(channel)
-    return viewStr
-
-def get_supply_data_http(datelow, datehigh, rack, voltage):
-    #TODO: more docstrings
-    startkey = getTimestamp(datelow)
-    endkey = getTimestamp(datehigh)
-    
-    try: #verify rack is int OR the string "timing"
-        rack = int(rack)
-        friendlyViewName = "Rack " + str(rack) + ": " + voltage + "V supply"
-    except ValueError:
         if rack == "timing":
-            if voltage == "mtcd":
-                friendlyViewName = "MTCD -2V Supply"
-            else: 
-                friendlyViewName = "Timing Rack: " + voltage + "V supply"
+            card = 'D'
+            channel = VOLTAGES_TIMING.index(voltage)
+            if voltage == 'mtcd':
+                channel = 7
         else:
-            raise Exception("Rack was invalid.")
+            raw_channel = 5 * RACKS.index(rack) + VOLTAGES.index(voltage)
+            card = CARDS[raw_channel // 20]
+            channel = raw_channel % 20
 
-    try: 
-        voltage = int(voltage)
-        baseRange = voltage
-    except ValueError:
-        if voltage != "mtcd":
-            return None, None
-        baseRange = -2
-    
-    viewName = get_rack_supply_voltage_view_name(rack=rack, voltage=voltage)
-    data = get_data_from_view_http_threaded(viewName, startkey=startkey, endkey=endkey)
+        self.ios = ios
+        self.card = card
+        self.channel = channel
+        
+        self.build_view_name()
 
-    x = len(data)
-    if x > MAX_ROWS_RETURNED:
-        crushFactor = int(x/MAX_ROWS_RETURNED) #cap rows
-        data = data[crushFactor::crushFactor]
-    
-    return json.dumps(data), friendlyViewName, baseRange
+class BaselineDataObject(SlowDataObject):
+    def __init__(self, datelow, datehigh, crate, trigger):
+        self.startkey = getTimestamp(datelow)
+        self.endkey = getTimestamp(datehigh)
 
-def get_baseline_data_http(datelow, datehigh, crate, trigger):
-    startkey = getTimestamp(datelow)
-    endkey = getTimestamp(datehigh)
+        self.handle_input_channel(crate, trigger)
+        
+        self.calc_view_name()
+        self.get_data_from_view_http_threaded()
+        
+        self.points = len(self.data) 
+        if self.points > MAX_ROWS_RETURNED:
+            crushFactor = int(self.points/MAX_ROWS_RETURNED) #cap rows
+            self.data = [self.data[0]] + self.data[crushFactor::crushFactor] + [self.data[-1]]
+        
+        # return json.dumps(data), friendlyViewName, baseRange
     
-    try: #verify crate, trigger is int - this SUCKS prob just returns string always anyways
-        crate = int(crate)
-        trigger = int(trigger)
-        friendlyViewName = "Crate " + str(crate) + ": N" + str(trigger) + "_BL"
-    except ValueError:
-        print("Crate (" + str(crate) + ") or trigger (" + str(trigger) + ") was invalid.")
-        return None, None
-    
-    viewName = get_crate_baseline_voltage_view_name(crate=crate, trigger=trigger)
-    data = get_data_from_view_http_threaded(viewName, startkey=startkey, endkey=endkey)
-    baseRange = 0 #TODO
-    
-    x = len(data) 
-    if x > MAX_ROWS_RETURNED:
-        crushFactor = int(x/MAX_ROWS_RETURNED) #cap rows
-        data = data[crushFactor::crushFactor]
-    
-    return json.dumps(data), friendlyViewName, baseRange
+    def handle_input_channel(self, crate, trigger):
+        try: #verify crate, trigger is int - this SUCKS prob just returns string always anyways
+            self.crate = int(crate)
+        except ValueError:
+            raise Exception("Crate (" + str(crate) + ") was invalid.")
+
+        try:
+            self.trigger = int(trigger)
+        except ValueError:
+            raise Exception("Trigger (" + str(trigger) + ") was invalid.")
+
+        self.baseline = 0 #TODO            
+        self.caption = "Crate " + str(crate) + ": N" + str(trigger) + "_BL"
+
+    def calc_view_name(self):
+        '''Gets the view name for a specified crate and trigger baseline voltage.
+            :param int self.crate: Integer from 0 to 18.
+            :param int self.trigger: Integers 100, 20. (N100_BL, N20_BL)'''
+        CRATES = range(0, 18+1)
+        TRIGGERS = [100, 20]
+        CARDS = ['A', 'B', 'C', 'D']
+        crate = self.crate
+        trigger = self.trigger
+        ios = 4
+
+        if crate not in CRATES: raise Exception("Crate " + str(crate) + " is invalid.")
+        if trigger not in TRIGGERS: raise Exception("Trigger " + str(trigger) + " is invalid.")
+
+        card = CARDS[crate // 6]
+        channel = (crate % 6) * 3 + TRIGGERS.index(trigger)
+        if channel >= 12: channel += 1
+
+        self.ios = ios
+        self.card = card
+        self.channel = channel
+
+        self.build_view_name()

--- a/minard/slowcontrol_data.py
+++ b/minard/slowcontrol_data.py
@@ -18,7 +18,7 @@ class SlowDataObject():
         baseThreadParams = {
             "stable": stable,
             "update": update,
-            "inclusive_end": "true",
+            "inclusive_end": "false", #avoid overlaps
             "sorted": "false", #faster to sort on our end with concurrent requests
         }
 
@@ -30,6 +30,9 @@ class SlowDataObject():
             newThreadParams["startkey"] = str(step)
             newThreadParams["endkey"] = str(step + interval)
             threadParamsList.append(newThreadParams)
+        
+        #make sure the LAST one includes the last point
+        threadParamsList[-1]["inclusive_end"] = "true"
         
         startTime = datetime.datetime.now()
 

--- a/minard/slowcontrol_data.py
+++ b/minard/slowcontrol_data.py
@@ -2,7 +2,7 @@ import couchdb
 import datetime
 import requests
 import json
-Updafrom . import app
+from . import app
 
 MAX_LIMIT = 268435456 #couchdb rules
 MAX_ROWS_RETURNED = 5000

--- a/minard/slowcontrol_data.py
+++ b/minard/slowcontrol_data.py
@@ -1,4 +1,7 @@
 import couchdb
+import datetime
+import requests
+import json
 
 BATCH_SIZE = 1
 
@@ -10,11 +13,21 @@ def connect(user=None, pw=None, server="localhost", port=5984):
     serverStr = "http://" + str(user) + ":" + str(pw) + "@" + str(server) + ":" + str(port)
     return couchdb.Server(serverStr)
 
-def get_data_from_view(db, view, startkey=0, endkey=999999999999, limit=500):
-    viewData = db.view(view, limit=limit, startkey=startkey, endkey=endkey)
-    return [[r["key"], r["value"]] for r in viewData] #time value pairs
+def get_data_from_view(db, viewName, startkey=0, endkey=999999999999, limit=500, request=True, collate=False):
+    viewData = db.view(viewName, limit=limit, startkey=startkey, endkey=endkey)
+    if collate: 
+        return [[r["key"], r["value"]] for r in viewData] #time value pairs (slower!!!)
+    else:
+        return [[r['key'] for r in viewData], [r["value"] for r in viewData]] #array of keys, array of values
 
-def get_rack_supply_voltage_view_name(rack, voltage):
+def get_data_from_view_http(viewName, server="http://192.168.80.89:5984", startkey=0, endkey=999999999999, limit=500):
+    opts = "limit=" + str(limit) + "&startkey=" + str(startkey) + "&endkey=" + str(endkey)    
+    tic = datetime.datetime.now()
+    r = requests.get(server+'/slowcontrol-data-5sec/_design/slowcontrol-data-5sec/_view/'+viewName+'?'+opts, auth=("admin", "pass"))
+    print("Data returned in " + str(datetime.datetime.now()-tic))
+    return json.dumps(r.json()['rows']) # really dumb... but sanitizes unicode (u'(whatever...)')
+
+def get_rack_supply_voltage_view_name(rack, voltage, httpStr=False):
     '''Gets the view name for a specified rack and voltage channel.
         Valid racks: Integers from 1 to 11 or "timing".
         Valid voltage channels: 24, -24, 8, 5, -5.'''
@@ -34,7 +47,7 @@ def get_rack_supply_voltage_view_name(rack, voltage):
         card = CARDS[raw_channel // 20]
         channel = raw_channel % 20
     
-    viewStr = "slowcontrol-data-5sec/" + str(ios) + "_" + str(card) + "_" + str(channel)
+    viewStr = str(ios) + "_" + str(card) + "_" + str(channel)
     return viewStr
 
 def get_crate_baseline_voltage_view_name(crate, trigger):
@@ -53,19 +66,27 @@ def get_crate_baseline_voltage_view_name(crate, trigger):
     channel = (crate % 6) * 3 + TRIGGERS.index(trigger)
     if channel >= 12: channel += 1
 
-    viewStr = "slowcontrol-data-5sec/" + str(ios) + "_" + str(card) + "_" + str(channel)
+    viewStr = str(ios) + "_" + str(card) + "_" + str(channel)
     return viewStr
 
-def get_plot_data(startDate, endDate):
+def get_plot_data(startDate, endDate, dataName=str(datetime.datetime.now().microsecond), collate=False, limit=1000):
     '''Test function for now'''
     db = connect(user="admin", pw="pass", server="192.168.80.89")['slowcontrol-data-5sec']
-    data = get_data_from_view(db, get_rack_supply_voltage_view_name(rack=1, voltage=24), limit=100000, startkey=1380882382)
-    return data,  startDate, endDate
+    tic = datetime.datetime.now()
+    data = get_data_from_view(db, 'slowcontrol-data-5sec/'+get_rack_supply_voltage_view_name(rack=1, voltage=24), limit=limit, startkey=1380882382, collate=collate)
+    print("Data returned in " + str(datetime.datetime.now()-tic) + " and collate was " + str(collate))
+    return data, dataName, startDate, endDate
+
+def get_plot_data_http(startDate, endDate, dataName=str(datetime.datetime.now().microsecond), limit=1000):
+    '''Test function for now'''
+    db = connect(user="admin", pw="pass", server="192.168.80.89")['slowcontrol-data-5sec']
+    tic = datetime.datetime.now()
+    viewName = get_rack_supply_voltage_view_name(rack=1, voltage=24)
+    data = get_data_from_view_http(viewName, limit=limit, startkey=1380882382)
+    print("Data returned in " + str(datetime.datetime.now()-tic))
+    return data, dataName, startDate, endDate
 
 if __name__ == "__main__":
     couch = connect(user="admin", pw="pass", server="192.168.80.89")
     db = couch['slowcontrol-data-5sec']
     viewname = get_rack_supply_voltage_view_name(rack=1, voltage=24)
-    data = get_data_from_view(db, viewname, limit=10)
-    
-    print(data)

--- a/minard/slowcontrol_data.py
+++ b/minard/slowcontrol_data.py
@@ -90,14 +90,11 @@ class SupplyDataObject(SlowDataObject):
             :param datetime datehigh: The end date/time of the query.
             :param int|str rack: Rack value from 1-11 or "timing".
             :param int|str voltage: Voltage value valid for that rack.'''
-        self.startkey = getTimestamp(datelow)
-        self.endkey = getTimestamp(datehigh)
-
+        self.startkey, self.endkey = map(getTimestamp, [datelow, datehigh])
         self.handle_input_channel(rack, voltage)
-        
+
         self.calc_view_name()
         self.get_data_from_view_http_threaded()
-
         self.compactData()
 
     def handle_input_channel(self, rack, voltage):
@@ -169,14 +166,11 @@ class BaselineDataObject(SlowDataObject):
             :param datetime datehigh: The end date/time of the query.
             :param int|str crate: Crate value from 0-18.
             :param int|str trigger: Trigger value, either 20 or 100.'''
-        self.startkey = getTimestamp(datelow)
-        self.endkey = getTimestamp(datehigh)
+        self.startkey, self.endkey = map(getTimestamp, [datelow, datehigh])
+        self.handle_input_channel(crate, trigger)  
 
-        self.handle_input_channel(crate, trigger)
-        
         self.calc_view_name()
         self.get_data_from_view_http_threaded()
-        
         self.compactData()
     
     def handle_input_channel(self, crate, trigger):

--- a/minard/static/js/slowcontrol_plots.js
+++ b/minard/static/js/slowcontrol_plots.js
@@ -4,16 +4,18 @@ const crateField = document.getElementById("baseline-crate");
 const triggerDropdown = document.getElementById("baseline-trigger");
 const flippyVoltage = document.getElementById("supply-flippy");
 const MTCDVoltage = document.getElementById("mtcd");
-const defaultVoltage = document.getElementById("default-voltage");
 const supplyRadio = document.getElementById("supply");
 const baselineRadio = document.getElementById("baseline");
-const metadataTable = document.getElementById("datastreams-listing")
-const newPlotButton = document.getElementById("new-plot")
 const appendPlotButton = document.getElementById("append-plot")
+const newPlotButton = document.getElementById("new-plot")
 const mismatchWarningText = document.getElementById("mismatch-warning")
-const datetimeLowInput = document.getElementById("datetime_low");
-const datetimeHighInput = document.getElementById("datetime_high");
-const dateWarningText = document.getElementById("date-warning");
+const yMaxCheckbox = document.getElementById("y-max-check");
+const yMinCheckbox = document.getElementById("y-min-check");
+const yMaxValueEntry = document.getElementById("y-max-value");
+const yMinValueEntry = document.getElementById("y-min-value");
+const absoluteRadio = document.getElementById("y-axis-absolute");
+const relativeRadio = document.getElementById("y-axis-relative");
+const updateButton = document.getElementById("update-plot")
 
 rackDropdown.onchange = function() {
     supplyRadio.checked = true;
@@ -47,27 +49,23 @@ triggerDropdown.onchange = function() {
 supplyRadio.onclick = function() {
     var currentMode = sessionStorage.getItem("dataType");
     if (currentMode == supplyRadio.id || currentMode == undefined) {
-        //newPlotButton.removeAttribute("disabled");
         appendPlotButton.removeAttribute("disabled");
-        mismatchWarningText.setAttribute("hidden", "");
+        mismatchWarningText.style.visibility = "hidden";
     }
     else {
-        //newPlotButton.setAttribute("disabled", "");
         appendPlotButton.setAttribute("disabled", "");
-        mismatchWarningText.removeAttribute("hidden");
+        mismatchWarningText.style.visibility = "";
     }
 }
 
 baselineRadio.onclick = function() {
     var currentMode = sessionStorage.getItem("dataType");
     if (currentMode == baselineRadio.id || currentMode == undefined) {
-        //newPlotButton.removeAttribute("disabled");
         appendPlotButton.removeAttribute("disabled");
-        mismatchWarningText.setAttribute("hidden", "");
+        mismatchWarningText.style.visibility = "hidden";
     }
     else {
-        //newPlotButton.setAttribute("disabled", "");
         appendPlotButton.setAttribute("disabled", "");
-        mismatchWarningText.removeAttribute("hidden")
+        mismatchWarningText.style.visibility = "";
     }
 }

--- a/minard/static/js/slowcontrol_plots.js
+++ b/minard/static/js/slowcontrol_plots.js
@@ -69,3 +69,53 @@ baselineRadio.onclick = function() {
         mismatchWarningText.style.visibility = "";
     }
 }
+
+yMaxCheckbox.onclick = function() {
+    if (yMaxCheckbox.checked == true) {
+        yMaxValueEntry.removeAttribute("disabled");
+    }
+    else {
+        yMaxValueEntry.setAttribute("disabled", "")
+    }
+}
+
+yMinCheckbox.onclick = function() {
+    if (yMinCheckbox.checked == true) {
+        yMinValueEntry.removeAttribute("disabled");
+    }
+    else {
+        yMinValueEntry.setAttribute("disabled", "")
+    }
+}
+
+const plotControls = [yMaxCheckbox, yMinCheckbox, yMaxValueEntry, 
+    yMinValueEntry, absoluteRadio, relativeRadio];
+
+function getPlotControlsState() {
+    return {
+        "yMaxOn": yMaxCheckbox.checked,
+        "yMinOn": yMinCheckbox.checked,
+        "yMaxVal": yMaxValueEntry.value,
+        "yMinVal": yMinValueEntry.value,
+        "yAxisMode": document.querySelector("input[name=y-axis-type]:checked").value
+    };
+}
+
+var initialPlotState = getPlotControlsState()
+
+function checkPlotControlsState() {
+    const currentPlotState = getPlotControlsState();
+    for (var key in currentPlotState) {
+        if (initialPlotState[key] !== currentPlotState[key]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+plotControls.forEach((element) => 
+    element.onchange = function() {
+        if (checkPlotControlsState()) { updateButton.setAttribute("disabled", ""); }
+        else { updateButton.removeAttribute("disabled"); }
+    }
+);

--- a/minard/static/js/slowcontrol_plots.js
+++ b/minard/static/js/slowcontrol_plots.js
@@ -21,7 +21,7 @@ rackDropdown.onchange = function(){
         if (voltageDropdown.value == "mtcd") {
             voltageDropdown.selectedIndex = 0;
         }
-        MTCDVoltage.setAttribute("hidden")
+        MTCDVoltage.setAttribute("hidden", "")
     }
 }
 

--- a/minard/static/js/slowcontrol_plots.js
+++ b/minard/static/js/slowcontrol_plots.js
@@ -1,0 +1,14 @@
+const rackDropdown = document.getElementById("supply-rack");
+const voltageDropdown = document.getElementById("supply-voltage");
+const flippyVoltage = document.getElementById("supply-flippy");
+
+rackDropdown.onchange = function(){
+    if (rackDropdown.value == "timing") {
+        flippyVoltage.value = "6";
+        flippyVoltage.innerHTML = "6V"
+    }
+    else {
+        flippyVoltage.value = "8";
+        flippyVoltage.innerHTML = "8V"
+    }
+}

--- a/minard/static/js/slowcontrol_plots.js
+++ b/minard/static/js/slowcontrol_plots.js
@@ -14,7 +14,8 @@ const yMinCheckbox = document.getElementById("y-min-check");
 const yMaxValueEntry = document.getElementById("y-max-value");
 const yMinValueEntry = document.getElementById("y-min-value");
 const absoluteRadio = document.getElementById("y-axis-absolute");
-const relativeRadio = document.getElementById("y-axis-relative");
+const boundedRadio = document.getElementById("y-axis-bounded");
+const focusedRadio = document.getElementById("y-axis-focused");
 const updateButton = document.getElementById("update-plot")
 
 rackDropdown.onchange = function() {
@@ -89,7 +90,7 @@ yMinCheckbox.onclick = function() {
 }
 
 const plotControls = [yMaxCheckbox, yMinCheckbox, yMaxValueEntry, 
-    yMinValueEntry, absoluteRadio, relativeRadio];
+    yMinValueEntry, absoluteRadio, boundedRadio, focusedRadio];
 
 function getPlotControlsState() {
     const yMaxOn = yMaxCheckbox.checked;

--- a/minard/static/js/slowcontrol_plots.js
+++ b/minard/static/js/slowcontrol_plots.js
@@ -92,12 +92,17 @@ const plotControls = [yMaxCheckbox, yMinCheckbox, yMaxValueEntry,
     yMinValueEntry, absoluteRadio, relativeRadio];
 
 function getPlotControlsState() {
+    const yMaxOn = yMaxCheckbox.checked;
+    const yMinOn = yMinCheckbox.checked;
+    const yMaxVal = yMaxCheckbox.checked ? yMaxValueEntry.value : null;
+    const yMinVal = yMinCheckbox.checked ? yMinValueEntry.value : null;
+    const yAxisMode = document.querySelector("input[name=y-axis-type]:checked").value;
     return {
-        "yMaxOn": yMaxCheckbox.checked,
-        "yMinOn": yMinCheckbox.checked,
-        "yMaxVal": yMaxValueEntry.value,
-        "yMinVal": yMinValueEntry.value,
-        "yAxisMode": document.querySelector("input[name=y-axis-type]:checked").value
+        "yMaxOn": yMaxOn, 
+        "yMinOn": yMinOn, 
+        "yMaxVal": yMaxVal, 
+        "yMinVal": yMinVal, 
+        "yAxisMode": yAxisMode, 
     };
 }
 

--- a/minard/static/js/slowcontrol_plots.js
+++ b/minard/static/js/slowcontrol_plots.js
@@ -7,8 +7,12 @@ const MTCDVoltage = document.getElementById("mtcd");
 const defaultVoltage = document.getElementById("default-voltage");
 const supplyRadio = document.getElementById("supply");
 const baselineRadio = document.getElementById("baseline");
+const metadataTable = document.getElementById("datastreams-listing")
+const newPlotButton = document.getElementById("new-plot")
+const appendPlotButton = document.getElementById("append-plot")
+const mismatchWarningText = document.getElementById("mismatch-warning")
 
-rackDropdown.onchange = function(){
+rackDropdown.onchange = function() {
     supplyRadio.checked = true;
     if (rackDropdown.value == "timing") {
         flippyVoltage.value = "6";
@@ -25,14 +29,42 @@ rackDropdown.onchange = function(){
     }
 }
 
-voltageDropdown.onchange = function(){
+voltageDropdown.onchange = function() {
     supplyRadio.checked = true;
 }
 
-crateField.onchange = function(){
+crateField.onchange = function() {
     baselineRadio.checked = true;
 }
 
-triggerDropdown.onchange = function(){
+triggerDropdown.onchange = function() {
     baselineRadio.checked = true;
+}
+
+supplyRadio.onclick = function() {
+    var currentMode = sessionStorage.getItem("dataType");
+    if (currentMode == supplyRadio.id || currentMode == undefined) {
+        //newPlotButton.removeAttribute("disabled");
+        appendPlotButton.removeAttribute("disabled");
+        mismatchWarningText.setAttribute("hidden", "");
+    }
+    else {
+        //newPlotButton.setAttribute("disabled", "");
+        appendPlotButton.setAttribute("disabled", "");
+        mismatchWarningText.removeAttribute("hidden");
+    }
+}
+
+baselineRadio.onclick = function() {
+    var currentMode = sessionStorage.getItem("dataType");
+    if (currentMode == baselineRadio.id || currentMode == undefined) {
+        //newPlotButton.removeAttribute("disabled");
+        appendPlotButton.removeAttribute("disabled");
+        mismatchWarningText.setAttribute("hidden", "");
+    }
+    else {
+        //newPlotButton.setAttribute("disabled", "");
+        appendPlotButton.setAttribute("disabled", "");
+        mismatchWarningText.removeAttribute("hidden")
+    }
 }

--- a/minard/static/js/slowcontrol_plots.js
+++ b/minard/static/js/slowcontrol_plots.js
@@ -1,14 +1,38 @@
 const rackDropdown = document.getElementById("supply-rack");
 const voltageDropdown = document.getElementById("supply-voltage");
+const crateField = document.getElementById("baseline-crate");
+const triggerDropdown = document.getElementById("baseline-trigger");
 const flippyVoltage = document.getElementById("supply-flippy");
+const MTCDVoltage = document.getElementById("mtcd");
+const defaultVoltage = document.getElementById("default-voltage");
+const supplyRadio = document.getElementById("supply");
+const baselineRadio = document.getElementById("baseline");
 
 rackDropdown.onchange = function(){
+    supplyRadio.checked = true;
     if (rackDropdown.value == "timing") {
         flippyVoltage.value = "6";
         flippyVoltage.innerHTML = "6V"
+        MTCDVoltage.removeAttribute("hidden")
     }
     else {
         flippyVoltage.value = "8";
         flippyVoltage.innerHTML = "8V"
+        if (voltageDropdown.value == "mtcd") {
+            voltageDropdown.selectedIndex = 0;
+        }
+        MTCDVoltage.setAttribute("hidden")
     }
+}
+
+voltageDropdown.onchange = function(){
+    supplyRadio.checked = true;
+}
+
+crateField.onchange = function(){
+    baselineRadio.checked = true;
+}
+
+triggerDropdown.onchange = function(){
+    baselineRadio.checked = true;
 }

--- a/minard/static/js/slowcontrol_plots.js
+++ b/minard/static/js/slowcontrol_plots.js
@@ -11,6 +11,9 @@ const metadataTable = document.getElementById("datastreams-listing")
 const newPlotButton = document.getElementById("new-plot")
 const appendPlotButton = document.getElementById("append-plot")
 const mismatchWarningText = document.getElementById("mismatch-warning")
+const datetimeLowInput = document.getElementById("datetime_low");
+const datetimeHighInput = document.getElementById("datetime_high");
+const dateWarningText = document.getElementById("date-warning");
 
 rackDropdown.onchange = function() {
     supplyRadio.checked = true;

--- a/minard/templates/layout.html
+++ b/minard/templates/layout.html
@@ -98,8 +98,8 @@
                         <li class='dropdown'>
                             <a href='#' class='dropdown-toggle' data-toggle='dropdown'>Data Quality <b class='caret'></b></a>
                             <ul class='dropdown-menu'>
-                                {{ nav_link('runselection', 'Run Selection')}}
-                                {{ nav_link('runselection_plots', 'Run Selection Plots')}}
+                                {{ nav_link('runselection', 'Run Selection') }}
+                                {{ nav_link('runselection_plots', 'Run Selection Plots') }}                           
                                 {{ nav_link('physicsdq', 'Physics DQ') }}
                                 {{ nav_link('calibdq_tellie', 'TELLIE  DQ') }}
                                 {{ nav_link('calibdq_smellie', 'SMELLIE DQ') }}
@@ -127,6 +127,7 @@
                                 {{ nav_link('scint_level', 'Scintillator Level and AV Offset') }}
                                 {{ nav_link('radon_monitor', 'Radon Monitor') }}
                                 {{ nav_link('light_level', 'Light Levels') }}
+                                {{ nav_link('slowcontrol_plots', 'Slow Control Plots (NEW!)') }}     
                             </ul>
                         <!-- Remote Control Rooms -->
                         <li class='dropdown'>

--- a/minard/templates/layout.html
+++ b/minard/templates/layout.html
@@ -73,6 +73,7 @@
                                 {{ nav_link('daq', 'Continuous Polling Data') }}
                                 {{ nav_link('check_rates', 'Check Rates Data') }}
                                 {{ nav_link('polling_history', 'Check Rates Polling By Channel') }}
+                                {{ nav_link('slowcontrol_plots', 'Slow Control Plots') }}
                             </ul>
                         <!-- Dropdown Nearline -->
                         <li class='dropdown'>
@@ -126,8 +127,7 @@
                                 {{ nav_link('deck_activity', 'Deck and DCR Activity') }}
                                 {{ nav_link('scint_level', 'Scintillator Level and AV Offset') }}
                                 {{ nav_link('radon_monitor', 'Radon Monitor') }}
-                                {{ nav_link('light_level', 'Light Levels') }}
-                                {{ nav_link('slowcontrol_plots', 'Slow Control Plots (NEW!)') }}     
+                                {{ nav_link('light_level', 'Light Levels') }}     
                             </ul>
                         <!-- Remote Control Rooms -->
                         <li class='dropdown'>

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -31,30 +31,51 @@
             <table class="table table-hover">
             <tr>
                 <th> Date Range: </th>
-                <th> Criteria: </th>
+                <th> Datastream: </th>
                 <th> </th>
             </tr>
             <tr>
-                <!-- Run date inputs -->
+                <!-- Data datetime inputs -->
                 <th>
-		            <input style="margin-bottom: 30px;" type="date" id="date_low" value={{date_low}} required></input>
-                    -
-                    <input style="margin-bottom: 30px;" type="date" id="date_high" value={{date_high}} required></input>
+                    <div>
+                        <input style="margin-bottom: 30px;" type="datetime-local" id="datetime_low" value={{datetime_low}} required></input> 
+                    </div>
+                    <div>
+                        <input style="margin-bottom: 30px;" type="datetime-local" id="datetime_high" value={{datetime_high}} required></input>
+                    </div>
                 </th>
-                <!-- Criteria drop-down -->
+                <!-- Channel selector -->
                 <th>
-                    <select id="crit">
-                    <option selected value="{{criteria}}">{{criteria}}</option>
-                    {% for n in drop_down_crits %}
-                        {% if n != criteria %}
-                            <option value="{{n}}">{{n}}</option>
-                        {% endif %}
-                    {% endfor %}
-                    </select>
+                    <div>
+                        <label for="supply">Supply Voltage</label>
+                        <input type="radio" id="supply" value="supply" name="crit" checked>
+                        <label for="supply-rack">Rack #</label>
+                        <input type="number" id="supply-rack" name="supply-rack" min="1" max="11" value="7" style="width: 4em">
+                        <label for="supply-voltage">Voltage</label>
+                        <select name="supply-voltage" id="supply-voltage">
+                            <option value="24">24V</option>
+                            <option value="-24">-24V</option>
+                            <option value="8">8V</option>
+                            <option value="5">5V</option>
+                            <option value="-5">-5V</option>
+                        </select>
+                    </div>
+
+                    <div>
+                        <label for="baseline">Baseline Voltage</label>
+                        <input type="radio" id="baseline" value="baseline" name="crit" checked>
+                        <label for="baseline-crate">Crate #</label>
+                        <input type="number" id="baseline-crate" name="baseline-crate" min="0" max="18" value="7" style="width: 4em">
+                        <label for="crate-trigger">Trigger</label>
+                        <select name="crate-trigger" id="crate-trigger">
+                            <option value="100">N100_BL</option>
+                            <option value="20">-N20_BL</option>
+                        </select>
+                    </div>
                 </th>
-                <!-- Button to update plots with the run dates & criteria -->
+                <!-- Button to plot the data -->
                 <th class="col-xs-3 col-xs-offset-0">
-                    <button type=button onclick="history();">Update Plot</button>
+                    <button type=button onclick="history();">Generate Plot</button>
 </th>
 </tr>
 </table>
@@ -92,11 +113,11 @@
     <script src="{{ url_for('static', filename='js/mg_line_brushing.js') }}"></script>
     <script src="{{ url_for('static', filename='js/stream_utilities.js') }}"></script>
     <script>
-        if (url_params.date_low && document.getElementById("date_low").value == "") {
-            document.getElementById("date_low").value = url_params.date_low;
+        if (url_params.datetime_low && document.getElementById("datetime_low").value == "") {
+            document.getElementById("datetime_low").value = url_params.datetime_low;
         }
-        if (url_params.date_high && document.getElementById("date_high").value == "") {
-            document.getElementById("date_high").value = url_params.date_high;
+        if (url_params.datetime_high && document.getElementById("datetime_high").value == "") {
+            document.getElementById("datetime_high").value = url_params.datetime_high;
         }
         if (url_params.criteria) {
             document.getElementById("crit").value = url_params.criteria;
@@ -187,14 +208,14 @@ for (var i=0; i < summaryTime.length; i++)
         function history() {
             var params = {};
             try {
-                params['date_low'] = document.getElementById("date_low").value;
+                params['datetime_low'] = document.getElementById("datetime_low").value;
             } catch (e) {
-                params['date_low'] = "2024-02-19";
+                params['datetime_low'] = "2024-02-19T00:00";
             }
             try {
-                params['date_high'] = document.getElementById("date_high").value;
+                params['datetime_high'] = document.getElementById("datetime_high").value;
             } catch (e) {
-                params['date_high'] = "2024-05-29";
+                params['datetime_high'] = "2024-05-29T23:59";
             }
             try {
                 params['criteria'] = document.getElementById("crit").value;

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -374,13 +374,13 @@
             legend: dataNames,
             interpolate: 'linear',
 
-            y_mouseover: function(data, index) {
+            y_mouseover: function(data) {
                 var voltage = parseFloat(data['value']).toFixed(4);
                 return voltage + ' V';
             },
 
-            x_mouseover: function(data, index) {
-                return moment(data.reftime).format(time_fmt);
+            x_mouseover: function(data) {
+                return moment(data.key).format(time_fmt);
             }
         };
 

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -106,7 +106,7 @@
     <div class="row">
     <div class="col-md-12" id="main">
       {% if not slow_data %}
-        <h2 align="left"> No data available </h2>
+        <h2 align="left"> No data </h2>
       {% endif %}
 
     </div>
@@ -147,38 +147,51 @@
         if (url_params.baseline_trigger) {
             document.getElementById("baseline-trigger").value = url_params.baseline_trigger;
         }
-        // if (url_params.criteria) {
-        //     document.getElementById("crit").value = url_params.criteria;
-        // }
 
-        var slow_data = {{ slow_data | safe }};
-
-        // TODO: may need to loop this with multi-line plots
-        var mySingleDatastream = new Array();
-        mySingleDatastream = slow_data;
-        
-        // TODO: store the human-readable "names" of each dataset?
-        var myDataNames = new Array();
-        myDataNames.push("Test Data")
-
-        for (var i=0; i < slow_data.length; i++)
-        {
-            slow_data[i]['key'] = moment.unix(slow_data[i]['key']).toDate()
-            // timestamps.push(slow_data[i][0]);
-            // mySingleDatastream.push({'time': slow_data[i][0], 'value': slow_data[i][1]});
+        function initializeStoredArray(name) {
+            rawValue = sessionStorage.getItem(name)
+            if ((typeof rawValue !== "undefined") && (rawValue !== null))  { //probably only need "null" 
+                return JSON.parse(rawValue)
+            }
+            else {
+                return []
+            }
         }
 
-        minTime = mySingleDatastream[0]['key'];
-        maxTime = mySingleDatastream[mySingleDatastream.length-1]['key'];
+        function storeArray(name, data) {
+            return sessionStorage.setItem(name, JSON.stringify(data))
+        }
+
+        var newSlowData = {{ slow_data | safe }};
+        var newDataName = "{{ data_name | safe }}"; // this sucks, fix it
+
+        var slowData = initializeStoredArray("storedSlowData")
+        var dataNames = initializeStoredArray("storedDataNames")
+
+        if (newSlowData !== undefined) { //unfortunate, but null handling is hard
+            slowData.push(newSlowData)
+        }
+        if (newDataName !== undefined) {
+            dataNames.push(newDataName)
+        }
+
+        const headData = slowData[0] // first array of data, avoids slowData[0][i]['key'] etc
+
+        for (var i=0; i < headData.length; i++) {
+            headData[i]['key'] = moment.unix(headData[i]['key']).toDate()
+        }
+
+        minTime = headData[0]['key'];
+        maxTime = headData[headData.length-1]['key'];
         var cscale = tzscale().domain([minTime, maxTime]).zone('America/Toronto');
 
         var time_fmt = 'MMMM Do YYYY, h:mm:ss a';
         
-// <!-- Messy bit of code to get the run summary section but it works... -MD -->
-//copied from runselection_plots, probably unneccesary here
-// 	var summaryTime = [rs_plot_data[rs_plot_data.length - 1]['phys_total'],rs_plot_data[rs_plot_data.length - 1]['pass_total'],rs_plot_data[rs_plot_data.length - 1]['fail_total'],rs_plot_data[rs_plot_data.length - 1]['purg_total']]
-    
-//     var summaryRuns = [rs_plot_data[rs_plot_data.length - 1]['phys_runs'],rs_plot_data[rs_plot_data.length - 1]['pass_runs'],rs_plot_data[rs_plot_data.length - 1]['fail_runs'],rs_plot_data[rs_plot_data.length - 1]['purg_runs']]
+    // <!-- Messy bit of code to get the run summary section but it works... -MD -->
+    //copied from runselection_plots, a summary is probably unneccesary here
+    // 	var summaryTime = [rs_plot_data[rs_plot_data.length - 1]['phys_total'],rs_plot_data[rs_plot_data.length - 1]['pass_total'],rs_plot_data[rs_plot_data.length - 1]['fail_total'],rs_plot_data[rs_plot_data.length - 1]['purg_total']]
+        
+    //     var summaryRuns = [rs_plot_data[rs_plot_data.length - 1]['phys_runs'],rs_plot_data[rs_plot_data.length - 1]['pass_runs'],rs_plot_data[rs_plot_data.length - 1]['fail_runs'],rs_plot_data[rs_plot_data.length - 1]['purg_runs']]
     
 
     // for (var i=0; i < summaryTime.length; i++)
@@ -197,7 +210,7 @@
 
         var dparams = {
             area: false,
-            data: [mySingleDatastream], //TODO: generate this with each line after constructing datasets
+            data: slowData,
             width: $('#main').width(),
             left: 100,
             right: 100,
@@ -207,12 +220,10 @@
             x_accessor:'key',
             y_accessor:'value',
             point_size: 4.0,
-            y_label: "Voltage",
             x_label: "Time",
+            y_label: "Voltage",
             decimals: 4,
-            legend: myDataNames,
-    
-	// <!-- Adding the unit to the mouse over legend and fixing the value to 3 decimal places -->
+            legend: dataNames,
             interpolate: 'linear',
 
             y_mouseover: function(data, index) {
@@ -225,7 +236,10 @@
             }
         };
 
-        MG.data_graphic(dparams);
+        if (headData !== undefined) {
+            MG.data_graphic(dparams); //replaces "No data" text
+        }
+        
         document.getElementById("waiting").innerHTML="";
 
         // the only way to change line width, i tried. ugh

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -67,12 +67,13 @@
                         </select>
                         <label for="supply-voltage">Voltage</label>
                         <select name="supply-voltage" id="supply-voltage">
-                            <option disabled selected hidden>...</option>
+                            <option disabled selected hidden id="default-voltage">...</option>
                             <option value="24">24V</option>
                             <option value="-24">-24V</option>
                             <option value="8" id="supply-flippy">8V</option>
                             <option value="5">5V</option>
                             <option value="-5">-5V</option>
+                            <option value="mtcd" id="mtcd" hidden>MTCD 2V</option>
                         </select>
                     </div>
 

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -96,16 +96,16 @@
     <div class="row">
     <div class="col-md-12" id="sum">
         <h2 align="left"> Summary: </h2>
-        <p id="phys_summary"> </p>
-        <p id="pass_summary"> </p>
-        <p id="fail_summary"> </p>
-        <p id="purg_summary"> </p>
+        <p id="data-summary"> </p>
+        <div id="waiting">
+            Received data, loading....
+        </div>
     </div>
         </div>
 <!-- Plot goes here -->
     <div class="row">
     <div class="col-md-12" id="main">
-      {% if not rs_plot_data %}
+      {% if not slow_data %}
         <h2 align="left"> No data available </h2>
       {% endif %}
 
@@ -153,22 +153,24 @@
 
         var slow_data = {{ slow_data | safe }};
 
-        var timestamps = new Array();
         // TODO: may need to loop this with multi-line plots
         var mySingleDatastream = new Array();
+        mySingleDatastream = slow_data;
         
         // TODO: store the human-readable "names" of each dataset?
         var myDataNames = new Array();
         myDataNames.push("Test Data")
 
-        for (var i=0; i < slow_data.length; i++)
-        {
-            // ts = moment(slow_data[i][0]).format('MMMM Do YYYY, h:mm:ss a')
-            // timestamps.push(ts); //sus
-            timestamps.push(slow_data[i][0]);
-            mySingleDatastream.push({'time': slow_data[i][0], 'value': slow_data[i][1]});
-        }
-        var cscale = tzscale().domain(timestamps).zone('America/Toronto');
+        // for (var i=0; i < slow_data.length; i++)
+        // {
+        //     ts = moment(slow_data[i][0]).format('MMMM Do YYYY, h:mm:ss a')
+        //     timestamps.push(slow_data[i][0]);
+        //     mySingleDatastream.push({'time': slow_data[i][0], 'value': slow_data[i][1]});
+        // }
+
+        minTime = mySingleDatastream[0]['key'];
+        maxTime = mySingleDatastream[mySingleDatastream.length-1]['key'];
+        var cscale = tzscale().domain([minTime, maxTime]).zone('America/Toronto');
 
         var time_fmt = 'MMMM Do YYYY, h:mm:ss a';
         
@@ -202,7 +204,7 @@
             height: 500,
             target: "#main",
             time_scale: cscale,
-            x_accessor:'time',
+            x_accessor:'key',
             y_accessor:'value',
             point_size: 4.0,
             y_label: "Voltage",
@@ -220,6 +222,7 @@
         };
 
         MG.data_graphic(dparams);
+        document.getElementById("waiting").innerHTML="";
 
         // the only way to change line width, i tried. ugh
         // changing dparams or overriding CSS did NOT work, for me at least

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -448,20 +448,41 @@
 
         function history() {
             var params = {};
+            
+            sessionStorage.setItem("endTimestamp", document.getElementById("datetime_high").value);
+            sessionStorage.setItem("dataType", document.querySelector("input[name=channel-type]:checked").value);
+            appendPlotButton.setAttribute("disabled", "");
+            newPlotButton.setAttribute("disabled", "");
+
+            // if timestamp bounds exist for past data, continue
+            // otherwise, set them, based on the value of the picker
+            // on error, set them to a default fallback value
+            // in either case, set the parameter to this stored value
             try {
-                params['datetime_low'] = document.getElementById("datetime_low").value;
+                if (sessionStorage.getItem("startTimestamp") === undefined) {
+                    sessionStorage.setItem("startTimestamp", document.getElementById("datetime_low").value);
+                }
             } catch (e) {
-                params['datetime_low'] = "2024-02-19T00:00";
+                sessionStorage.setItem("startTimestamp", "2024-02-19T00:00");
+            } finally {
+                params['datetime_low'] = sessionStorage.getItem("startTimestamp")
             }
             try {
-                params['datetime_high'] = document.getElementById("datetime_high").value;
+                if (sessionStorage.getItem("endTimestamp") === undefined) {
+                    sessionStorage.setItem("endTimestamp", document.getElementById("datetime_high").value);
+                }
+                params['datetime_high'] = sessionStorage.getItem("endTimestamp")
             } catch (e) {
-                params['datetime_high'] = "2024-05-29T23:59";
+                sessionStorage.setItem("endTimestamp", "2024-05-29T23:59");
+            } finally {
+                params['datetime_high'] = sessionStorage.getItem("endTimestamp")
             }
+
+            // set all other parameters (simply query the input, or fall back on a default)
             try {
                 params['channel_type'] = document.querySelector("input[name=channel-type]:checked").value;
             } catch (e) {
-                //pass?
+                //pass? there's no good default here
             }
             try {
                 params['supply_rack'] = document.getElementById("supply-rack").value;
@@ -483,11 +504,7 @@
             } catch (e) {
                 params['baseline_trigger'] = "100";
             }
-            // try {
-            //     params['criteria'] = document.getElementById("crit").value;
-            // } catch (e) {
-            //     params['criteria'] = "scintillator_silver";
-            // }
+
             window.location.replace($SCRIPT_ROOT + "/slowcontrol_plots?" + $.param(params));
         }
 
@@ -501,28 +518,18 @@
         function historyAppend() {
             storeArray("storedSlowData", slowData);
             storeArray("storedDataNames", dataNames);
-            sessionStorage.setItem("dataType", document.querySelector("input[name=channel-type]:checked").value);
             appendPlotButton.innerHTML = `Est. wait: ${getEstTimeString()}`;
-            appendPlotButton.setAttribute("disabled", "");
-            newPlotButton.setAttribute("disabled", "");
             history();
         }
         
         function historyNew() {
-            sessionStorage.removeItem("storedSlowData");
-            sessionStorage.removeItem("storedDataNames");
-            sessionStorage.setItem("dataType", document.querySelector("input[name=channel-type]:checked").value);
+            sessionStorage.clear();
             newPlotButton.innerHTML = `Est. wait: ${getEstTimeString()}`;
-            appendPlotButton.setAttribute("disabled", "");
-            newPlotButton.setAttribute("disabled", "");
             history();
         }
 
         function historyClear() {
-            sessionStorage.removeItem("storedSlowData");
-            sessionStorage.removeItem("storedDataNames");
-            sessionStorage.removeItem("dataType");
-
+            sessionStorage.clear();
             window.location.replace($SCRIPT_ROOT + "/slowcontrol_plots");
         }
 

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -6,17 +6,6 @@
     <link rel="stylesheet" type="text/css"  href="{{ url_for('static',filename='css/metricsgraphics.css') }}">
     <link rel="stylesheet" type="text/css"  href="{{ url_for('static',filename='css/mg_line_brushing.css') }}">
   {{ super() }}
-  <style>
-    .btn2 {
-        background-color: #228B22;
-        padding: 6px 6px;
-        color: white;
-        text-align: center;
-        font-size: 14px;
-        margin: 4px 2px;
-        cursor: pointer;
-    }
-  </style>
 {% endblock %}
 {% block body %}
     {{ super() }}
@@ -91,7 +80,7 @@
                         </select>
                     </div>
                 </th>
-                <!-- Button to plot the data -->
+                <!-- Plot controls -->
                 <th class="col-xs-3 col-xs-offset-0">
                     <div> <button type=button id="new-plot" onclick="historyNew();">Generate New Plot</button> </div>
                     <div> <button type=button id="append-plot" onclick="historyAppend();">Add To Plot</button> </div>
@@ -143,108 +132,35 @@
 </div>
 
 <style>
-    .mg-line1-legend-color {
-        color: #88D642;
-        fill: #88D642;
-    }
+    .mg-line1-legend-color {color: #88D642; fill: #88D642;} 
+    .mg-line1-color {stroke: #88D642;}
+    .mg-hover-line1-color {fill: #88D642;}
+    .mg-area1-color {fill: #88D642;}
 
-    .mg-line1-color {
-        stroke: #88D642;
-    }
+    .mg-line2-legend-color {color: #FF79C0; fill: #FF79C0;}
+    .mg-line2-color {stroke: #FF79C0;}
+    .mg-hover-line2-color {fill: #FF79C0;}
+    .mg-area2-color {fill: #FF79C0;}
 
-    .mg-hover-line1-color {
-        fill: #88D642;
-    }
-    
-    .mg-area1-color {
-        fill: #88D642;
-    }
+    .mg-line3-legend-color {color: #60c1bf; fill: #60c1bf;}
+    .mg-line3-color {stroke: #60c1bf;}
+    .mg-hover-line3-color {fill: #60c1bf;}
+    .mg-area3-color {fill: #60c1bf;}
 
-    .mg-line2-legend-color {
-        color: #FF79C0;
-        fill: #FF79C0;
-    }
+    .mg-line4-legend-color {color: #f8b128; fill: #f8b128;}
+    .mg-line4-color {stroke: #f8b128;}
+    .mg-hover-line4-color {fill: #f8b128;}
+    .mg-area4-color {fill: #f8b128;}
 
-    .mg-line2-color {
-        stroke: #FF79C0;
-    }
+    .mg-line5-legend-color {color: #5c5c5c; fill: #5c5c5c;}    
+    .mg-line5-color {stroke: #5c5c5c;}
+    .mg-hover-line5-color {fill: #5c5c5c;}
+    .mg-area5-color {fill: #5c5c5c;}
 
-    .mg-hover-line2-color {
-        fill: #FF79C0;
-    }
-
-    .mg-area2-color {
-        fill: #FF79C0;
-    }
-
-    .mg-line3-legend-color {
-        color: #60c1bf;
-        fill: #60c1bf;
-    }
-    
-    .mg-line3-color {
-        stroke: #60c1bf;
-    }
-
-    .mg-hover-line3-color {
-        fill: #60c1bf;
-    }
-
-    .mg-area3-color {
-        fill: #60c1bf;
-    }
-
-    .mg-line4-legend-color {
-        color: #f8b128;
-        fill: #f8b128;
-    }
-
-    .mg-line4-color {
-        stroke: #f8b128;
-    }
-
-    .mg-hover-line4-color {
-        fill: #f8b128;
-    }
-
-    .mg-area4-color {
-        fill: #f8b128;
-    }
-
-    .mg-line5-legend-color {
-        color: #5c5c5c;
-        fill: #5c5c5c;
-    }    
-
-    .mg-line5-color {
-        stroke: #5c5c5c;
-    }
-
-    .mg-hover-line5-color {
-        fill: #5c5c5c;
-    }
-
-    .mg-area5-color {
-        fill: #5c5c5c;
-    }
-
-    .mg-line6-legend-color {
-        color: #0101d4;
-        fill: #0101d4;
-    }    
-
-    .mg-line6-color {
-        stroke: #0101d4;
-    }
-
-    .mg-hover-line6-color {
-        fill: #0101d4;
-    }
-
-    .mg-area6-color {
-        fill: #0101d4;
-    }
-
+    .mg-line6-legend-color {color: #0101d4; fill: #0101d4;}    
+    .mg-line6-color {stroke: #0101d4;}
+    .mg-hover-line6-color {fill: #0101d4;}
+    .mg-area6-color {fill: #0101d4;}
 </style>
 
 {% endblock %}
@@ -268,18 +184,6 @@
         if (url_params.channel_type) {
             document.getElementById(url_params.channel_type).checked = true 
         }
-        // if (url_params.supply_rack) {
-        //     document.getElementById("supply-rack").value = url_params.supply_rack;
-        // }
-        // if (url_params.supply_voltage) {
-        //     document.getElementById("supply-voltage").value = url_params.supply_voltage;
-        // }
-        // if (url_params.baseline_crate) {
-        //     document.getElementById("baseline-crate").value = url_params.baseline_crate;
-        // }
-        // if (url_params.baseline_trigger) {
-        //     document.getElementById("baseline-trigger").value = url_params.baseline_trigger;
-        // }
 
         function initializeStoredArray(name) {
             rawValue = sessionStorage.getItem(name)
@@ -318,15 +222,9 @@
                     throw new Error("Data streams were incompatible.");
                 }
                 datastream.forEach((datapoint) => {
-                    datapoint['reftime'] = moment.unix(datapoint['key']).toDate();
+                    datapoint['key'] = moment.unix(datapoint['key']).toDate();
                 });
             });
-
-            // for (var i = 0; i < slowData[0].length; i++) {
-            //     // assumes same times for all data
-            //     var currentTimeData = slowData.map((datastream) => datastream[i]['value']) // build array of each datastream's value at current time
-            //     mergedData.push({'value': currentTimeData, 'reftime': slowData[0][i]['reftime']}); //pair array with reftime of first datastream
-            // }
 
             mintime = slowData[0][0]['key'];
             maxtime = slowData[0][slowData[0].length-1]['key'];
@@ -334,27 +232,6 @@
         } 
 
         var time_fmt = 'MMMM Do YYYY, h:mm:ss a';
-        
-    // <!-- Messy bit of code to get the run summary section but it works... -MD -->
-    //copied from runselection_plots, a summary is probably unneccesary here
-    // 	var summaryTime = [rs_plot_data[rs_plot_data.length - 1]['phys_total'],rs_plot_data[rs_plot_data.length - 1]['pass_total'],rs_plot_data[rs_plot_data.length - 1]['fail_total'],rs_plot_data[rs_plot_data.length - 1]['purg_total']]
-        
-    //     var summaryRuns = [rs_plot_data[rs_plot_data.length - 1]['phys_runs'],rs_plot_data[rs_plot_data.length - 1]['pass_runs'],rs_plot_data[rs_plot_data.length - 1]['fail_runs'],rs_plot_data[rs_plot_data.length - 1]['purg_runs']]
-    
-
-    // for (var i=0; i < summaryTime.length; i++)
-    //     {
-    //         var j = parseFloat(summaryTime[i]).toFixed(3);
-    //         summaryTime[i] = j;
-    //     }
-
-	// document.getElementById("phys_summary").innerHTML = 'Physics: ' + summaryTime[0].toString() + ' Days, ' +summaryRuns[0].toString() + ' Runs';
-    // if (summaryRuns[1] == 0) {document.getElementById("pass_summary").innerHTML = 'Passed: None';}
-    // else{document.getElementById("pass_summary").innerHTML = 'Passed: ' + summaryTime[1].toString() + ' Days, ' +summaryRuns[1].toString() + ' Runs';}
-    // if (summaryRuns[2] == 0) {document.getElementById("fail_summary").innerHTML = 'Failed: None';}
-    // else{document.getElementById("fail_summary").innerHTML = 'Failed: ' + summaryTime[2].toString() + ' Days, ' +summaryRuns[2].toString() + ' Runs';}
-    // if (summaryRuns[3] == 0) {document.getElementById("purg_summary").innerHTML = 'Purgatory: None';}
-    // else{document.getElementById("purg_summary").innerHTML = 'Purgatory: ' + summaryTime[3].toString()  + ' Days, ' +summaryRuns[3].toString() + ' Runs';}
 
         var dparams = {
             area: false,
@@ -365,7 +242,7 @@
             height: 500,
             target: "#main",
             time_scale: cscale,
-            x_accessor:'reftime',
+            x_accessor:'key',
             y_accessor:'value',
             point_size: 4.0,
             x_label: "Time",
@@ -418,8 +295,8 @@
         for (var i = 0; i < slowData.length; i++) {
             var streamLength = slowData[i].length;
             var myName = dataNames[i];
-            var myFirstTime = moment.unix(slowData[i][0].key).format(time_fmt);
-            var myLastTime = moment.unix(slowData[i][streamLength-1].key).format(time_fmt);
+            var myFirstTime = moment(slowData[i][0].key).format(time_fmt);
+            var myLastTime = moment(slowData[i][streamLength-1].key).format(time_fmt);
             addDatastreamTableRow(myName, myFirstTime, myLastTime, streamLength, i);
         }
         

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -491,20 +491,30 @@
             window.location.replace($SCRIPT_ROOT + "/slowcontrol_plots?" + $.param(params));
         }
 
+        function getEstTimeString() {
+            var millisecondDifference = moment(datetimeHighInput.value) - moment(datetimeLowInput.value);
+            const DataMsPerMsQueryTime = 100000; //ie. 1 ms of query time returns 20 results, or 100secs of data
+            var estWaitTimeMs = millisecondDifference / DataMsPerMsQueryTime;
+            return moment.duration(estWaitTimeMs).locale('en').humanize(); 
+        }
+
         function historyAppend() {
             storeArray("storedSlowData", slowData);
             storeArray("storedDataNames", dataNames);
             sessionStorage.setItem("dataType", document.querySelector("input[name=channel-type]:checked").value);
-
+            appendPlotButton.innerHTML = `Est. wait: ${getEstTimeString()}`;
+            appendPlotButton.setAttribute("disabled", "");
+            newPlotButton.setAttribute("disabled", "");
             history();
         }
-
         
         function historyNew() {
             sessionStorage.removeItem("storedSlowData");
             sessionStorage.removeItem("storedDataNames");
             sessionStorage.setItem("dataType", document.querySelector("input[name=channel-type]:checked").value);
-
+            newPlotButton.innerHTML = `Est. wait: ${getEstTimeString()}`;
+            appendPlotButton.setAttribute("disabled", "");
+            newPlotButton.setAttribute("disabled", "");
             history();
         }
 

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -19,13 +19,17 @@
         <div class="col-md-12">
             <table class="table table-hover">
             <tr>
-                <th> Date Range: </th>
-                <th> Datastream: </th>
-                <th> </th>
+                <th> Date Range </th>
+                <th> Datastream </th>
+                <th> Plot Actions </th>
+                <th> Plot Controls 
+                    <button style="margin-left:0.5em; {% if not slow_data %} visibility:hidden {% endif %}" disabled 
+                    id="update-plot" onclick="updatePlot()">Update</button> 
+                </th>
             </tr>
             <tr>
                 <!-- Data datetime inputs -->
-                <th>
+                <th class="col-s-3 col-xs-offset-0">
                     <div>
                         <input style="margin-bottom: 10px;" type="datetime-local" id="datetime_low" value="{{datetime_low}}" required></input> 
                     </div>
@@ -35,60 +39,84 @@
                     <div id="date-warning" hidden style="color:red">Clear the plot to unlock dates.</div>
                 </th>
                 <!-- Channel selector -->
-                <th>
-                    <div>
-                        <label for="supply">Supply Voltage</label>
-                        <input type="radio" id="supply" value="supply" name="channel-type" checked>
-                        <label for="supply-rack">Rack #</label>
-                        <select name="supply-rack" id="supply-rack">
-                            <option disabled selected hidden>...</option>
-                            <option value="1">Rack 1</option>
-                            <option value="2">Rack 2</option>
-                            <option value="3">Rack 3</option>
-                            <option value="4">Rack 4</option>
-                            <option value="5">Rack 5</option>
-                            <option value="6">Rack 6</option>
-                            <option value="7">Rack 7</option>
-                            <option value="8">Rack 8</option>
-                            <option value="9">Rack 9</option>
-                            <option value="10">Rack 10</option>
-                            <option value="11">Rack 11</option>
-                            <option value="timing">Timing Rack</option>
-                        </select>
-                        <label for="supply-voltage">Voltage</label>
-                        <select name="supply-voltage" id="supply-voltage">
-                            <option disabled selected hidden id="default-voltage">...</option>
-                            <option value="24">24V</option>
-                            <option value="-24">-24V</option>
-                            <option value="8" id="supply-flippy">8V</option>
-                            <option value="5">5V</option>
-                            <option value="-5">-5V</option>
-                            <option value="mtcd" id="mtcd" hidden>MTCD 2V</option>
-                        </select>
-                    </div>
-
-                    <div>
-                        <label for="baseline">Baseline Voltage</label>
-                        <input type="radio" id="baseline" value="baseline" name="channel-type">
-                        <label for="baseline-crate">Crate #</label>
-                        <input type="number" id="baseline-crate" name="baseline-crate" min="0" max="18" value="" style="width: 4em">
-                        <label for="baseline-trigger">Trigger</label>
-                        <select name="baseline-trigger" id="baseline-trigger">
-                            <option disabled selected hidden>...</option>
-                            <option value="100">N100_BL</option>
-                            <option value="20">N20_BL</option>
-                        </select>
-                    </div>
+                <th class="col-s-3 col-xs-offset-0">
+                    <table style="border-spacing:0 1em; border-collapse:separate">
+                        <tr>
+                            <th class="col-m-3 col-xs-offset-0" style="padding-right:1em">
+                                <label for="supply">Supply Voltage</label>
+                                <input type="radio" id="supply" value="supply" name="channel-type" style="float:right" checked>
+                            </th>
+                            <th class="col-m-3 col-xs-offset-0" style="padding-right:1em">
+                                <label for="supply-rack">Rack #</label>
+                                <select name="supply-rack" id="supply-rack">
+                                    <option disabled selected hidden>...</option>
+                                    <option value="1">Rack 1</option>
+                                    <option value="2">Rack 2</option>
+                                    <option value="3">Rack 3</option>
+                                    <option value="4">Rack 4</option>
+                                    <option value="5">Rack 5</option>
+                                    <option value="6">Rack 6</option>
+                                    <option value="7">Rack 7</option>
+                                    <option value="8">Rack 8</option>
+                                    <option value="9">Rack 9</option>
+                                    <option value="10">Rack 10</option>
+                                    <option value="11">Rack 11</option>
+                                    <option value="timing">Timing Rack</option>
+                                </select>
+                            </th>
+                            <th class="col-m-3 col-xs-offset-0">
+                                <label for="supply-voltage">Voltage</label>
+                                <select name="supply-voltage" id="supply-voltage">
+                                    <option disabled selected hidden id="default-voltage">...</option>
+                                    <option value="24">24V</option>
+                                    <option value="-24">-24V</option>
+                                    <option value="8" id="supply-flippy">8V</option>
+                                    <option value="5">5V</option>
+                                    <option value="-5">-5V</option>
+                                    <option value="mtcd" id="mtcd" hidden>MTCD 2V</option>
+                                </select>
+                            <th>
+                        </tr>
+                        <tr>
+                            <th class="col-m-3 col-xs-offset-0" style="padding-right:1em">
+                                <label for="baseline">Baseline Voltage</label>
+                                <input type="radio" id="baseline" value="baseline" name="channel-type">
+                            </th>
+                            <th class="col-m-3 col-xs-offset-0" style="padding-right:1em">
+                                <label for="baseline-crate">Crate #</label>
+                                <input type="number" id="baseline-crate" name="baseline-crate" min="0" max="18" value="" style="width: 4em">
+                            </th>
+                            <th>
+                                <label for="baseline-trigger">Trigger</label>
+                                <select name="baseline-trigger" id="baseline-trigger">
+                                    <option disabled selected hidden>...</option>
+                                    <option value="100">N100_BL</option>
+                                    <option value="20">N20_BL</option>
+                                </select>
+                            </th>
+                        </tr>
+                    </table>
+                </th>
+                <!-- Plot actions -->
+                <th class="col-xl-3 col-xs-offset-0" style="padding-left">
+                    <div style="padding-bottom:0.5em"> <button type=button id="new-plot" onclick="historyNew();">Generate New Plot</button> </div>
+                    <div style="padding-bottom:0.5em"> <button type=button id="append-plot" onclick="historyAppend();">Add To Plot</button> </div>
+                    <div> <button type=button id="append-plot" onclick="historyClear();">Clear Plot</button> </div>
+                    <div id="mismatch-warning" style="color:red; padding-top:0.6em; visibility:hidden">Data types must match.</div>
                 </th>
                 <!-- Plot controls -->
-                <th class="col-xs-3 col-xs-offset-0">
-                    <div> <button type=button id="new-plot" onclick="historyNew();">Generate New Plot</button> </div>
-                    <div> <button type=button id="append-plot" onclick="historyAppend();">Add To Plot</button> </div>
-                    <div id="mismatch-warning" style="color:red" hidden>Data types must match.</div>
-                    <div> <button type=button id="append-plot" onclick="historyClear();">Clear Plot</button> </div>
+                <th class="col-s-3 col-xs-offset-0">
+                    {% if slow_data %}
+                    <div> <input type=checkbox id="y-max-check"> Override Max </input> <input type="number" id="y-max-value" step="0.1" style="width:4em" disabled> </div>
+                    <div> <input type=checkbox id="y-min-check"> Override Min </input> <input type="number" id="y-min-value" step="0.1" style="width:4em" disabled> </div>
+                    <div> <input type="radio" id="y-axis-relative" value="relative" name="y-axis-type" checked> <label for="axis-relative">Relative Default Range</label> </div>
+                    <div> <input type="radio" id="y-axis-absolute" value="absolute" name="y-axis-type"> <label for="axis-absolute">Absolute Default Range</label> </div>
+                    {% else %}
+                    <div> (No data) </div>
+                    {% endif %}
                 </th>
-                </tr>
-                </table>
+            </tr>
+            </table>
     <div class="row">
         <div class="col-md-12" id="sum">
             <div id="waiting" { % if not slow_data % } hidden { % endif % }>
@@ -177,11 +205,16 @@
     <script src="{{ url_for('static', filename='js/stream_utilities.js') }}"></script>
     <script src="{{ url_for('static', filename='js/slowcontrol_plots.js') }}"></script>
     <script>
-        if (url_params.datetime_low && document.getElementById("datetime_low").value == "") {
-            document.getElementById("datetime_low").value = url_params.datetime_low;
+
+        const datetimeLowInput = document.getElementById("datetime_low");
+        const datetimeHighInput = document.getElementById("datetime_high");
+        const dateWarningText = document.getElementById("date-warning");
+
+        if (url_params.datetime_low && datetimeLowInput.value == "") {
+            datetimeLowInput.value = url_params.datetime_low;
         }
-        if (url_params.datetime_high && document.getElementById("datetime_high").value == "") {
-            document.getElementById("datetime_high").value = url_params.datetime_high;
+        if (url_params.datetime_high && datetimeHighInput.value == "") {
+            datetimeHighInput.value = url_params.datetime_high;
         }
         if (url_params.channel_type) {
             document.getElementById(url_params.channel_type).checked = true 
@@ -209,6 +242,7 @@
         var dataNames = initializeStoredArray("storedDataNames")
         var baseRanges = initializeStoredArray("storedBaseRanges")
         var dataType = sessionStorage.getItem("dataType");
+        var plotControlsState = sessionStorage.getItem("storedPlotControls")
 
         if (newSlowData !== null) { //unfortunate, but null handling is hard
             slowData.push(newSlowData)
@@ -218,6 +252,19 @@
         }
         if (newBaseRange !== null && !baseRanges.includes(newBaseRange)) {
             baseRanges.push(newBaseRange)
+        }
+
+        if (plotControlsState !== null) {
+            yMaxCheckbox.checked = plotControlsState["yMaxOn"];
+            yMinCheckbox.checked = plotControlsState["yMinOn"];
+            yMaxValueEntry.checked = plotControlsState["yMaxVal"];
+            yMinValueEntry.checked = plotControlsState["yMinVal"];
+            if (plotControlsState["yAxisMode"] === "relative") {
+                relativeRadio.checked = true;
+            }
+            else if (plotControlsState["yAxisMode"] === "absolute") {
+                absoluteRadio.checked = true;
+            }
         }
 
         var mergedData = []
@@ -246,42 +293,97 @@
         } 
 
         var time_fmt = 'MMMM Do YYYY, h:mm:ss a';
-
-        var dparams = {
-            area: false,
-            data: slowData,
-            width: $('#main').width(),
-            left: 100,
-            right: 100,
-            height: 500,
-            target: "#main",
-            time_scale: cscale,
-            x_accessor:'key',
-            y_accessor:'value',
-            point_size: 4.0,
-            x_label: "Time",
-            y_label: "Voltage",
-            max_y: (Math.max(...baseRanges) * 1.1) + 1,
-            min_y: (Math.min(...baseRanges) - (0.1 * Math.abs(Math.min(...baseRanges)))) - 1,
-            baselines: baseRanges.map(function(baseline, index) {
-                    return {"value": baseline, "label": `${baseline}V`};
-                }),
-            decimals: 4,
-            legend: dataNames,
-            interpolate: 'linear',
-
-            y_mouseover: function(data) {
-                var voltage = parseFloat(data['value']).toFixed(4);
-                return voltage + ' V';
-            },
-
-            x_mouseover: function(data) {
-                return moment(data.key).format(time_fmt);
+        
+        function getMaxY() {
+            if (yMaxCheckbox.checked) { 
+                return yMaxValueEntry.value; 
             }
-        };
+            else {
+                var axisMode = document.querySelector("input[name=y-axis-type]:checked").value;
+                if (axisMode === relativeRadio.value) { 
+                    return (Math.max(...baseRanges) * 1.1) + 1; 
+                }
+                else if (axisMode === absoluteRadio.value) { 
+                    return null; 
+                }
+            }
+            return null;
+        }
+        
+        function getMinY() {
+            if (yMinCheckbox.checked) { 
+                return yMinValueEntry.value; 
+            }
+            else {
+                var axisMode = document.querySelector("input[name=y-axis-type]:checked").value;
+                if (axisMode === relativeRadio.value) { 
+                    return (Math.min(...baseRanges) - (0.1 * Math.abs(Math.min(...baseRanges)))) - 1;
+                }
+                else if (axisMode === absoluteRadio.value) { 
+                    return null; 
+                }
+            }
+            return null;
+        }
 
-        if (slowData.length > 0) {
-            MG.data_graphic(dparams); //replaces "No data" text
+        function updatePlot() {
+            var dparams = {
+                area: false,
+                data: slowData,
+                width: $('#main').width(),
+                left: 100,
+                right: 100,
+                height: 500,
+                target: "#main",
+                time_scale: cscale,
+                animate_on_load: true,
+                x_accessor:'key',
+                y_accessor:'value',
+                point_size: 4.0,
+                x_label: "Time",
+                y_label: "Voltage",
+                max_y: getMaxY(),
+                min_y: getMinY(), 
+                baselines: baseRanges.map(function(baseline, index) {
+                        return {"value": baseline, "label": `${baseline}V`};
+                    }),
+                decimals: 4,
+                legend: dataNames,
+                interpolate: 'linear',
+
+                y_mouseover: function(data) {
+                    var voltage = parseFloat(data['value']).toFixed(4);
+                    return voltage + ' V' ;
+                },
+
+                x_mouseover: function(data) {
+                    return moment(data.key).format(time_fmt);
+                }
+            };
+
+            sessionStorage.setItem("storedPlotControls", getPlotControlsState())
+            initialPlotState = getPlotControlsState()
+            updateButton.setAttribute("disabled", "");
+
+            if (slowData.length > 0) {
+                MG.data_graphic(dparams); //replaces "No data" text
+            }
+
+            // the only way to change line width, i tried. ugh
+            // changing dparams or overriding CSS did NOT work, for me at least
+            // needs to be in here to update new lines
+            document.querySelectorAll('#main svg path.mg-main-line').forEach(function(path) {
+                path.style.strokeWidth = '1.5px';
+            });
+            document.querySelectorAll('#main svg .mg-line-legend text').forEach(function(text) {
+                text.style.fontSize = '1.2em';
+                text.style.fontWeight = '600';
+            });
+            document.querySelectorAll('.mg-x-axis text, .mg-y-axis text, .mg-histogram .axis text').forEach(function(text) {
+                text.style.fontSize = '1.1em';
+            });
+
+            return dparams;
         }
 
         function deleteStream(index) {
@@ -295,18 +397,16 @@
         }
 
         function addDatastreamTableRow(name, first, last, length, index) {
-            console.log(`Adding row: ${index} ${name} ${first} ${last} ${length}`)
-            
             tableData=
-                `<tr>
+            `<tr>
                     <td class="mg-line${index+1}-legend-color">${index+1}</td>
                     <td>${name}</td>
                     <td>${first}</td>
                     <td>${last}</td>
                     <td>${length}</td>
                     <td><button onclick="deleteStream(${index})">Remove</button></td>
-                </tr>`;
-            var newRow = metadataTable.insertRow();
+                    </tr>`;
+            var newRow = document.getElementById("datastreams-listing").insertRow();
             newRow.innerHTML = tableData;
             return true;
         } //would really rather put these in the .js, but alas...
@@ -329,19 +429,6 @@
             dateWarningText.setAttribute("hidden", "");
         }
 
-        // the only way to change line width, i tried. ugh
-        // changing dparams or overriding CSS did NOT work, for me at least
-        document.querySelectorAll('#main svg path.mg-main-line').forEach(function(path) {
-            path.style.strokeWidth = '1.5px';
-        });
-        document.querySelectorAll('#main svg .mg-line-legend text').forEach(function(text) {
-            text.style.fontSize = '1.2em';
-            text.style.fontWeight = '600';
-        });
-        document.querySelectorAll('.mg-x-axis text, .mg-y-axis text, .mg-histogram .axis text').forEach(function(text) {
-            text.style.fontSize = '1.1em';
-        });
-
         function history() {
             var params = {};
             
@@ -355,7 +442,7 @@
             // in either case, set the parameter to this stored value
             try {
                 if (sessionStorage.getItem("startTimestamp") === null) {
-                    sessionStorage.setItem("startTimestamp", document.getElementById("datetime_low").value);
+                    sessionStorage.setItem("startTimestamp", datetimeLowInput.value);
                 }
             } catch (e) {
                 sessionStorage.setItem("startTimestamp", "2024-02-19T00:00");
@@ -364,7 +451,7 @@
             }
             try {
                 if (sessionStorage.getItem("endTimestamp") === null) {
-                    sessionStorage.setItem("endTimestamp", document.getElementById("datetime_high").value);
+                    sessionStorage.setItem("endTimestamp", datetimeHighInput.value);
                 }
                 params['datetime_high'] = sessionStorage.getItem("endTimestamp")
             } catch (e) {
@@ -428,6 +515,8 @@
             sessionStorage.clear();
             window.location.replace($SCRIPT_ROOT + "/slowcontrol_plots");
         }
+
+        updatePlot();
 
     </script>
 {% endblock %}

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -98,7 +98,7 @@
                     </table>
                 </th>
                 <!-- Plot actions -->
-                <th class="col-xl-3 col-xs-offset-0" style="padding-left">
+                <th class="col-xl-3 col-xs-offset-0">
                     <div style="padding-bottom:0.5em"> <button type=button id="new-plot" onclick="historyNew();">Generate New Plot</button> </div>
                     <div style="padding-bottom:0.5em"> <button type=button id="append-plot" onclick="historyAppend();">Add To Plot</button> </div>
                     <div> <button type=button id="append-plot" onclick="historyClear();">Clear Plot</button> </div>
@@ -234,7 +234,7 @@
             return sessionStorage.setItem(name, JSON.stringify(data));
         }
 
-        var newSlowData = {{ slow_data | safe if slow_data is not none else "null" }};
+        var newSlowData = {{ slow_data | safe if slow_data is not none else "null" }}; //yes it's lowercase, because jinja none (not python None)
         var newDataName = "{{ data_name | safe if data_name is not none else "null" }}"; // this sucks i am so sorry
         var newBaseRange = {{ base_range | safe if base_range is not none else "null" }};
 
@@ -244,7 +244,7 @@
         var dataType = sessionStorage.getItem("dataType");
         var plotControlsState = sessionStorage.getItem("storedPlotControls")
 
-        if (newSlowData !== null) { //unfortunate, but null handling is hard
+        if (newSlowData !== null && newSlowData.length > 0) { //unfortunate, but null handling is hard
             slowData.push(newSlowData)
         }
         if (newDataName !== "null") { //more unfortunate

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -449,7 +449,6 @@
         function history() {
             var params = {};
             
-            sessionStorage.setItem("endTimestamp", document.getElementById("datetime_high").value);
             sessionStorage.setItem("dataType", document.querySelector("input[name=channel-type]:checked").value);
             appendPlotButton.setAttribute("disabled", "");
             newPlotButton.setAttribute("disabled", "");
@@ -459,7 +458,7 @@
             // on error, set them to a default fallback value
             // in either case, set the parameter to this stored value
             try {
-                if (sessionStorage.getItem("startTimestamp") === undefined) {
+                if (sessionStorage.getItem("startTimestamp") === null) {
                     sessionStorage.setItem("startTimestamp", document.getElementById("datetime_low").value);
                 }
             } catch (e) {
@@ -468,7 +467,7 @@
                 params['datetime_low'] = sessionStorage.getItem("startTimestamp")
             }
             try {
-                if (sessionStorage.getItem("endTimestamp") === undefined) {
+                if (sessionStorage.getItem("endTimestamp") === null) {
                     sessionStorage.setItem("endTimestamp", document.getElementById("datetime_high").value);
                 }
                 params['datetime_high'] = sessionStorage.getItem("endTimestamp")

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -127,10 +127,11 @@
                 <!-- Plot controls -->
                 <th id="plot-controls-layer-1" class="col-md-2"> <!-- this and child used to disable when no data -->
                     <div id="plot-controls-layer-2"> <!-- cannot be done using jinja template, as python only sends NEW data (stateless) :( -->
+                        <div> <input type="radio" id="y-axis-bounded" value="bounded" name="y-axis-type" checked> <label for="axis-bounded"> <abbr title="Sets the plot range based on the expected voltage range.">Bounded</abbr> Default Range</label> </div>
+                        <div> <input type="radio" id="y-axis-absolute" value="absolute" name="y-axis-type"> <label for="axis-absolute"> <abbr title="Sets the plot range based on the data range, including zero.">Absolute</abbr> Default Range</label> </div>
+                        <div> <input type="radio" id="y-axis-focused" value="focused" name="y-axis-type"> <label for="axis-focused"> <abbr title="Sets the plot range based on the data range.">Focused</abbr> Default Range</label> </div>
                         <div> <input type=checkbox id="y-max-check"> Override Max </input> <input type="number" id="y-max-value" step="0.1" style="width:4em" disabled> </div>
                         <div> <input type=checkbox id="y-min-check"> Override Min </input> <input type="number" id="y-min-value" step="0.1" style="width:4em" disabled> </div>
-                        <div> <input type="radio" id="y-axis-relative" value="relative" name="y-axis-type" checked> <label for="axis-relative">Relative Default Range</label> </div>
-                        <div> <input type="radio" id="y-axis-absolute" value="absolute" name="y-axis-type"> <label for="axis-absolute">Absolute Default Range</label> </div>
                     </div>
                 </th>
             </tr>
@@ -272,11 +273,14 @@
             yMinCheckbox.checked = plotControlsState["yMinOn"];
             yMaxValueEntry.value = plotControlsState["yMaxVal"];
             yMinValueEntry.value = plotControlsState["yMinVal"];
-            if (plotControlsState["yAxisMode"] === "relative") {
-                relativeRadio.checked = true;
+            if (plotControlsState["yAxisMode"] === "bounded") {
+                boundedRadio.checked = true;
             }
             else if (plotControlsState["yAxisMode"] === "absolute") {
                 absoluteRadio.checked = true;
+            }
+            else if (plotControlsState["yAxisMode"] === "focused") {
+                focusedRadio.checked = true;
             }
         }
 
@@ -318,52 +322,27 @@
         var time_fmt = 'MMMM Do YYYY, h:mm:ss a';
         
         function getMaxY() {
-            try {
-                if (yMaxCheckbox.checked) { 
-                    return yMaxValueEntry.value; 
-                }
-                else {
-                    var axisMode = document.querySelector("input[name=y-axis-type]:checked").value;
-                    if (axisMode === relativeRadio.value) { 
-                        return (Math.max(...baseRanges) * 1.1) + 1; 
-                    }
-                    else if (axisMode === absoluteRadio.value) { 
-                        return null; 
-                    }
-                }
+            if (yMaxCheckbox.checked) { return yMaxValueEntry.value; }
+            
+            var axisMode = document.querySelector("input[name=y-axis-type]:checked").value;
+            if (axisMode === boundedRadio.value) { 
+                return (Math.max(...baseRanges) * 1.1) + 1; 
             }
-            finally { //if error, checkbox does not exist
-                return null; //if exists but no condition hit, return null
-            }
+
+            // else, axisMode is absolute or focused
+            return null; 
         }
         
         function getMinY() {
-            try {
-                if (yMinCheckbox.checked) { 
-                    return yMinValueEntry.value;
-                }
-                else {
-                    var axisMode = document.querySelector("input[name=y-axis-type]:checked").value;
-                    if (axisMode === relativeRadio.value) { 
-                        const val = (Math.min(...baseRanges) - (0.1 * Math.abs(Math.min(...baseRanges)))) - 1;
-                        console.log(`using relative: ${val}`);
-                        return val;
-                    }
-                    else if (axisMode === absoluteRadio.value) { 
-                        console.log("using absolute")
-                        return null;
-                    }
-                }
+            if (yMinCheckbox.checked) { return yMinValueEntry.value;}
+            
+            var axisMode = document.querySelector("input[name=y-axis-type]:checked").value;
+            if (axisMode === boundedRadio.value) { 
+                return (Math.min(...baseRanges) - (0.1 * Math.abs(Math.min(...baseRanges)))) - 1;
             }
-            finally {
-                return null;
-            }
-        }
 
-        function wgetMinY() {
-            var y = getMinY();
-            console.log(`min y: ${y}`);
-            return y;
+            // else, axisMode is absolute or focused
+            return null;
         }
 
         function updatePlot() {
@@ -383,7 +362,8 @@
                 x_label: "Time",
                 y_label: "Voltage",
                 max_y: getMaxY(),
-                min_y: wgetMinY(), 
+                min_y: getMinY(),
+                min_y_from_data: focusedRadio.checked, //sets min y to min of data (or 0 if false)
                 baselines: baseRanges.map(function(baseline, index) {
                         return {"value": baseline, "label": `${baseline}V`};
                     }),
@@ -410,9 +390,7 @@
                 try {
                     document.getElementById("data-status").remove();
                 }
-                catch { 
-                    console.log("testing!")
-                } //if it already doesn't exist, just continue
+                catch { } //if it already doesn't exist, just continue
             }
 
             // the only way to change line width, i tried. ugh

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -92,11 +92,8 @@
 </th>
 </tr>
 </table>
-<!-- Runs summary goes here -->
     <div class="row">
     <div class="col-md-12" id="sum">
-        <h2 align="left"> Summary: </h2>
-        <p id="data-summary"> </p>
         <div id="waiting">
             Received data, loading....
         </div>
@@ -105,7 +102,7 @@
 <!-- Plot goes here -->
     <div class="row">
     <div class="col-md-12" id="main">
-      {% if not slow_data %}
+      {% if (not slow_data) or (slow_data == []) or (slow_data == "\"none\"") %}
         <h2 align="left"> No data </h2>
       {% endif %}
 
@@ -168,23 +165,24 @@
         var slowData = initializeStoredArray("storedSlowData")
         var dataNames = initializeStoredArray("storedDataNames")
 
-        if (newSlowData !== undefined) { //unfortunate, but null handling is hard
+        if (newSlowData !== "none") { //unfortunate, but null handling is hard
             slowData.push(newSlowData)
         }
-        if (newDataName !== undefined) {
+        if (newDataName !== "none") {
             dataNames.push(newDataName)
         }
 
-        const headData = slowData[0] // first array of data, avoids slowData[0][i]['key'] etc
+        if (slowData.length > 0) {
+            const headData = slowData[0] // first array of data, avoids slowData[0][i]['key'] etc
 
-        for (var i=0; i < headData.length; i++) {
-            headData[i]['key'] = moment.unix(headData[i]['key']).toDate()
-        }
+            for (var i=0; i < headData.length; i++) {
+                headData[i]['key'] = moment.unix(headData[i]['key']).toDate()
+            }
 
-        minTime = headData[0]['key'];
-        maxTime = headData[headData.length-1]['key'];
-        var cscale = tzscale().domain([minTime, maxTime]).zone('America/Toronto');
-
+            minTime = headData[0]['key'];
+            maxTime = headData[headData.length-1]['key'];
+            var cscale = tzscale().domain([minTime, maxTime]).zone('America/Toronto');
+        } 
         var time_fmt = 'MMMM Do YYYY, h:mm:ss a';
         
     // <!-- Messy bit of code to get the run summary section but it works... -MD -->
@@ -236,7 +234,7 @@
             }
         };
 
-        if (headData !== undefined) {
+        if (slowData.length > 0) {
             MG.data_graphic(dparams); //replaces "No data" text
         }
         

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -79,7 +79,7 @@
 
                     <div>
                         <label for="baseline">Baseline Voltage</label>
-                        <input type="radio" id="baseline" value="baseline" name="channel-type" checked>
+                        <input type="radio" id="baseline" value="baseline" name="channel-type">
                         <label for="baseline-crate">Crate #</label>
                         <input type="number" id="baseline-crate" name="baseline-crate" min="0" max="18" value="" style="width: 4em">
                         <label for="baseline-trigger">Trigger</label>
@@ -92,26 +92,51 @@
                 </th>
                 <!-- Button to plot the data -->
                 <th class="col-xs-3 col-xs-offset-0">
-                    <button type=button onclick="history();">Generate Plot</button>
-</th>
-</tr>
-</table>
+                    <div> <button type=button id="new-plot" onclick="historyNew();">Generate New Plot</button> </div>
+                    <div> <button type=button id="append-plot" onclick="historyAppend();">Add To Plot</button> </div>
+                    <div id="mismatch-warning" style="color:red" hidden>Data types must match.</div>
+                    <div> <button type=button id="append-plot" onclick="historyClear();">Clear Plot</button> </div>
+                </th>
+                </tr>
+                </table>
     <div class="row">
-    <div class="col-md-12" id="sum">
-        <div id="waiting">
-            Received data, loading...
+        <div class="col-md-12" id="sum">
+            <div id="waiting" { % if not slow_data % } hidden { % endif % }>
+                Received data, loading...
+            </div>
+            <div id="incompatible" style="color:red" hidden>
+                Data was incompatible. This should never happen.
+            </div>
         </div>
     </div>
-        </div>
 <!-- Plot goes here -->
     <div class="row">
-    <div class="col-md-12" id="main">
-      {% if not slow_data %}
-        <h2 align="left"> No data </h2>
-      {% endif %}
-
-    </div>
+        <div class="col-md-12" id="main">
+            {% if not slow_data %}
+                <h2 align="left"> No data </h2>
+            {% endif %}
         </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <h2 align="left"> Available Data </h2>
+            <table class="table table-hover" id="datastreams-listing">
+                <thead>
+                    <tr>
+                    <th>Index</th>
+                    <th>Datastream</th>
+                    <th>Start time</th>
+                    <th>End time</th>
+                    <th>Points</th>
+                    <th>Operations</th>
+                    </tr>
+                </thead>
+                <tbody id="datastreams-body">
+                </tbody>
+            </table>
+        </div>
+    </div>
 
     </div>
 </div>
@@ -161,7 +186,7 @@
         }
 
         function storeArray(name, data) {
-            return sessionStorage.setItem(name, JSON.stringify(data))
+            return sessionStorage.setItem(name, JSON.stringify(data));
         }
 
         var newSlowData = {{ slow_data | safe if slow_data else 'null' }};
@@ -169,6 +194,7 @@
 
         var slowData = initializeStoredArray("storedSlowData")
         var dataNames = initializeStoredArray("storedDataNames")
+        var dataType = sessionStorage.getItem("dataType");
 
         if (newSlowData !== null) { //unfortunate, but null handling is hard
             slowData.push(newSlowData)
@@ -177,17 +203,30 @@
             dataNames.push(newDataName)
         }
 
+        var mergedData = []
+
         if (slowData.length > 0) {
-            const headData = slowData[0] // first array of data, avoids slowData[0][i]['key'] etc
+            slowData.forEach((datastream) => {
+                if (datastream.length !== slowData[0].length) {
+                    document.getElementById("incompatible").removeAttribute("hidden")
+                    throw new Error("Data streams were incompatible.");
+                }
+                datastream.forEach((datapoint) => {
+                    datapoint['reftime'] = moment.unix(datapoint['key']).toDate();
+                });
+            });
 
-            for (var i=0; i < headData.length; i++) {
-                headData[i]['key'] = moment.unix(headData[i]['key']).toDate()
-            }
+            // for (var i = 0; i < slowData[0].length; i++) {
+            //     // assumes same times for all data
+            //     var currentTimeData = slowData.map((datastream) => datastream[i]['value']) // build array of each datastream's value at current time
+            //     mergedData.push({'value': currentTimeData, 'reftime': slowData[0][i]['reftime']}); //pair array with reftime of first datastream
+            // }
 
-            minTime = headData[0]['key'];
-            maxTime = headData[headData.length-1]['key'];
-            var cscale = tzscale().domain([minTime, maxTime]).zone('America/Toronto');
+            mintime = slowData[0][0]['key'];
+            maxtime = slowData[0][slowData[0].length-1]['key'];
+            var cscale = tzscale().domain([mintime, maxtime]).zone('America/Toronto');
         } 
+
         var time_fmt = 'MMMM Do YYYY, h:mm:ss a';
         
     // <!-- Messy bit of code to get the run summary section but it works... -MD -->
@@ -220,7 +259,7 @@
             height: 500,
             target: "#main",
             time_scale: cscale,
-            x_accessor:'key',
+            x_accessor:'reftime',
             y_accessor:'value',
             point_size: 4.0,
             x_label: "Time",
@@ -235,12 +274,47 @@
             },
 
             x_mouseover: function(data, index) {
-                return moment(data.key).format(time_fmt);
+                return moment(data.reftime).format(time_fmt);
             }
         };
 
         if (slowData.length > 0) {
             MG.data_graphic(dparams); //replaces "No data" text
+        }
+
+        function deleteStream(index) {
+            slowData.splice(index, 1);
+            storeArray("storedSlowData", slowData);
+            dataNames.splice(index, 1);
+            storeArray("storedDataNames", dataNames);
+            sessionStorage.setItem("dataType", document.querySelector("input[name=channel-type]:checked").value);
+
+            window.location.replace($SCRIPT_ROOT + "/slowcontrol_plots");
+        }
+
+        function addDatastreamTableRow(name, first, last, length, index) {
+            console.log(`Adding row: ${index} ${name} ${first} ${last} ${length}`)
+            
+            tableData=
+                `<tr>
+                    <td style="color">${index}</td>
+                    <td>${name}</td>
+                    <td>${first}</td>
+                    <td>${last}</td>
+                    <td>${length}</td>
+                    <td><button onclick="deleteStream(${index})">Remove</button></td>
+                </tr>`;
+            var newRow = metadataTable.insertRow();
+            newRow.innerHTML = tableData;
+            return true;
+        } //would really rather put these in the .js, but alas...
+
+        for (var i = 0; i < slowData.length; i++) {
+            var streamLength = slowData[i].length;
+            var myName = dataNames[i];
+            var myFirstTime = moment.unix(slowData[i][0].key).format(time_fmt);
+            var myLastTime = moment.unix(slowData[i][streamLength-1].key).format(time_fmt);
+            addDatastreamTableRow(myName, myFirstTime, myLastTime, streamLength, i);
         }
         
         document.getElementById("waiting").innerHTML="";
@@ -301,6 +375,31 @@
             //     params['criteria'] = "scintillator_silver";
             // }
             window.location.replace($SCRIPT_ROOT + "/slowcontrol_plots?" + $.param(params));
+        }
+
+        function historyAppend() {
+            storeArray("storedSlowData", slowData);
+            storeArray("storedDataNames", dataNames);
+            sessionStorage.setItem("dataType", document.querySelector("input[name=channel-type]:checked").value);
+
+            history();
+        }
+
+        
+        function historyNew() {
+            sessionStorage.removeItem("storedSlowData");
+            sessionStorage.removeItem("storedDataNames");
+            sessionStorage.removeItem("dataType");
+
+            history();
+        }
+
+        function historyClear() {
+            sessionStorage.removeItem("storedSlowData");
+            sessionStorage.removeItem("storedDataNames");
+            sessionStorage.removeItem("dataType");
+
+            window.location.replace($SCRIPT_ROOT + "/slowcontrol_plots");
         }
 
     </script>

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -50,7 +50,20 @@
                         <label for="supply">Supply Voltage</label>
                         <input type="radio" id="supply" value="supply" name="channel-type" checked>
                         <label for="supply-rack">Rack #</label>
-                        <input type="number" id="supply-rack" name="supply-rack" min="1" max="11" value="7" style="width: 4em">
+                        <select name="supply-rack" id="supply-rack">
+                            <option value="1">Rack 1</option>
+                            <option value="2">Rack 2</option>
+                            <option value="3">Rack 3</option>
+                            <option value="4">Rack 4</option>
+                            <option value="5">Rack 5</option>
+                            <option value="6">Rack 6</option>
+                            <option value="7">Rack 7</option>
+                            <option value="8">Rack 8</option>
+                            <option value="9">Rack 9</option>
+                            <option value="10">Rack 10</option>
+                            <option value="11">Rack 11</option>
+                            <option value="timing">Timing Rack</option>
+                        </select>
                         <label for="supply-voltage">Voltage</label>
                         <select name="supply-voltage" id="supply-voltage">
                             <option value="24">24V</option>
@@ -66,10 +79,10 @@
                         <input type="radio" id="baseline" value="baseline" name="channel-type" checked>
                         <label for="baseline-crate">Crate #</label>
                         <input type="number" id="baseline-crate" name="baseline-crate" min="0" max="18" value="7" style="width: 4em">
-                        <label for="crate-trigger">Trigger</label>
-                        <select name="crate-trigger" id="crate-trigger">
+                        <label for="baseline-trigger">Trigger</label>
+                        <select name="baseline-trigger" id="baseline-trigger">
                             <option value="100">N100_BL</option>
-                            <option value="20">-N20_BL</option>
+                            <option value="20">N20_BL</option>
                         </select>
                     </div>
                 </th>
@@ -118,6 +131,21 @@
         }
         if (url_params.datetime_high && document.getElementById("datetime_high").value == "") {
             document.getElementById("datetime_high").value = url_params.datetime_high;
+        }
+        if (url_params.channel_type) {
+            document.getElementById(url_params.channel_type).checked = true 
+        }
+        if (url_params.supply_rack) {
+            document.getElementById("supply-rack").value = url_params.supply_rack;
+        }
+        if (url_params.supply_voltage) {
+            document.getElementById("supply-voltage").value = url_params.supply_voltage;
+        }
+        if (url_params.baseline_crate) {
+            document.getElementById("baseline-crate").value = url_params.baseline_crate;
+        }
+        if (url_params.baseline_trigger) {
+            document.getElementById("baseline-trigger").value = url_params.baseline_trigger;
         }
         // if (url_params.criteria) {
         //     document.getElementById("crit").value = url_params.criteria;
@@ -216,6 +244,31 @@ for (var i=0; i < summaryTime.length; i++)
                 params['datetime_high'] = document.getElementById("datetime_high").value;
             } catch (e) {
                 params['datetime_high'] = "2024-05-29T23:59";
+            }
+            try {
+                params['channel_type'] = document.querySelector("input[name=channel-type]:checked").value;
+            } catch (e) {
+                //pass?
+            }
+            try {
+                params['supply_rack'] = document.getElementById("supply-rack").value;
+            } catch (e) {
+                params['supply_rack'] = "1";
+            }
+            try {
+                params['supply_voltage'] = document.getElementById("supply-voltage").value;
+            } catch (e) {
+                params['supply_voltage'] = "24";
+            }
+            try {
+                params['baseline_crate'] = document.getElementById("baseline-crate").value;
+            } catch (e) {
+                params['baseline_crate'] = "0";
+            }
+            try {
+                params['baseline_trigger'] = document.getElementById("baseline-trigger").value;
+            } catch (e) {
+                params['baseline_trigger'] = "100";
             }
             // try {
             //     params['criteria'] = document.getElementById("crit").value;

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -151,69 +151,70 @@
         //     document.getElementById("crit").value = url_params.criteria;
         // }
 
-        var rs_plot_data = {{ rs_plot_data | safe }};
+        var slow_data = {{ slow_data | safe }};
 
-        var dates = new Array();
-        var phys = new Array();
-        var pass = new Array();
-        var fail = new Array();
-        var purg = new Array();
-
-        for (var i=0; i < rs_plot_data.length; i++)
-        {
-            date_ = moment(rs_plot_data[i]['timestamp']).toDate();
-            dates.push(date_);
-            phys.push({'date': date_, 'value': rs_plot_data[rs_plot_data.length - 1]['phys_total'] - rs_plot_data[i]['phys_total']});
-            pass.push({'date': date_, 'value': rs_plot_data[rs_plot_data.length - 1]['pass_total'] - rs_plot_data[i]['pass_total']});
-            fail.push({'date': date_, 'value': rs_plot_data[rs_plot_data.length - 1]['fail_total'] - rs_plot_data[i]['fail_total']});
-            purg.push({'date': date_, 'value': rs_plot_data[rs_plot_data.length - 1]['purg_total'] - rs_plot_data[i]['purg_total']});
-        }
-        var cscale = tzscale().domain(dates).zone('America/Toronto');
-
-        var time_fmt = 'MMM Do YYYY';
+        var timestamps = new Array();
+        // TODO: may need to loop this with multi-line plots
+        var mySingleDatastream = new Array();
         
-<!-- Messy bit of code to get the run summary section but it works... -MD -->
-	var summaryTime = [rs_plot_data[rs_plot_data.length - 1]['phys_total'],rs_plot_data[rs_plot_data.length - 1]['pass_total'],rs_plot_data[rs_plot_data.length - 1]['fail_total'],rs_plot_data[rs_plot_data.length - 1]['purg_total']]
+        // TODO: store the human-readable "names" of each dataset?
+        var myDataNames = new Array();
+        myDataNames.push("Test Data")
+
+        for (var i=0; i < slow_data.length; i++)
+        {
+            // ts = moment(slow_data[i][0]).format('MMMM Do YYYY, h:mm:ss a')
+            // timestamps.push(ts); //sus
+            timestamps.push(slow_data[i][0]);
+            mySingleDatastream.push({'time': slow_data[i][0], 'value': slow_data[i][1]});
+        }
+        var cscale = tzscale().domain(timestamps).zone('America/Toronto');
+
+        var time_fmt = 'MMMM Do YYYY, h:mm:ss a';
+        
+// <!-- Messy bit of code to get the run summary section but it works... -MD -->
+//copied from runselection_plots, probably unneccesary here
+// 	var summaryTime = [rs_plot_data[rs_plot_data.length - 1]['phys_total'],rs_plot_data[rs_plot_data.length - 1]['pass_total'],rs_plot_data[rs_plot_data.length - 1]['fail_total'],rs_plot_data[rs_plot_data.length - 1]['purg_total']]
     
-    var summaryRuns = [rs_plot_data[rs_plot_data.length - 1]['phys_runs'],rs_plot_data[rs_plot_data.length - 1]['pass_runs'],rs_plot_data[rs_plot_data.length - 1]['fail_runs'],rs_plot_data[rs_plot_data.length - 1]['purg_runs']]
+//     var summaryRuns = [rs_plot_data[rs_plot_data.length - 1]['phys_runs'],rs_plot_data[rs_plot_data.length - 1]['pass_runs'],rs_plot_data[rs_plot_data.length - 1]['fail_runs'],rs_plot_data[rs_plot_data.length - 1]['purg_runs']]
     
 
-for (var i=0; i < summaryTime.length; i++)
-	{
-		var j = parseFloat(summaryTime[i]).toFixed(3);
-		summaryTime[i] = j;
-	}
+    // for (var i=0; i < summaryTime.length; i++)
+    //     {
+    //         var j = parseFloat(summaryTime[i]).toFixed(3);
+    //         summaryTime[i] = j;
+    //     }
 
-	document.getElementById("phys_summary").innerHTML = 'Physics: ' + summaryTime[0].toString() + ' Days, ' +summaryRuns[0].toString() + ' Runs';
-    if (summaryRuns[1] == 0) {document.getElementById("pass_summary").innerHTML = 'Passed: None';}
-    else{document.getElementById("pass_summary").innerHTML = 'Passed: ' + summaryTime[1].toString() + ' Days, ' +summaryRuns[1].toString() + ' Runs';}
-    if (summaryRuns[2] == 0) {document.getElementById("fail_summary").innerHTML = 'Failed: None';}
-    else{document.getElementById("fail_summary").innerHTML = 'Failed: ' + summaryTime[2].toString() + ' Days, ' +summaryRuns[2].toString() + ' Runs';}
-    if (summaryRuns[3] == 0) {document.getElementById("purg_summary").innerHTML = 'Purgatory: None';}
-    else{document.getElementById("purg_summary").innerHTML = 'Purgatory: ' + summaryTime[3].toString()  + ' Days, ' +summaryRuns[3].toString() + ' Runs';}
+	// document.getElementById("phys_summary").innerHTML = 'Physics: ' + summaryTime[0].toString() + ' Days, ' +summaryRuns[0].toString() + ' Runs';
+    // if (summaryRuns[1] == 0) {document.getElementById("pass_summary").innerHTML = 'Passed: None';}
+    // else{document.getElementById("pass_summary").innerHTML = 'Passed: ' + summaryTime[1].toString() + ' Days, ' +summaryRuns[1].toString() + ' Runs';}
+    // if (summaryRuns[2] == 0) {document.getElementById("fail_summary").innerHTML = 'Failed: None';}
+    // else{document.getElementById("fail_summary").innerHTML = 'Failed: ' + summaryTime[2].toString() + ' Days, ' +summaryRuns[2].toString() + ' Runs';}
+    // if (summaryRuns[3] == 0) {document.getElementById("purg_summary").innerHTML = 'Purgatory: None';}
+    // else{document.getElementById("purg_summary").innerHTML = 'Purgatory: ' + summaryTime[3].toString()  + ' Days, ' +summaryRuns[3].toString() + ' Runs';}
 
         var dparams = {
             area: false,
-            data: [phys, pass, fail, purg],
+            data: [mySingleDatastream], //TODO: generate this with each line after constructing datasets
             width: $('#main').width(),
             left: 100,
             right: 100,
             height: 500,
             target: "#main",
             time_scale: cscale,
-            x_accessor:'date',
+            x_accessor:'time',
             y_accessor:'value',
             point_size: 4.0,
-            y_label: "Time (Days)",
-            x_label: "Date",
+            y_label: "Voltage",
+            x_label: "Time",
             decimals: 5,
-            legend: ['Physics', 'Passed', 'Failed', 'Purgatory'],
+            legend: myDataNames,
     
 	<!-- Adding the unit (days) to the mouse over legend and fixing the value to 3 decimal places -->
             interpolate: 'linear',
                         y_mouseover: function(d, i) {
 		 var y = parseFloat(d['value']).toFixed(3);
-                return y + ' (days)';
+                return y + ' V';
 
             },
         };

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -161,12 +161,12 @@
         var myDataNames = new Array();
         myDataNames.push("Test Data")
 
-        // for (var i=0; i < slow_data.length; i++)
-        // {
-        //     ts = moment(slow_data[i][0]).format('MMMM Do YYYY, h:mm:ss a')
-        //     timestamps.push(slow_data[i][0]);
-        //     mySingleDatastream.push({'time': slow_data[i][0], 'value': slow_data[i][1]});
-        // }
+        for (var i=0; i < slow_data.length; i++)
+        {
+            slow_data[i]['key'] = moment.unix(slow_data[i]['key']).toDate()
+            // timestamps.push(slow_data[i][0]);
+            // mySingleDatastream.push({'time': slow_data[i][0], 'value': slow_data[i][1]});
+        }
 
         minTime = mySingleDatastream[0]['key'];
         maxTime = mySingleDatastream[mySingleDatastream.length-1]['key'];
@@ -209,16 +209,20 @@
             point_size: 4.0,
             y_label: "Voltage",
             x_label: "Time",
-            decimals: 5,
+            decimals: 4,
             legend: myDataNames,
     
-	<!-- Adding the unit (days) to the mouse over legend and fixing the value to 3 decimal places -->
+	// <!-- Adding the unit to the mouse over legend and fixing the value to 3 decimal places -->
             interpolate: 'linear',
-                        y_mouseover: function(d, i) {
-		 var y = parseFloat(d['value']).toFixed(3);
-                return y + ' V';
 
+            y_mouseover: function(data, index) {
+                var voltage = parseFloat(data['value']).toFixed(4);
+                return voltage + ' V';
             },
+
+            x_mouseover: function(data, index) {
+                return moment(data.key).format(time_fmt);
+            }
         };
 
         MG.data_graphic(dparams);

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -141,6 +141,111 @@
     </div>
 </div>
 
+<style>
+    .mg-line1-legend-color {
+        color: #88D642;
+        fill: #88D642;
+    }
+
+    .mg-line1-color {
+        stroke: #88D642;
+    }
+
+    .mg-hover-line1-color {
+        fill: #88D642;
+    }
+    
+    .mg-area1-color {
+        fill: #88D642;
+    }
+
+    .mg-line2-legend-color {
+        color: #FF79C0;
+        fill: #FF79C0;
+    }
+
+    .mg-line2-color {
+        stroke: #FF79C0;
+    }
+
+    .mg-hover-line2-color {
+        fill: #FF79C0;
+    }
+
+    .mg-area2-color {
+        fill: #FF79C0;
+    }
+
+    .mg-line3-legend-color {
+        color: #60c1bf;
+        fill: #60c1bf;
+    }
+    
+    .mg-line3-color {
+        stroke: #60c1bf;
+    }
+
+    .mg-hover-line3-color {
+        fill: #60c1bf;
+    }
+
+    .mg-area3-color {
+        fill: #60c1bf;
+    }
+
+    .mg-line4-legend-color {
+        color: #f8b128;
+        fill: #f8b128;
+    }
+
+    .mg-line4-color {
+        stroke: #f8b128;
+    }
+
+    .mg-hover-line4-color {
+        fill: #f8b128;
+    }
+
+    .mg-area4-color {
+        fill: #f8b128;
+    }
+
+    .mg-line5-legend-color {
+        color: #5c5c5c;
+        fill: #5c5c5c;
+    }    
+
+    .mg-line5-color {
+        stroke: #5c5c5c;
+    }
+
+    .mg-hover-line5-color {
+        fill: #5c5c5c;
+    }
+
+    .mg-area5-color {
+        fill: #5c5c5c;
+    }
+
+    .mg-line6-legend-color {
+        color: #0101d4;
+        fill: #0101d4;
+    }    
+
+    .mg-line6-color {
+        stroke: #0101d4;
+    }
+
+    .mg-hover-line6-color {
+        fill: #0101d4;
+    }
+
+    .mg-area6-color {
+        fill: #0101d4;
+    }
+
+</style>
+
 {% endblock %}
 
 {% block script %}
@@ -297,7 +402,7 @@
             
             tableData=
                 `<tr>
-                    <td style="color">${index}</td>
+                    <td class="mg-line${index}-legend-color">${index}</td>
                     <td>${name}</td>
                     <td>${first}</td>
                     <td>${last}</td>

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -38,17 +38,17 @@
                 <!-- Data datetime inputs -->
                 <th>
                     <div>
-                        <input style="margin-bottom: 30px;" type="datetime-local" id="datetime_low" value={{datetime_low}} required></input> 
+                        <input style="margin-bottom: 30px;" type="datetime-local" id="datetime_low" value="{{datetime_low}}" required></input> 
                     </div>
                     <div>
-                        <input style="margin-bottom: 30px;" type="datetime-local" id="datetime_high" value={{datetime_high}} required></input>
+                        <input style="margin-bottom: 30px;" type="datetime-local" id="datetime_high" value="{{datetime_high}}" required></input>
                     </div>
                 </th>
                 <!-- Channel selector -->
                 <th>
                     <div>
                         <label for="supply">Supply Voltage</label>
-                        <input type="radio" id="supply" value="supply" name="crit" checked>
+                        <input type="radio" id="supply" value="supply" name="channel-type" checked>
                         <label for="supply-rack">Rack #</label>
                         <input type="number" id="supply-rack" name="supply-rack" min="1" max="11" value="7" style="width: 4em">
                         <label for="supply-voltage">Voltage</label>
@@ -63,7 +63,7 @@
 
                     <div>
                         <label for="baseline">Baseline Voltage</label>
-                        <input type="radio" id="baseline" value="baseline" name="crit" checked>
+                        <input type="radio" id="baseline" value="baseline" name="channel-type" checked>
                         <label for="baseline-crate">Crate #</label>
                         <input type="number" id="baseline-crate" name="baseline-crate" min="0" max="18" value="7" style="width: 4em">
                         <label for="crate-trigger">Trigger</label>
@@ -119,9 +119,9 @@
         if (url_params.datetime_high && document.getElementById("datetime_high").value == "") {
             document.getElementById("datetime_high").value = url_params.datetime_high;
         }
-        if (url_params.criteria) {
-            document.getElementById("crit").value = url_params.criteria;
-        }
+        // if (url_params.criteria) {
+        //     document.getElementById("crit").value = url_params.criteria;
+        // }
 
         var rs_plot_data = {{ rs_plot_data | safe }};
 
@@ -217,11 +217,11 @@ for (var i=0; i < summaryTime.length; i++)
             } catch (e) {
                 params['datetime_high'] = "2024-05-29T23:59";
             }
-            try {
-                params['criteria'] = document.getElementById("crit").value;
-            } catch (e) {
-                params['criteria'] = "scintillator_silver";
-            }
+            // try {
+            //     params['criteria'] = document.getElementById("crit").value;
+            // } catch (e) {
+            //     params['criteria'] = "scintillator_silver";
+            // }
             window.location.replace($SCRIPT_ROOT + "/slowcontrol_plots?" + $.param(params));
         }
 

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -108,6 +108,7 @@
         </div>
     </div>
 
+    {% if slow_data %}
     <div class="row">
         <div class="col-md-12">
             <h2 align="left"> Available Data </h2>
@@ -127,6 +128,7 @@
             </table>
         </div>
     </div>
+    {% endif %}
 
     </div>
 </div>
@@ -201,9 +203,11 @@
 
         var newSlowData = {{ slow_data | safe if slow_data else "null" }};
         var newDataName = "{{ data_name | safe if data_name else "null" }}"; // this sucks i am so sorry
+        var newBaseRange = {{ base_range | safe if base_range else "null" }};
 
         var slowData = initializeStoredArray("storedSlowData")
         var dataNames = initializeStoredArray("storedDataNames")
+        var baseRanges = initializeStoredArray("storedBaseRanges")
         var dataType = sessionStorage.getItem("dataType");
 
         if (newSlowData !== null) { //unfortunate, but null handling is hard
@@ -211,6 +215,9 @@
         }
         if (newDataName !== "null") { //more unfortunate
             dataNames.push(newDataName)
+        }
+        if (newBaseRange !== null && !baseRanges.includes(newBaseRange)) {
+            baseRanges.push(newBaseRange)
         }
 
         var mergedData = []
@@ -254,6 +261,11 @@
             point_size: 4.0,
             x_label: "Time",
             y_label: "Voltage",
+            max_y: (Math.max(...baseRanges) * 1.1) + 1,
+            min_y: (Math.min(...baseRanges) - (0.1 * Math.abs(Math.min(...baseRanges)))) - 1,
+            baselines: baseRanges.map(function(baseline, index) {
+                    return {"value": baseline, "label": `${baseline}V`};
+                }),
             decimals: 4,
             legend: dataNames,
             interpolate: 'linear',
@@ -320,7 +332,7 @@
         // the only way to change line width, i tried. ugh
         // changing dparams or overriding CSS did NOT work, for me at least
         document.querySelectorAll('#main svg path.mg-main-line').forEach(function(path) {
-            path.style.strokeWidth = '4px';
+            path.style.strokeWidth = '1.5px';
         });
         document.querySelectorAll('#main svg .mg-line-legend text').forEach(function(text) {
             text.style.fontSize = '1.2em';
@@ -401,6 +413,7 @@
         function historyAppend() {
             storeArray("storedSlowData", slowData);
             storeArray("storedDataNames", dataNames);
+            storeArray("storedBaseRanges", baseRanges);
             appendPlotButton.innerHTML = `Est. wait: ${getEstTimeString()}`;
             history();
         }

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -16,8 +16,7 @@
 
     <!-- Set up display options -->
     <div class="container">
-        <div class="col-md-12">
-            <table class="table table-hover">
+            <table class="table">
             <tr>
                 <th> Date Range </th>
                 <th> Datastream </th>
@@ -29,24 +28,24 @@
             </tr>
             <tr>
                 <!-- Data datetime inputs -->
-                <th class="col-s-3 col-xs-offset-0">
+                <th class="col-md-2">
                     <div>
                         <input style="margin-bottom: 10px;" type="datetime-local" id="datetime_low" value="{{datetime_low}}" required></input> 
                     </div>
                     <div>
                         <input style="margin-bottom: 10px;" type="datetime-local" id="datetime_high" value="{{datetime_high}}" required></input>
                     </div>
-                    <div id="date-warning" hidden style="color:red">Clear the plot to unlock dates.</div>
+                    <div id="date-warning" style="color:red; visibility:hidden">Clear the plot to unlock dates.</div>
                 </th>
                 <!-- Channel selector -->
-                <th class="col-s-3 col-xs-offset-0">
-                    <table style="border-spacing:0 1em; border-collapse:separate">
+                <th class="col-md-5">
+                    <table style="border-spacing:0 0em; border-collapse:separate">
                         <tr>
-                            <th class="col-m-3 col-xs-offset-0" style="padding-right:1em">
+                            <th class="col-md-4" style="padding-right:2em">
                                 <label for="supply">Supply Voltage</label>
-                                <input type="radio" id="supply" value="supply" name="channel-type" style="float:right" checked>
+                                <input type="radio" id="supply" value="supply" name="channel-type" style="float:right">
                             </th>
-                            <th class="col-m-3 col-xs-offset-0" style="padding-right:1em">
+                            <th class="col-md-3">
                                 <label for="supply-rack">Rack #</label>
                                 <select name="supply-rack" id="supply-rack">
                                     <option disabled selected hidden>...</option>
@@ -64,7 +63,7 @@
                                     <option value="timing">Timing Rack</option>
                                 </select>
                             </th>
-                            <th class="col-m-3 col-xs-offset-0">
+                            <th class="col-md-3">
                                 <label for="supply-voltage">Voltage</label>
                                 <select name="supply-voltage" id="supply-voltage">
                                     <option disabled selected hidden id="default-voltage">...</option>
@@ -75,18 +74,39 @@
                                     <option value="-5">-5V</option>
                                     <option value="mtcd" id="mtcd" hidden>MTCD 2V</option>
                                 </select>
-                            <th>
+                            </th>
                         </tr>
                         <tr>
-                            <th class="col-m-3 col-xs-offset-0" style="padding-right:1em">
+                            <th class="col-md-4" style="padding-right:2em">
                                 <label for="baseline">Baseline Voltage</label>
-                                <input type="radio" id="baseline" value="baseline" name="channel-type">
+                                <input type="radio" id="baseline" value="baseline" name="channel-type" style="float:right">
                             </th>
-                            <th class="col-m-3 col-xs-offset-0" style="padding-right:1em">
+                            <th class="col-md-3">
                                 <label for="baseline-crate">Crate #</label>
-                                <input type="number" id="baseline-crate" name="baseline-crate" min="0" max="18" value="" style="width: 4em">
+                                <select name="baseline-crate" id="baseline-crate">
+                                    <option disabled selected hidden>...</option>
+                                    <option value="0">Crate 0</option>
+                                    <option value="1">Crate 1</option>
+                                    <option value="2">Crate 2</option>
+                                    <option value="3">Crate 3</option>
+                                    <option value="4">Crate 4</option>
+                                    <option value="5">Crate 5</option>
+                                    <option value="6">Crate 6</option>
+                                    <option value="7">Crate 7</option>
+                                    <option value="8">Crate 8</option>
+                                    <option value="9">Crate 9</option>
+                                    <option value="10">Crate 10</option>
+                                    <option value="11">Crate 11</option>
+                                    <option value="12">Crate 12</option>
+                                    <option value="13">Crate 13</option>
+                                    <option value="14">Crate 14</option>
+                                    <option value="15">Crate 15</option>
+                                    <option value="16">Crate 16</option>
+                                    <option value="17">Crate 17</option>
+                                    <option value="18">Crate 18</option>
+                                </select>
                             </th>
-                            <th>
+                            <th class="col-md-3">
                                 <label for="baseline-trigger">Trigger</label>
                                 <select name="baseline-trigger" id="baseline-trigger">
                                     <option disabled selected hidden>...</option>
@@ -98,68 +118,61 @@
                     </table>
                 </th>
                 <!-- Plot actions -->
-                <th class="col-xl-3 col-xs-offset-0">
+                <th class="col-md-2">
                     <div style="padding-bottom:0.5em"> <button type=button id="new-plot" onclick="historyNew();">Generate New Plot</button> </div>
                     <div style="padding-bottom:0.5em"> <button type=button id="append-plot" onclick="historyAppend();">Add To Plot</button> </div>
                     <div> <button type=button id="append-plot" onclick="historyClear();">Clear Plot</button> </div>
-                    <div id="mismatch-warning" style="color:red; padding-top:0.6em; visibility:hidden">Data types must match.</div>
+                    <div id="mismatch-warning" style="color:red; padding-top:0.6em; visibility:hidden">Datastream types must match.</div>
                 </th>
                 <!-- Plot controls -->
-                <th class="col-s-3 col-xs-offset-0">
-                    {% if slow_data %}
-                    <div> <input type=checkbox id="y-max-check"> Override Max </input> <input type="number" id="y-max-value" step="0.1" style="width:4em" disabled> </div>
-                    <div> <input type=checkbox id="y-min-check"> Override Min </input> <input type="number" id="y-min-value" step="0.1" style="width:4em" disabled> </div>
-                    <div> <input type="radio" id="y-axis-relative" value="relative" name="y-axis-type" checked> <label for="axis-relative">Relative Default Range</label> </div>
-                    <div> <input type="radio" id="y-axis-absolute" value="absolute" name="y-axis-type"> <label for="axis-absolute">Absolute Default Range</label> </div>
-                    {% else %}
-                    <div> (No data) </div>
-                    {% endif %}
+                <th id="plot-controls-layer-1" class="col-md-2"> <!-- this and child used to disable when no data -->
+                    <div id="plot-controls-layer-2"> <!-- cannot be done using jinja template, as python only sends NEW data (stateless) :( -->
+                        <div> <input type=checkbox id="y-max-check"> Override Max </input> <input type="number" id="y-max-value" step="0.1" style="width:4em" disabled> </div>
+                        <div> <input type=checkbox id="y-min-check"> Override Min </input> <input type="number" id="y-min-value" step="0.1" style="width:4em" disabled> </div>
+                        <div> <input type="radio" id="y-axis-relative" value="relative" name="y-axis-type" checked> <label for="axis-relative">Relative Default Range</label> </div>
+                        <div> <input type="radio" id="y-axis-absolute" value="absolute" name="y-axis-type"> <label for="axis-absolute">Absolute Default Range</label> </div>
+                    </div>
                 </th>
             </tr>
             </table>
-    <div class="row">
-        <div class="col-md-12" id="sum">
-            <div id="waiting" { % if not slow_data % } hidden { % endif % }>
-                Received data, loading...
-            </div>
-            <div id="incompatible" style="color:red" hidden>
-                Data was incompatible. This should never happen.
+        <div class="row">
+            <div class="col-md-12" id="sum">
+                <div id="waiting" {% if not slow_data %} hidden {% endif %}>
+                    Received data, loading...
+                </div>
+                <div id="incompatible" style="color:red" hidden>
+                    Data was incompatible. This should never happen.
+                </div>
             </div>
         </div>
-    </div>
-<!-- Plot goes here -->
-    <div class="row">
-        <div class="col-md-12" id="main">
-            {% if not slow_data %}
-                <h2 align="left"> No data </h2>
-            {% endif %}
+    <!-- Plot goes here -->
+        <div class="row">
+            <div class="col-md-12" id="main">
+                <h2 align="left" id="data-status"> No data </h2>
+            </div>
         </div>
-    </div>
 
-    {% if slow_data %}
-    <div class="row">
-        <div class="col-md-12">
-            <h2 align="left"> Available Data </h2>
-            <table class="table table-hover" id="datastreams-listing">
-                <thead>
-                    <tr>
-                    <th>Index</th>
-                    <th>Datastream</th>
-                    <th>Start time</th>
-                    <th>End time</th>
-                    <th>Points</th>
-                    <th>Operations</th>
-                    </tr>
-                </thead>
-                <tbody id="datastreams-body">
-                </tbody>
-            </table>
+        <div class="row" id="datastreams-listing-container">
+            <div class="col-md-12">
+                <h2 align="left"> Available Data </h2>
+                <table class="table table-hover" id="datastreams-listing">
+                    <thead>
+                        <tr>
+                        <th>Index</th>
+                        <th>Datastream</th>
+                        <th>Start time</th>
+                        <th>End time</th>
+                        <th>Points</th>
+                        <th>Operations</th>
+                        </tr>
+                    </thead>
+                    <tbody id="datastreams-body">
+                    </tbody>
+                </table>
+            </div>
         </div>
-    </div>
-    {% endif %}
 
     </div>
-</div>
 
 <style>
     .mg-line1-legend-color {color: #88D642; fill: #88D642;} 
@@ -242,7 +255,7 @@
         var dataNames = initializeStoredArray("storedDataNames")
         var baseRanges = initializeStoredArray("storedBaseRanges")
         var dataType = sessionStorage.getItem("dataType");
-        var plotControlsState = sessionStorage.getItem("storedPlotControls")
+        var plotControlsState = JSON.parse(sessionStorage.getItem("storedPlotControls"))
 
         if (newSlowData !== null && newSlowData.length > 0) { //unfortunate, but null handling is hard
             slowData.push(newSlowData)
@@ -257,8 +270,8 @@
         if (plotControlsState !== null) {
             yMaxCheckbox.checked = plotControlsState["yMaxOn"];
             yMinCheckbox.checked = plotControlsState["yMinOn"];
-            yMaxValueEntry.checked = plotControlsState["yMaxVal"];
-            yMinValueEntry.checked = plotControlsState["yMinVal"];
+            yMaxValueEntry.value = plotControlsState["yMaxVal"];
+            yMinValueEntry.value = plotControlsState["yMinVal"];
             if (plotControlsState["yAxisMode"] === "relative") {
                 relativeRadio.checked = true;
             }
@@ -267,9 +280,11 @@
             }
         }
 
-        var mergedData = []
+        var mergedData = [];
 
         if (slowData.length > 0) {
+            document.getElementById("data-status").innerHTML = "Data recieved, loading...";
+
             slowData.forEach((datastream) => {
                 // if (datastream.length !== slowData[0].length) {
                 //     document.getElementById("incompatible").removeAttribute("hidden")
@@ -290,40 +305,65 @@
             mintime = slowData[0][0]['key'];
             maxtime = slowData[0][slowData[0].length-1]['key'];
             var cscale = tzscale().domain([mintime, maxtime]).zone('America/Toronto');
-        } 
+        }
+        else {
+            document.getElementById("datastreams-listing-container").remove();
+            var plotControlsLayer1 = document.getElementById("plot-controls-layer-1");
+            plotControlsLayer1.title = "No data. Add data to the plot to enable controls.";
+            var plotControlsLayer2 = document.getElementById("plot-controls-layer-2");
+            plotControlsLayer2.style.pointerEvents = "none";
+            plotControlsLayer2.style.opacity = "33.3%"; 
+        }
 
         var time_fmt = 'MMMM Do YYYY, h:mm:ss a';
         
         function getMaxY() {
-            if (yMaxCheckbox.checked) { 
-                return yMaxValueEntry.value; 
-            }
-            else {
-                var axisMode = document.querySelector("input[name=y-axis-type]:checked").value;
-                if (axisMode === relativeRadio.value) { 
-                    return (Math.max(...baseRanges) * 1.1) + 1; 
+            try {
+                if (yMaxCheckbox.checked) { 
+                    return yMaxValueEntry.value; 
                 }
-                else if (axisMode === absoluteRadio.value) { 
-                    return null; 
+                else {
+                    var axisMode = document.querySelector("input[name=y-axis-type]:checked").value;
+                    if (axisMode === relativeRadio.value) { 
+                        return (Math.max(...baseRanges) * 1.1) + 1; 
+                    }
+                    else if (axisMode === absoluteRadio.value) { 
+                        return null; 
+                    }
                 }
             }
-            return null;
+            finally { //if error, checkbox does not exist
+                return null; //if exists but no condition hit, return null
+            }
         }
         
         function getMinY() {
-            if (yMinCheckbox.checked) { 
-                return yMinValueEntry.value; 
-            }
-            else {
-                var axisMode = document.querySelector("input[name=y-axis-type]:checked").value;
-                if (axisMode === relativeRadio.value) { 
-                    return (Math.min(...baseRanges) - (0.1 * Math.abs(Math.min(...baseRanges)))) - 1;
+            try {
+                if (yMinCheckbox.checked) { 
+                    return yMinValueEntry.value;
                 }
-                else if (axisMode === absoluteRadio.value) { 
-                    return null; 
+                else {
+                    var axisMode = document.querySelector("input[name=y-axis-type]:checked").value;
+                    if (axisMode === relativeRadio.value) { 
+                        const val = (Math.min(...baseRanges) - (0.1 * Math.abs(Math.min(...baseRanges)))) - 1;
+                        console.log(`using relative: ${val}`);
+                        return val;
+                    }
+                    else if (axisMode === absoluteRadio.value) { 
+                        console.log("using absolute")
+                        return null;
+                    }
                 }
             }
-            return null;
+            finally {
+                return null;
+            }
+        }
+
+        function wgetMinY() {
+            var y = getMinY();
+            console.log(`min y: ${y}`);
+            return y;
         }
 
         function updatePlot() {
@@ -343,7 +383,7 @@
                 x_label: "Time",
                 y_label: "Voltage",
                 max_y: getMaxY(),
-                min_y: getMinY(), 
+                min_y: wgetMinY(), 
                 baselines: baseRanges.map(function(baseline, index) {
                         return {"value": baseline, "label": `${baseline}V`};
                     }),
@@ -361,12 +401,18 @@
                 }
             };
 
-            sessionStorage.setItem("storedPlotControls", getPlotControlsState())
-            initialPlotState = getPlotControlsState()
+            initialPlotState = getPlotControlsState();
+            sessionStorage.setItem("storedPlotControls", JSON.stringify(initialPlotState));
             updateButton.setAttribute("disabled", "");
 
             if (slowData.length > 0) {
                 MG.data_graphic(dparams); //replaces "No data" text
+                try {
+                    document.getElementById("data-status").remove();
+                }
+                catch { 
+                    console.log("testing!")
+                } //if it already doesn't exist, just continue
             }
 
             // the only way to change line width, i tried. ugh
@@ -424,9 +470,9 @@
         if (slowData.length !== 0) {
             datetimeLowInput.setAttribute("disabled", "");
             datetimeHighInput.setAttribute("disabled", "");
-            dateWarningText.removeAttribute("hidden");
+            dateWarningText.style.visibility = "visible";
         } else {
-            dateWarningText.setAttribute("hidden", "");
+            dateWarningText.style.visibility = "hidden";
         }
 
         function history() {
@@ -501,6 +547,7 @@
             storeArray("storedSlowData", slowData);
             storeArray("storedDataNames", dataNames);
             storeArray("storedBaseRanges", baseRanges);
+            sessionStorage.setItem("storedPlotControls", JSON.stringify(getPlotControlsState()));
             appendPlotButton.innerHTML = `Est. wait: ${getEstTimeString()}`;
             history();
         }

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -51,6 +51,7 @@
                         <input type="radio" id="supply" value="supply" name="channel-type" checked>
                         <label for="supply-rack">Rack #</label>
                         <select name="supply-rack" id="supply-rack">
+                            <option disabled selected hidden>...</option>
                             <option value="1">Rack 1</option>
                             <option value="2">Rack 2</option>
                             <option value="3">Rack 3</option>
@@ -66,9 +67,10 @@
                         </select>
                         <label for="supply-voltage">Voltage</label>
                         <select name="supply-voltage" id="supply-voltage">
+                            <option disabled selected hidden>...</option>
                             <option value="24">24V</option>
                             <option value="-24">-24V</option>
-                            <option value="8">8V</option>
+                            <option value="8" id="supply-flippy">8V</option>
                             <option value="5">5V</option>
                             <option value="-5">-5V</option>
                         </select>
@@ -78,9 +80,10 @@
                         <label for="baseline">Baseline Voltage</label>
                         <input type="radio" id="baseline" value="baseline" name="channel-type" checked>
                         <label for="baseline-crate">Crate #</label>
-                        <input type="number" id="baseline-crate" name="baseline-crate" min="0" max="18" value="7" style="width: 4em">
+                        <input type="number" id="baseline-crate" name="baseline-crate" min="0" max="18" value="" style="width: 4em">
                         <label for="baseline-trigger">Trigger</label>
                         <select name="baseline-trigger" id="baseline-trigger">
+                            <option disabled selected hidden>...</option>
                             <option value="100">N100_BL</option>
                             <option value="20">N20_BL</option>
                         </select>
@@ -95,7 +98,7 @@
     <div class="row">
     <div class="col-md-12" id="sum">
         <div id="waiting">
-            Received data, loading....
+            Received data, loading...
         </div>
     </div>
         </div>
@@ -122,6 +125,7 @@
     <script src="{{ url_for('static', filename='js/metricsgraphics.js') }}"></script>
     <script src="{{ url_for('static', filename='js/mg_line_brushing.js') }}"></script>
     <script src="{{ url_for('static', filename='js/stream_utilities.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/slowcontrol_plots.js') }}"></script>
     <script>
         if (url_params.datetime_low && document.getElementById("datetime_low").value == "") {
             document.getElementById("datetime_low").value = url_params.datetime_low;
@@ -132,18 +136,18 @@
         if (url_params.channel_type) {
             document.getElementById(url_params.channel_type).checked = true 
         }
-        if (url_params.supply_rack) {
-            document.getElementById("supply-rack").value = url_params.supply_rack;
-        }
-        if (url_params.supply_voltage) {
-            document.getElementById("supply-voltage").value = url_params.supply_voltage;
-        }
-        if (url_params.baseline_crate) {
-            document.getElementById("baseline-crate").value = url_params.baseline_crate;
-        }
-        if (url_params.baseline_trigger) {
-            document.getElementById("baseline-trigger").value = url_params.baseline_trigger;
-        }
+        // if (url_params.supply_rack) {
+        //     document.getElementById("supply-rack").value = url_params.supply_rack;
+        // }
+        // if (url_params.supply_voltage) {
+        //     document.getElementById("supply-voltage").value = url_params.supply_voltage;
+        // }
+        // if (url_params.baseline_crate) {
+        //     document.getElementById("baseline-crate").value = url_params.baseline_crate;
+        // }
+        // if (url_params.baseline_trigger) {
+        //     document.getElementById("baseline-trigger").value = url_params.baseline_trigger;
+        // }
 
         function initializeStoredArray(name) {
             rawValue = sessionStorage.getItem(name)

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -1,0 +1,208 @@
+{% extends "layout.html" %}
+{% block title %}Slow Control Plots{% endblock %}
+{% block head %}
+    <!-- metrics-graphics stylesheet goes above super() because we want bootstrap's style
+    (which is linked in super()) to override it. -->
+    <link rel="stylesheet" type="text/css"  href="{{ url_for('static',filename='css/metricsgraphics.css') }}">
+    <link rel="stylesheet" type="text/css"  href="{{ url_for('static',filename='css/mg_line_brushing.css') }}">
+  {{ super() }}
+  <style>
+    .btn2 {
+        background-color: #228B22;
+        padding: 6px 6px;
+        color: white;
+        text-align: center;
+        font-size: 14px;
+        margin: 4px 2px;
+        cursor: pointer;
+    }
+  </style>
+{% endblock %}
+{% block body %}
+    {{ super() }}
+
+    <div class="page-header">
+        <h1 align="center">Slow Control Plots</h1>
+    </div>
+
+    <!-- Set up display options -->
+    <div class="container">
+        <div class="col-md-12">
+            <table class="table table-hover">
+            <tr>
+                <th> Date Range: </th>
+                <th> Criteria: </th>
+                <th> </th>
+            </tr>
+            <tr>
+                <!-- Run date inputs -->
+                <th>
+		            <input style="margin-bottom: 30px;" type="date" id="date_low" value={{date_low}} required></input>
+                    -
+                    <input style="margin-bottom: 30px;" type="date" id="date_high" value={{date_high}} required></input>
+                </th>
+                <!-- Criteria drop-down -->
+                <th>
+                    <select id="crit">
+                    <option selected value="{{criteria}}">{{criteria}}</option>
+                    {% for n in drop_down_crits %}
+                        {% if n != criteria %}
+                            <option value="{{n}}">{{n}}</option>
+                        {% endif %}
+                    {% endfor %}
+                    </select>
+                </th>
+                <!-- Button to update plots with the run dates & criteria -->
+                <th class="col-xs-3 col-xs-offset-0">
+                    <button type=button onclick="history();">Update Plot</button>
+</th>
+</tr>
+</table>
+<!-- Runs summary goes here -->
+    <div class="row">
+    <div class="col-md-12" id="sum">
+        <h2 align="left"> Summary: </h2>
+        <p id="phys_summary"> </p>
+        <p id="pass_summary"> </p>
+        <p id="fail_summary"> </p>
+        <p id="purg_summary"> </p>
+    </div>
+        </div>
+<!-- Plot goes here -->
+    <div class="row">
+    <div class="col-md-12" id="main">
+      {% if not rs_plot_data %}
+        <h2 align="left"> No data available </h2>
+      {% endif %}
+
+    </div>
+        </div>
+
+    </div>
+</div>
+
+{% endblock %}
+
+{% block script %}
+    <script src="{{ url_for('static', filename='js/d3.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/moment.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/moment-timezone-with-data.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/tzscale.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/metricsgraphics.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/mg_line_brushing.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/stream_utilities.js') }}"></script>
+    <script>
+        if (url_params.date_low && document.getElementById("date_low").value == "") {
+            document.getElementById("date_low").value = url_params.date_low;
+        }
+        if (url_params.date_high && document.getElementById("date_high").value == "") {
+            document.getElementById("date_high").value = url_params.date_high;
+        }
+        if (url_params.criteria) {
+            document.getElementById("crit").value = url_params.criteria;
+        }
+
+        var rs_plot_data = {{ rs_plot_data | safe }};
+
+        var dates = new Array();
+        var phys = new Array();
+        var pass = new Array();
+        var fail = new Array();
+        var purg = new Array();
+
+        for (var i=0; i < rs_plot_data.length; i++)
+        {
+            date_ = moment(rs_plot_data[i]['timestamp']).toDate();
+            dates.push(date_);
+            phys.push({'date': date_, 'value': rs_plot_data[rs_plot_data.length - 1]['phys_total'] - rs_plot_data[i]['phys_total']});
+            pass.push({'date': date_, 'value': rs_plot_data[rs_plot_data.length - 1]['pass_total'] - rs_plot_data[i]['pass_total']});
+            fail.push({'date': date_, 'value': rs_plot_data[rs_plot_data.length - 1]['fail_total'] - rs_plot_data[i]['fail_total']});
+            purg.push({'date': date_, 'value': rs_plot_data[rs_plot_data.length - 1]['purg_total'] - rs_plot_data[i]['purg_total']});
+        }
+        var cscale = tzscale().domain(dates).zone('America/Toronto');
+
+        var time_fmt = 'MMM Do YYYY';
+        
+<!-- Messy bit of code to get the run summary section but it works... -MD -->
+	var summaryTime = [rs_plot_data[rs_plot_data.length - 1]['phys_total'],rs_plot_data[rs_plot_data.length - 1]['pass_total'],rs_plot_data[rs_plot_data.length - 1]['fail_total'],rs_plot_data[rs_plot_data.length - 1]['purg_total']]
+    
+    var summaryRuns = [rs_plot_data[rs_plot_data.length - 1]['phys_runs'],rs_plot_data[rs_plot_data.length - 1]['pass_runs'],rs_plot_data[rs_plot_data.length - 1]['fail_runs'],rs_plot_data[rs_plot_data.length - 1]['purg_runs']]
+    
+
+for (var i=0; i < summaryTime.length; i++)
+	{
+		var j = parseFloat(summaryTime[i]).toFixed(3);
+		summaryTime[i] = j;
+	}
+
+	document.getElementById("phys_summary").innerHTML = 'Physics: ' + summaryTime[0].toString() + ' Days, ' +summaryRuns[0].toString() + ' Runs';
+    if (summaryRuns[1] == 0) {document.getElementById("pass_summary").innerHTML = 'Passed: None';}
+    else{document.getElementById("pass_summary").innerHTML = 'Passed: ' + summaryTime[1].toString() + ' Days, ' +summaryRuns[1].toString() + ' Runs';}
+    if (summaryRuns[2] == 0) {document.getElementById("fail_summary").innerHTML = 'Failed: None';}
+    else{document.getElementById("fail_summary").innerHTML = 'Failed: ' + summaryTime[2].toString() + ' Days, ' +summaryRuns[2].toString() + ' Runs';}
+    if (summaryRuns[3] == 0) {document.getElementById("purg_summary").innerHTML = 'Purgatory: None';}
+    else{document.getElementById("purg_summary").innerHTML = 'Purgatory: ' + summaryTime[3].toString()  + ' Days, ' +summaryRuns[3].toString() + ' Runs';}
+
+        var dparams = {
+            area: false,
+            data: [phys, pass, fail, purg],
+            width: $('#main').width(),
+            left: 100,
+            right: 100,
+            height: 500,
+            target: "#main",
+            time_scale: cscale,
+            x_accessor:'date',
+            y_accessor:'value',
+            point_size: 4.0,
+            y_label: "Time (Days)",
+            x_label: "Date",
+            decimals: 5,
+            legend: ['Physics', 'Passed', 'Failed', 'Purgatory'],
+    
+	<!-- Adding the unit (days) to the mouse over legend and fixing the value to 3 decimal places -->
+            interpolate: 'linear',
+                        y_mouseover: function(d, i) {
+		 var y = parseFloat(d['value']).toFixed(3);
+                return y + ' (days)';
+
+            },
+        };
+
+        MG.data_graphic(dparams);
+
+        // the only way to change line width, i tried. ugh
+        // changing dparams or overriding CSS did NOT work, for me at least
+        document.querySelectorAll('#main svg path.mg-main-line').forEach(function(path) {
+            path.style.strokeWidth = '4px';
+        });
+        document.querySelectorAll('#main svg .mg-line-legend text').forEach(function(text) {
+            text.style.fontSize = '1.2em';
+            text.style.fontWeight = '600';
+        });
+        document.querySelectorAll('.mg-x-axis text, .mg-y-axis text, .mg-histogram .axis text').forEach(function(text) {
+            text.style.fontSize = '1.1em';
+        });
+
+        function history() {
+            var params = {};
+            try {
+                params['date_low'] = document.getElementById("date_low").value;
+            } catch (e) {
+                params['date_low'] = "2024-02-19";
+            }
+            try {
+                params['date_high'] = document.getElementById("date_high").value;
+            } catch (e) {
+                params['date_high'] = "2024-05-29";
+            }
+            try {
+                params['criteria'] = document.getElementById("crit").value;
+            } catch (e) {
+                params['criteria'] = "scintillator_silver";
+            }
+            window.location.replace($SCRIPT_ROOT + "/slowcontrol_plots?" + $.param(params));
+        }
+
+    </script>
+{% endblock %}

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -217,13 +217,20 @@
 
         if (slowData.length > 0) {
             slowData.forEach((datastream) => {
-                if (datastream.length !== slowData[0].length) {
-                    document.getElementById("incompatible").removeAttribute("hidden")
-                    throw new Error("Data streams were incompatible.");
+                // if (datastream.length !== slowData[0].length) {
+                //     document.getElementById("incompatible").removeAttribute("hidden")
+                //     throw new Error("Data streams were incompatible.");
+                // }
+                if (typeof datastream[0].key == "string") {
+                    datastream.forEach((datapoint) => {
+                        datapoint['key'] = moment(datapoint['key']).toDate();
+                    });
                 }
-                datastream.forEach((datapoint) => {
-                    datapoint['key'] = moment.unix(datapoint['key']).toDate();
-                });
+                if (typeof datastream[0].key == "number") {
+                    datastream.forEach((datapoint) => {
+                        datapoint['key'] = moment.unix(datapoint['key']).toDate();
+                    });
+                }
             });
 
             mintime = slowData[0][0]['key'];
@@ -386,7 +393,7 @@
 
         function getEstTimeString() {
             var millisecondDifference = moment(datetimeHighInput.value) - moment(datetimeLowInput.value);
-            const DataMsPerMsQueryTime = 100000; //ie. 1 ms of query time returns 20 results, or 100secs of data
+            const DataMsPerMsQueryTime = 400000; //ie. 1 ms of query time returns ~80 results, or 400secs of data (when threaded)
             var estWaitTimeMs = millisecondDifference / DataMsPerMsQueryTime;
             return moment.duration(estWaitTimeMs).locale('en').humanize(); 
         }

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -38,11 +38,12 @@
                 <!-- Data datetime inputs -->
                 <th>
                     <div>
-                        <input style="margin-bottom: 30px;" type="datetime-local" id="datetime_low" value="{{datetime_low}}" required></input> 
+                        <input style="margin-bottom: 10px;" type="datetime-local" id="datetime_low" value="{{datetime_low}}" required></input> 
                     </div>
                     <div>
-                        <input style="margin-bottom: 30px;" type="datetime-local" id="datetime_high" value="{{datetime_high}}" required></input>
+                        <input style="margin-bottom: 10px;" type="datetime-local" id="datetime_high" value="{{datetime_high}}" required></input>
                     </div>
+                    <div id="date-warning" hidden style="color:red">Clear the plot to unlock.</div>
                 </th>
                 <!-- Channel selector -->
                 <th>
@@ -294,8 +295,8 @@
             return sessionStorage.setItem(name, JSON.stringify(data));
         }
 
-        var newSlowData = {{ slow_data | safe if slow_data else 'null' }};
-        var newDataName = "{{ data_name | safe if data_name else 'null' }}"; // this sucks, fix it
+        var newSlowData = {{ slow_data | safe if slow_data else "null" }};
+        var newDataName = "{{ data_name | safe if data_name else "null" }}"; // this sucks i am so sorry
 
         var slowData = initializeStoredArray("storedSlowData")
         var dataNames = initializeStoredArray("storedDataNames")
@@ -304,7 +305,7 @@
         if (newSlowData !== null) { //unfortunate, but null handling is hard
             slowData.push(newSlowData)
         }
-        if (newDataName !== null) {
+        if (newDataName !== "null") { //more unfortunate
             dataNames.push(newDataName)
         }
 
@@ -402,7 +403,7 @@
             
             tableData=
                 `<tr>
-                    <td class="mg-line${index}-legend-color">${index}</td>
+                    <td class="mg-line${index+1}-legend-color">${index+1}</td>
                     <td>${name}</td>
                     <td>${first}</td>
                     <td>${last}</td>
@@ -423,6 +424,14 @@
         }
         
         document.getElementById("waiting").innerHTML="";
+
+        if (slowData.length !== 0) {
+            datetimeLowInput.setAttribute("disabled", "");
+            datetimeHighInput.setAttribute("disabled", "");
+            dateWarningText.removeAttribute("hidden");
+        } else {
+            dateWarningText.setAttribute("hidden", "");
+        }
 
         // the only way to change line width, i tried. ugh
         // changing dparams or overriding CSS did NOT work, for me at least
@@ -494,7 +503,7 @@
         function historyNew() {
             sessionStorage.removeItem("storedSlowData");
             sessionStorage.removeItem("storedDataNames");
-            sessionStorage.removeItem("dataType");
+            sessionStorage.setItem("dataType", document.querySelector("input[name=channel-type]:checked").value);
 
             history();
         }

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -516,7 +516,7 @@
 
         function getEstTimeString() {
             var millisecondDifference = moment(datetimeHighInput.value) - moment(datetimeLowInput.value);
-            const DataMsPerMsQueryTime = 400000; //ie. 1 ms of query time returns ~80 results, or 400secs of data (when threaded)
+            const DataMsPerMsQueryTime = 100000; //ie. 1 ms of query time returns ~20 results, or 100secs of data (when threaded)
             var estWaitTimeMs = millisecondDifference / DataMsPerMsQueryTime;
             return moment.duration(estWaitTimeMs).locale('en').humanize(); 
         }

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -102,7 +102,7 @@
 <!-- Plot goes here -->
     <div class="row">
     <div class="col-md-12" id="main">
-      {% if (not slow_data) or (slow_data == []) or (slow_data == "\"none\"") %}
+      {% if not slow_data %}
         <h2 align="left"> No data </h2>
       {% endif %}
 
@@ -159,16 +159,16 @@
             return sessionStorage.setItem(name, JSON.stringify(data))
         }
 
-        var newSlowData = {{ slow_data | safe }};
-        var newDataName = "{{ data_name | safe }}"; // this sucks, fix it
+        var newSlowData = {{ slow_data | safe if slow_data else 'null' }};
+        var newDataName = "{{ data_name | safe if data_name else 'null' }}"; // this sucks, fix it
 
         var slowData = initializeStoredArray("storedSlowData")
         var dataNames = initializeStoredArray("storedDataNames")
 
-        if (newSlowData !== "none") { //unfortunate, but null handling is hard
+        if (newSlowData !== null) { //unfortunate, but null handling is hard
             slowData.push(newSlowData)
         }
-        if (newDataName !== "none") {
+        if (newDataName !== null) {
             dataNames.push(newDataName)
         }
 

--- a/minard/templates/slowcontrol_plots.html
+++ b/minard/templates/slowcontrol_plots.html
@@ -32,7 +32,7 @@
                     <div>
                         <input style="margin-bottom: 10px;" type="datetime-local" id="datetime_high" value="{{datetime_high}}" required></input>
                     </div>
-                    <div id="date-warning" hidden style="color:red">Clear the plot to unlock.</div>
+                    <div id="date-warning" hidden style="color:red">Clear the plot to unlock dates.</div>
                 </th>
                 <!-- Channel selector -->
                 <th>
@@ -201,9 +201,9 @@
             return sessionStorage.setItem(name, JSON.stringify(data));
         }
 
-        var newSlowData = {{ slow_data | safe if slow_data else "null" }};
-        var newDataName = "{{ data_name | safe if data_name else "null" }}"; // this sucks i am so sorry
-        var newBaseRange = {{ base_range | safe if base_range else "null" }};
+        var newSlowData = {{ slow_data | safe if slow_data is not none else "null" }};
+        var newDataName = "{{ data_name | safe if data_name is not none else "null" }}"; // this sucks i am so sorry
+        var newBaseRange = {{ base_range | safe if base_range is not none else "null" }};
 
         var slowData = initializeStoredArray("storedSlowData")
         var dataNames = initializeStoredArray("storedDataNames")
@@ -319,7 +319,7 @@
             addDatastreamTableRow(myName, myFirstTime, myLastTime, streamLength, i);
         }
         
-        document.getElementById("waiting").innerHTML="";
+        document.getElementById("waiting").setAttribute("hidden", "")
 
         if (slowData.length !== 0) {
             datetimeLowInput.setAttribute("disabled", "");

--- a/minard/views.py
+++ b/minard/views.py
@@ -2167,7 +2167,7 @@ def slowcontrol_plots():
     supplyRack = request.args.get("supply_rack", None, type=str)
     supplyVoltage = request.args.get("supply_voltage", None, type=str)
     baselineCrate = request.args.get("baseline_crate", None, type=str)
-    baseline_trigger = request.args.get("baseline_trigger", None, type=str)
+    baselineTrigger = request.args.get("baseline_trigger", None, type=str)
     if datelow is not None:
         try:
             datelow = datetime.strptime(datelow, "%Y-%m-%dT%H:%M")
@@ -2184,13 +2184,16 @@ def slowcontrol_plots():
         datehigh = default_datehigh
     if datelow > datehigh:
         datelow, datehigh = datehigh, datelow
-    slow_data, dataName, adj_datelow, adj_datehigh = slowcontrol_data.get_plot_data_http(datelow, datehigh)
-    #rs_plot_data, drop_down_crits, adj_datelow, adj_datehigh = RSTools.pass_fail_plot_info(criteria, date_range)
-    # datelow_str = adj_datelow.strftime("%Y-%m-%dT%H:%M")
-    # datehigh_str = adj_datehigh.strftime("%Y-%m-%dT%H:%M")
+
+    if channelType == "supply":
+        slow_data, data_name = slowcontrol_data.get_supply_data_http(datelow, datehigh, supplyRack, supplyVoltage)
+    elif channelType == "baseline":
+        slow_data, data_name = slowcontrol_data.get_baseline_data_http(datelow, datehigh, baselineCrate, baselineTrigger)
+    else:
+        slow_data = None
+        data_name = None #initialize if we return
+
     datelow_str = datelow.strftime("%Y-%m-%dT%H:%M")
     datehigh_str = datehigh.strftime("%Y-%m-%dT%H:%M")
-    rs_plot_data = []
-    drop_down_crits = []
     # Return info to webpage
-    return render_template('slowcontrol_plots.html', slow_data=slow_data, datetime_low=datelow_str, datetime_high=datehigh_str)
+    return render_template('slowcontrol_plots.html', slow_data=slow_data, data_name=data_name, datetime_low=datelow_str, datetime_high=datehigh_str)

--- a/minard/views.py
+++ b/minard/views.py
@@ -2190,8 +2190,8 @@ def slowcontrol_plots():
     elif channelType == "baseline":
         newSlowData, newDataName = slowcontrol_data.get_baseline_data_http(datelow, datehigh, baselineCrate, baselineTrigger)
     else:
-        newSlowData = ""
-        newDataName = "" #initialize if we return
+        newSlowData = "\"none\""
+        newDataName = "none" #initialize if we return
 
     datelow_str = datelow.strftime("%Y-%m-%dT%H:%M")
     datehigh_str = datehigh.strftime("%Y-%m-%dT%H:%M")

--- a/minard/views.py
+++ b/minard/views.py
@@ -2190,8 +2190,8 @@ def slowcontrol_plots():
     elif channelType == "baseline":
         newSlowData, newDataName = slowcontrol_data.get_baseline_data_http(datelow, datehigh, baselineCrate, baselineTrigger)
     else:
-        newSlowData = "\"none\""
-        newDataName = "none" #initialize if we return
+        newSlowData = None
+        newDataName = None #initialize since we return
 
     datelow_str = datelow.strftime("%Y-%m-%dT%H:%M")
     datehigh_str = datehigh.strftime("%Y-%m-%dT%H:%M")

--- a/minard/views.py
+++ b/minard/views.py
@@ -2153,3 +2153,35 @@ def runselection_plots():
     datehigh_str = adj_datehigh.strftime("%Y-%m-%d")
     # Return info to webpage
     return render_template('runselection_plots.html', rs_plot_data=rs_plot_data, drop_down_crits=drop_down_crits, criteria=criteria, date_low=datelow_str, date_high=datehigh_str)
+
+@app.route('/slowcontrol_plots')
+def slowcontrol_plots():
+    default_datehigh = datetime.now()
+    default_datelow = default_datehigh - timedelta(days=7)
+    # Get variable info from webpage (with defaults defined)
+    criteria = request.args.get("criteria", "scintillator_silver", type=str)
+    datelow = request.args.get("date_low", None, type=str)
+    datehigh = request.args.get("date_high", None, type=str)
+    if datelow is not None:
+        try:
+            datelow = datetime.strptime(datelow, "%Y-%m-%d")
+        except ValueError: #invalid date
+            datelow = datetime(2024, 02, 19)
+    else:
+        datelow = default_datelow
+    if datehigh is not None:
+        try:
+            datehigh = datetime.strptime(datehigh, "%Y-%m-%d")
+        except ValueError: #invalid date
+            datehigh = datetime(2024, 05, 29)
+    else:
+        datehigh = default_datehigh
+    # Use this to get run info from databases, to display in list
+    if datelow > datehigh:
+        datelow, datehigh = datehigh, datelow
+    date_range = [datelow, datehigh]
+    rs_plot_data, drop_down_crits, adj_datelow, adj_datehigh = RSTools.pass_fail_plot_info(criteria, date_range)
+    datelow_str = adj_datelow.strftime("%Y-%m-%d")
+    datehigh_str = adj_datehigh.strftime("%Y-%m-%d")
+    # Return info to webpage
+    return render_template('slowcontrol_plots.html', rs_plot_data=rs_plot_data, drop_down_crits=drop_down_crits, criteria=criteria, date_low=datelow_str, date_high=datehigh_str)

--- a/minard/views.py
+++ b/minard/views.py
@@ -55,6 +55,7 @@ from datetime import datetime, timedelta
 from functools import wraps, update_wrapper
 from dead_time import get_dead_time, get_dead_time_runs, get_dead_time_run_by_key
 from radon_monitor import get_radon_monitor
+import slowcontrol_data
 
 TRIGGER_NAMES = \
 ['100L',
@@ -2161,7 +2162,12 @@ def slowcontrol_plots():
     # Get variable info from webpage (with defaults defined)
     criteria = request.args.get("criteria", "scintillator_silver", type=str)
     datelow = request.args.get("datetime_low", None, type=str)
-    datehigh = request.args.get("datetime_high", None, type=str)
+    datehigh = request.args.get("datetime_high", None, type=str) 
+    channelType = request.args.get("channel_type", None, type=str)
+    supplyRack = request.args.get("supply_rack", None, type=str)
+    supplyVoltage = request.args.get("supply_voltage", None, type=str)
+    baselineCrate = request.args.get("baseline_crate", None, type=str)
+    baseline_trigger = request.args.get("baseline_trigger", None, type=str)
     if datelow is not None:
         try:
             datelow = datetime.strptime(datelow, "%Y-%m-%dT%H:%M")
@@ -2176,10 +2182,9 @@ def slowcontrol_plots():
             datehigh = datetime(2024, 05, 29, 23, 59)
     else:
         datehigh = default_datehigh
-    # Use this to get run info from databases, to display in list
     if datelow > datehigh:
         datelow, datehigh = datehigh, datelow
-    date_range = [datelow, datehigh]
+    slow_data, adj_datelow, adj_datehigh = slowcontrol_data.get_plot_data(datelow, datehigh)
     #rs_plot_data, drop_down_crits, adj_datelow, adj_datehigh = RSTools.pass_fail_plot_info(criteria, date_range)
     # datelow_str = adj_datelow.strftime("%Y-%m-%dT%H:%M")
     # datehigh_str = adj_datehigh.strftime("%Y-%m-%dT%H:%M")
@@ -2188,4 +2193,4 @@ def slowcontrol_plots():
     rs_plot_data = []
     drop_down_crits = []
     # Return info to webpage
-    return render_template('slowcontrol_plots.html', rs_plot_data=rs_plot_data, drop_down_crits=drop_down_crits, criteria=criteria, datetime_low=datelow_str, datetime_high=datehigh_str)
+    return render_template('slowcontrol_plots.html', slow_data=slow_data, datetime_low=datelow_str, datetime_high=datehigh_str)

--- a/minard/views.py
+++ b/minard/views.py
@@ -2185,9 +2185,9 @@ def slowcontrol_plots():
     if datelow > datehigh:
         datelow, datehigh = datehigh, datelow
 
-    if channelType == "supply":
+    if channelType == "supply" and supplyRack != "..." and supplyVoltage != "...":
         newSlowData, newDataName = slowcontrol_data.get_supply_data_http(datelow, datehigh, supplyRack, supplyVoltage)
-    elif channelType == "baseline":
+    elif channelType == "baseline" and baselineTrigger != "...": #there has to be a better way
         newSlowData, newDataName = slowcontrol_data.get_baseline_data_http(datelow, datehigh, baselineCrate, baselineTrigger)
     else:
         newSlowData = None

--- a/minard/views.py
+++ b/minard/views.py
@@ -2164,16 +2164,16 @@ def slowcontrol_plots():
     datehigh = request.args.get("date_high", None, type=str)
     if datelow is not None:
         try:
-            datelow = datetime.strptime(datelow, "%Y-%m-%d")
+            datelow = datetime.strptime(datelow, "%Y-%m-%dT%H:%M")
         except ValueError: #invalid date
-            datelow = datetime(2024, 02, 19)
+            datelow = datetime(2024, 02, 19, 0, 0)
     else:
         datelow = default_datelow
     if datehigh is not None:
         try:
-            datehigh = datetime.strptime(datehigh, "%Y-%m-%d")
+            datehigh = datetime.strptime(datehigh, "%Y-%m-%dT%H:%M")
         except ValueError: #invalid date
-            datehigh = datetime(2024, 05, 29)
+            datehigh = datetime(2024, 05, 29, 23, 59)
     else:
         datehigh = default_datehigh
     # Use this to get run info from databases, to display in list
@@ -2181,7 +2181,7 @@ def slowcontrol_plots():
         datelow, datehigh = datehigh, datelow
     date_range = [datelow, datehigh]
     rs_plot_data, drop_down_crits, adj_datelow, adj_datehigh = RSTools.pass_fail_plot_info(criteria, date_range)
-    datelow_str = adj_datelow.strftime("%Y-%m-%d")
-    datehigh_str = adj_datehigh.strftime("%Y-%m-%d")
+    datelow_str = adj_datelow.strftime("%Y-%m-%dT%H:%M")
+    datehigh_str = adj_datehigh.strftime("%Y-%m-%dT%H:%M")
     # Return info to webpage
-    return render_template('slowcontrol_plots.html', rs_plot_data=rs_plot_data, drop_down_crits=drop_down_crits, criteria=criteria, date_low=datelow_str, date_high=datehigh_str)
+    return render_template('slowcontrol_plots.html', rs_plot_data=rs_plot_data, drop_down_crits=drop_down_crits, criteria=criteria, datetime_low=datelow_str, datetime_high=datehigh_str)

--- a/minard/views.py
+++ b/minard/views.py
@@ -2186,14 +2186,14 @@ def slowcontrol_plots():
         datelow, datehigh = datehigh, datelow
 
     if channelType == "supply":
-        slow_data, data_name = slowcontrol_data.get_supply_data_http(datelow, datehigh, supplyRack, supplyVoltage)
+        newSlowData, newDataName = slowcontrol_data.get_supply_data_http(datelow, datehigh, supplyRack, supplyVoltage)
     elif channelType == "baseline":
-        slow_data, data_name = slowcontrol_data.get_baseline_data_http(datelow, datehigh, baselineCrate, baselineTrigger)
+        newSlowData, newDataName = slowcontrol_data.get_baseline_data_http(datelow, datehigh, baselineCrate, baselineTrigger)
     else:
-        slow_data = None
-        data_name = None #initialize if we return
+        newSlowData = ""
+        newDataName = "" #initialize if we return
 
     datelow_str = datelow.strftime("%Y-%m-%dT%H:%M")
     datehigh_str = datehigh.strftime("%Y-%m-%dT%H:%M")
     # Return info to webpage
-    return render_template('slowcontrol_plots.html', slow_data=slow_data, data_name=data_name, datetime_low=datelow_str, datetime_high=datehigh_str)
+    return render_template('slowcontrol_plots.html', slow_data=newSlowData, data_name=newDataName, datetime_low=datelow_str, datetime_high=datehigh_str)

--- a/minard/views.py
+++ b/minard/views.py
@@ -2160,8 +2160,8 @@ def slowcontrol_plots():
     default_datelow = default_datehigh - timedelta(days=7)
     # Get variable info from webpage (with defaults defined)
     criteria = request.args.get("criteria", "scintillator_silver", type=str)
-    datelow = request.args.get("date_low", None, type=str)
-    datehigh = request.args.get("date_high", None, type=str)
+    datelow = request.args.get("datetime_low", None, type=str)
+    datehigh = request.args.get("datetime_high", None, type=str)
     if datelow is not None:
         try:
             datelow = datetime.strptime(datelow, "%Y-%m-%dT%H:%M")
@@ -2180,8 +2180,12 @@ def slowcontrol_plots():
     if datelow > datehigh:
         datelow, datehigh = datehigh, datelow
     date_range = [datelow, datehigh]
-    rs_plot_data, drop_down_crits, adj_datelow, adj_datehigh = RSTools.pass_fail_plot_info(criteria, date_range)
-    datelow_str = adj_datelow.strftime("%Y-%m-%dT%H:%M")
-    datehigh_str = adj_datehigh.strftime("%Y-%m-%dT%H:%M")
+    #rs_plot_data, drop_down_crits, adj_datelow, adj_datehigh = RSTools.pass_fail_plot_info(criteria, date_range)
+    # datelow_str = adj_datelow.strftime("%Y-%m-%dT%H:%M")
+    # datehigh_str = adj_datehigh.strftime("%Y-%m-%dT%H:%M")
+    datelow_str = datelow.strftime("%Y-%m-%dT%H:%M")
+    datehigh_str = datehigh.strftime("%Y-%m-%dT%H:%M")
+    rs_plot_data = []
+    drop_down_crits = []
     # Return info to webpage
     return render_template('slowcontrol_plots.html', rs_plot_data=rs_plot_data, drop_down_crits=drop_down_crits, criteria=criteria, datetime_low=datelow_str, datetime_high=datehigh_str)

--- a/minard/views.py
+++ b/minard/views.py
@@ -2186,14 +2186,15 @@ def slowcontrol_plots():
         datelow, datehigh = datehigh, datelow
 
     if channelType == "supply" and supplyRack != "..." and supplyVoltage != "...":
-        newSlowData, newDataName = slowcontrol_data.get_supply_data_http(datelow, datehigh, supplyRack, supplyVoltage)
+        newSlowData, newDataName, baseRange = slowcontrol_data.get_supply_data_http(datelow, datehigh, supplyRack, supplyVoltage)
     elif channelType == "baseline" and baselineTrigger != "...": #there has to be a better way
-        newSlowData, newDataName = slowcontrol_data.get_baseline_data_http(datelow, datehigh, baselineCrate, baselineTrigger)
+        newSlowData, newDataName, baseRange = slowcontrol_data.get_baseline_data_http(datelow, datehigh, baselineCrate, baselineTrigger)
     else:
         newSlowData = None
         newDataName = None #initialize since we return
+        baseRange = None
 
     datelow_str = datelow.strftime("%Y-%m-%dT%H:%M")
     datehigh_str = datehigh.strftime("%Y-%m-%dT%H:%M")
     # Return info to webpage
-    return render_template('slowcontrol_plots.html', slow_data=newSlowData, data_name=newDataName, datetime_low=datelow_str, datetime_high=datehigh_str)
+    return render_template('slowcontrol_plots.html', slow_data=newSlowData, data_name=newDataName, base_range=baseRange, datetime_low=datelow_str, datetime_high=datehigh_str)

--- a/minard/views.py
+++ b/minard/views.py
@@ -2186,12 +2186,19 @@ def slowcontrol_plots():
         datelow, datehigh = datehigh, datelow
 
     if channelType == "supply" and supplyRack != "..." and supplyVoltage != "...":
-        newSlowData, newDataName, baseRange = slowcontrol_data.get_supply_data_http(datelow, datehigh, supplyRack, supplyVoltage)
-    elif channelType == "baseline" and baselineTrigger != "...": #there has to be a better way
-        newSlowData, newDataName, baseRange = slowcontrol_data.get_baseline_data_http(datelow, datehigh, baselineCrate, baselineTrigger)
+        newSlowObject = slowcontrol_data.SupplyDataObject(datelow, datehigh, supplyRack, supplyVoltage)
+    elif channelType == "baseline" and baselineTrigger != "...": #there has to be a better way, also what's crate?
+        newSlowObject = slowcontrol_data.BaselineDataObject(datelow, datehigh, baselineCrate, baselineTrigger)
+    else:
+        newSlowObject = None
+
+    if newSlowObject is not None:
+        newSlowData = json.dumps(newSlowObject.data)
+        newDataName = newSlowObject.caption
+        baseRange = newSlowObject.baseline
     else:
         newSlowData = None
-        newDataName = None #initialize since we return
+        newDataName = None
         baseRange = None
 
     datelow_str = datelow.strftime("%Y-%m-%dT%H:%M")

--- a/minard/views.py
+++ b/minard/views.py
@@ -2184,7 +2184,7 @@ def slowcontrol_plots():
         datehigh = default_datehigh
     if datelow > datehigh:
         datelow, datehigh = datehigh, datelow
-    slow_data, adj_datelow, adj_datehigh = slowcontrol_data.get_plot_data(datelow, datehigh)
+    slow_data, dataName, adj_datelow, adj_datehigh = slowcontrol_data.get_plot_data_http(datelow, datehigh)
     #rs_plot_data, drop_down_crits, adj_datelow, adj_datehigh = RSTools.pass_fail_plot_info(criteria, date_range)
     # datelow_str = adj_datelow.strftime("%Y-%m-%dT%H:%M")
     # datehigh_str = adj_datehigh.strftime("%Y-%m-%dT%H:%M")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ redis==2.10.5
 argparse==1.2.1
 sphinx==1.8.6
 requests==2.6.0
+grequests==0.7.0
 python-dateutil==2.5.3
 sqlalchemy==1.0.12
 psycopg2-binary==2.8.6


### PR DESCRIPTION
Implement a new page on Minard to plot historical slow controls data.

## Features
* Plots both rack power supply voltages and crate trigger baseline voltages over arbitrary periods of time.
* Plots implemented using MetricsGraphics, based on the run selection plot page.
* Expected baselines are shown alongside each line on the plot (eg. 24V or -8V).
* Multiple datastreams can be plotted simultaneously and compared. Lines can be added or removed one by one.
* Time and voltage axes can be zoomed in or out by clicking on the plot or using the Plot Controls panel. The plot can be moused over to read specific values for each datastream at each point.
* Data requests have been heavily optimized thanks to [database restructuring on CouchDB](https://github.com/snoplus/rat-tools/pull/298/) and multithreading (using grequests)

## Code changes
### New files
* `slowcontrol_plots.html`: The slow control plotting web page. Written using the run selection page layout/logic as a starting point.
* `slowcontrol_plots.js`: Extra JS logic for the slow control plotting page (bulkier functions that don't make sense to keep in a `<script>` in the HTML).
* `slowcontrol_data.py`: Communicates with the snoplus CouchDB server over HTTP (using grequests to multithread chunks of the request) to request data, then package it to pass back to the webpage. **This file holds the bulk of the actual logic and is commented throughout.**

### Changed files
* `layout.html`: Adds the slowcontrol plot page to the **Polling** dropdown in the navbar.
* `views.py`: Accepts a request from the webpage and returns data once ready.
* `gitignore.txt`: Adds ignore rules for some scripts on vminard for convenience. Change is not neccesary.
* `requirements.txt`: Adds `grequests==0.7.0`. Library is required for multithreaded HTTP requests to CouchDB.

Requirements:
* New python package `grequests==0.7.0`.

Screenshot:
| ![image](https://github.com/user-attachments/assets/5bafe01a-dd01-4e31-9511-2e39b8538b8c) |
|:--:|
| *An example plot for the first half of 2024. Shows Rack 6 was offline for slightly over a week in late February while Rack 3 (the orange signal) was mostly online, and that all racks went offline for a few days in March.* |

Concerns:
* This page uses the environment variables `COUCH_USER` and `COUCH_PASS` (specifically on Line 12 of `slowcontrol_data.py`). I'm not sure if the minard configuration has these environment variables set.
* The page loads (for several minutes in larger requests) while waiting for the CouchDB request to complete. This may be difficult to refactor due to the Flask backend but is a possible improvement moving forward.