### PR TITLE
Stacked and Incremental Run Selection Plots

### DIFF
--- a/minard/RSTools.py
+++ b/minard/RSTools.py
@@ -1118,7 +1118,7 @@ def get_RS_reports_date_range(criteria=None, run_max=None, min_date=None, max_da
             else:
                 tempt_dict['run_duration'] = 'No Data'
             tempt_dict['run_number'] = row[1]
-            tempt_dict['timestamp'] = row[2]
+            tempt_dict['timestamp'] = row[2].strftime('%Y-%m-%d %H:%M:%S')
             rs_tables_list.append(tempt_dict)
         if len(rs_tables_list) == 0:
             return OrderedDict()

--- a/minard/RSTools.py
+++ b/minard/RSTools.py
@@ -950,18 +950,10 @@ def format_data(runNum):
 def pass_fail_plot_info(criteria, date_range):
     ''' calculates the cumulative number of days of physics, passed, failed and purgatory runs 
         based on input criteria and date range '''
-    # list of values we want to plot
-    data = []
-    phys = 0
-    physrun = 0
-    passed = 0
-    passrun = 0
-    failed = 0
-    failrun = 0
-    purg = 0
-    purgrun = 0
+
     # Get list of criteria to put in drop-down menu (in order)
     drop_down_crits = app.config['DROP_DOWN_MENU_CRITS']
+
     # Get date limits
     min_runTime = None
     max_runTime = None
@@ -975,63 +967,93 @@ def pass_fail_plot_info(criteria, date_range):
         max_runTime = min(max_runTime, datetime.datetime.now())
     else:
         return False, drop_down_crits, min_runTime, None
-    # download physics runs in given date range - do this 1000 runs at a time until all the runs in the date range have been downloaded
-    min_dl_time = max_runTime  # the minimum time that has been dowloaded to compare with the minimum time we want to download
-    final_run_num = None
-    attempt = 1
-    while min_dl_time > min_runTime:
-        rs_tables = get_RS_reports_date_range(criteria=criteria, run_max=final_run_num)
-        if rs_tables is False:
-            return False, drop_down_crits, min_runTime, max_runTime
-        # Loop through RS tables and sum up the cumulative number of days of each result
-        for run_number in rs_tables.keys():
-            # check run duration was found and if it was convert into days, skip if not
-            if rs_tables[run_number][criteria]['run_duration'] == 'No Data':
-                continue
-            # Get run time and put into specific format
-            run_start_time = str(rs_tables[run_number][criteria]['run_start']).replace(' ', 'T')
-            # get the run date to apply date range to
-            run_start_lst = rs_tables[run_number][criteria]['run_start'].split(' ')[0].split('-')
-            run_start_date = datetime.datetime(int(run_start_lst[0]), int(run_start_lst[1]), int(run_start_lst[2]), 0, 0)
-            # if no date conditions were given, skip the filter
-            if not min_runTime is None:
-                if run_start_date < min_runTime:
-                    continue
-            if not max_runTime is None:
-                if run_start_date > max_runTime:
-                    continue
-            run_length = rs_tables[run_number][criteria]['run_duration']/(60**2*24)
-            # get result (pass=True, fail=False, purgatory=None)
-            result = rs_tables[run_number][criteria]['result']
-            # add number of days to cumulative sum
-            phys += run_length
-            physrun += 1
+
+    # Create hourly buckets for the entire time range
+    num_hours = int((max_runTime - min_runTime).total_seconds() / 3600) + 1
+    data = []
+    for i in range(num_hours):
+        hour_start = min_runTime + datetime.timedelta(hours=i)
+        data.append({
+            'timestamp': hour_start.isoformat(),
+            'pass_time': 0.0,  # hours spent in passing state
+            'fail_time': 0.0,  # hours spent in failing state
+            'purg_time': 0.0,  # hours spent in purgatory state
+            'idle_time': 1.0   # hours with no run (default to full hour)
+        })
+
+    # Download physics runs in given date range
+    rstables = get_RS_reports_date_range(criteria=criteria)
+    if rstables is False:
+        return False, drop_down_crits, min_runTime, max_runTime
+
+    # Process each run and allocate its time to the appropriate hourly buckets
+    for run_number in rstables.keys():
+        if rstables[run_number][criteria]['run_duration'] == 'No Data':
+            continue
+        if rstables[run_number][criteria]['run_start'] == 'No Data':
+            continue
+
+        # Parse run start time
+        run_start_str = rstables[run_number][criteria]['run_start']
+        try:
+            # Handle both formats: with and without microseconds
+            if '.' in run_start_str:
+                run_start = datetime.datetime.strptime(run_start_str, '%Y-%m-%d %H:%M:%S.%f')
+            else:
+                run_start = datetime.datetime.strptime(run_start_str, '%Y-%m-%d %H:%M:%S')
+        except:
+            continue
+
+        # Get run duration in seconds
+        run_duration_seconds = rstables[run_number][criteria]['run_duration']
+        run_end = run_start + datetime.timedelta(seconds=run_duration_seconds)
+
+        # Skip runs outside our time range
+        if run_end < min_runTime or run_start > max_runTime:
+            continue
+
+        # Clip run to our time range
+        run_start_clipped = max(run_start, min_runTime)
+        run_end_clipped = min(run_end, max_runTime)
+
+        # Get result (pass=True, fail=False, purgatory=None)
+        result = rstables[run_number][criteria]['result']
+
+        # Distribute run time across the hours it spans
+        current_time = run_start_clipped
+        while current_time < run_end_clipped:
+            # Find which hour bucket this time falls into
+            hours_from_start = (current_time - min_runTime).total_seconds() / 3600
+            hour_index = int(hours_from_start)
+            
+            if hour_index >= len(data):
+                break
+
+            # Calculate how much of this hour the run occupies
+            hour_start = min_runTime + datetime.timedelta(hours=hour_index)
+            hour_end = hour_start + datetime.timedelta(hours=1)
+            
+            segment_start = max(current_time, hour_start)
+            segment_end = min(run_end_clipped, hour_end)
+            segment_duration_hours = (segment_end - segment_start).total_seconds() / 3600
+
+            # Add to appropriate category and subtract from idle
             if result == True:
-                passed += run_length
-                passrun += 1
-            if result == False:
-                failed += run_length
-                failrun += 1
-            if result == None:
-                purg += run_length
-                purgrun += 1
-            rs_result = {}
-            rs_result['timestamp'] = run_start_time
-            rs_result['phys_total'] = phys
-            rs_result['phys_runs'] = physrun
-            rs_result['pass_total'] = passed
-            rs_result['pass_runs'] = passrun
-            rs_result['fail_total'] = failed
-            rs_result['fail_runs'] = failrun
-            rs_result['purg_total'] = purg
-            rs_result['purg_runs'] = purgrun
-            data.append(rs_result)
-        # get final run number and date of final run to check if more runs need to be downloaded
-        len_rs_tables = len(rs_tables)
-        final_run_num = rs_tables.keys()[len_rs_tables-1]
-        last_run_start = rs_tables[final_run_num][criteria]['run_start'].split(' ')[0].split('-')
-        min_dl_time = datetime.datetime(int(last_run_start[0]), int(last_run_start[1]), int(last_run_start[2]), 0, 0)
-        attempt += 1
+                data[hour_index]['pass_time'] += segment_duration_hours
+            elif result == False:
+                data[hour_index]['fail_time'] += segment_duration_hours
+            else:  # None = purgatory
+                data[hour_index]['purg_time'] += segment_duration_hours
+            
+            data[hour_index]['idle_time'] -= segment_duration_hours
+
+            # Move to next hour
+            current_time = hour_end
+
+    # Ensure idle_time doesn't go negative due to overlapping runs
+    for hour_data in data:
+        hour_data['idle_time'] = max(0.0, hour_data['idle_time'])
+
     return data, drop_down_crits, min_runTime, max_runTime
 
 def get_RS_reports_date_range(criteria=None, run_max=None):

--- a/minard/RSTools.py
+++ b/minard/RSTools.py
@@ -1118,7 +1118,7 @@ def get_RS_reports_date_range(criteria=None, run_max=None, min_date=None, max_da
             else:
                 tempt_dict['run_duration'] = 'No Data'
             tempt_dict['run_number'] = row[1]
-            tempt_dict['timestamp'] = row[2].strftime('%Y-%m-%d %H:%M:%S')
+            tempt_dict['timestamp'] = row[2]
             rs_tables_list.append(tempt_dict)
         if len(rs_tables_list) == 0:
             return OrderedDict()

--- a/minard/RSTools.py
+++ b/minard/RSTools.py
@@ -986,6 +986,14 @@ def pass_fail_plot_info(criteria, date_range):
     if rstables is False:
         return False, drop_down_crits, min_runTime, max_runTime
 
+    # Track run counts
+    run_counts = {
+        'pass_runs': 0,
+        'fail_runs': 0,
+        'purg_runs': 0,
+        'phys_runs': 0
+    }
+
     # Process each run and allocate its time to the appropriate hourly buckets
     for run_number in rstables.keys():
         if rstables[run_number][criteria]['run_duration'] == 'No Data':
@@ -1018,6 +1026,15 @@ def pass_fail_plot_info(criteria, date_range):
 
         # Get result (pass=True, fail=False, purgatory=None)
         result = rstables[run_number][criteria]['result']
+
+        # Count this run
+        run_counts['phys_runs'] += 1
+        if result == True:
+            run_counts['pass_runs'] += 1
+        elif result == False:
+            run_counts['fail_runs'] += 1
+        else:  # None = purgatory
+            run_counts['purg_runs'] += 1
 
         # Distribute run time across the hours it spans
         current_time = run_start_clipped
@@ -1054,7 +1071,13 @@ def pass_fail_plot_info(criteria, date_range):
     for hour_data in data:
         hour_data['idle_time'] = max(0.0, hour_data['idle_time'])
 
-    return data, drop_down_crits, min_runTime, max_runTime
+    # Add run counts to the data structure
+    summary = {
+        'data': data,
+        'run_counts': run_counts
+    }
+
+    return summary, drop_down_crits, min_runTime, max_runTime
 
 def get_RS_reports_date_range(criteria=None, run_max=None):
     '''Get run-selection tables in a run range. If duplicate tables, only keeps one

--- a/minard/templates/runselection.html
+++ b/minard/templates/runselection.html
@@ -256,7 +256,7 @@
                                 {% set det = run_info[run_number]["summary"] %}
                                 <td>{{ det["name"] }}</td>
                                 <td>{{ det["run_start"] }}</td>
-                                <td>{{ det["timestamp"] }}</td>
+                                <td>{{ det["timestamp"].strftime('%Y-%m-%d %H:%M:%S') if det["timestamp"] != 'No Data' else 'No Data' }}</td>
                             </tr> 
                         {% endfor %}
                     {% endif %}

--- a/minard/templates/runselection_plots.html
+++ b/minard/templates/runselection_plots.html
@@ -174,6 +174,11 @@
         var total_purg = cumulative_purg;
         var total_phys = total_pass + total_fail + total_purg;
 
+        var pass_incremental_minutes = pass_incremental.map(x => x * 60)
+        var fail_incremental_minutes = fail_incremental.map(x => x * 60)
+        var purg_incremental_minutes = purg_incremental.map(x => x * 60)
+
+
         document.getElementById("phys_summary").innerHTML = 'Physics: ' + total_phys.toFixed(2) + ' Hours, ' + run_counts.phys_runs + ' Runs';
         document.getElementById("pass_summary").innerHTML = 'Passed: ' + total_pass.toFixed(2) + ' Hours, ' + run_counts.pass_runs + ' Runs';
         document.getElementById("fail_summary").innerHTML = 'Failed: ' + total_fail.toFixed(2) + ' Hours, ' + run_counts.fail_runs + ' Runs';
@@ -276,7 +281,7 @@
                 datasets: [
                     {
                         label: 'Passed',
-                        data: pass_incremental,
+                        data: pass_incremental_minutes,
                         backgroundColor: 'rgba(54, 162, 235, 0.5)',
                         borderColor: 'rgb(54, 162, 235)',
                         borderWidth: 1,
@@ -286,7 +291,7 @@
                     },
                     {
                         label: 'Failed',
-                        data: fail_incremental,
+                        data: fail_incremental_minutes,
                         backgroundColor: 'rgba(255, 99, 132, 0.5)',
                         borderColor: 'rgb(255, 99, 132)',
                         borderWidth: 1,
@@ -296,7 +301,7 @@
                     },
                     {
                         label: 'Purgatory',
-                        data: purg_incremental,
+                        data: purg_incremental_minutes,
                         backgroundColor: 'rgba(255, 206, 86, 0.5)',
                         borderColor: 'rgb(255, 206, 86)',
                         borderWidth: 1,
@@ -326,7 +331,7 @@
                         intersect: false,
                         callbacks: {
                             label: function(ctx) {
-                                return ctx.dataset.label + ': ' + Number(ctx.parsed.y).toFixed(3) + ' hours';
+                                return ctx.dataset.label + ': ' + Number(ctx.parsed.y).toFixed(3) + ' minutes';
                             }
                         }
                     }
@@ -340,7 +345,7 @@
                     y: { 
                         stacked: true,
                         beginAtZero: true,
-                        max: 1.0,
+                        max: 60.0,
                         title: { display: true, text: 'Incremental Datahours', font: { size: 14 } }, 
                         ticks: { 
                             font: { size: 12 }, 

--- a/minard/templates/runselection_plots.html
+++ b/minard/templates/runselection_plots.html
@@ -130,22 +130,31 @@
         var purg_incremental = [];
         var idle_incremental = [];
 
+        // Extract hourly data and run counts
+        var hourly_data = rs_plot_data.data || rs_plot_data;
+        var run_counts = rs_plot_data.run_counts || {
+            pass_runs: 0,
+            fail_runs: 0,
+            purg_runs: 0,
+            phys_runs: 0
+        };
+
         // Process hourly data to build cumulative and incremental arrays
         var cumulative_pass = 0;
         var cumulative_fail = 0;
         var cumulative_purg = 0;
         var cumulative_idle = 0;
 
-        for (var i = 0; i < rs_plot_data.length; i++)
+        for (var i = 0; i < hourly_data.length; i++)
         {
-            var date_ = moment(rs_plot_data[i]['timestamp']).toDate();
+            var date_ = moment(hourly_data[i]['timestamp']).toDate();
             dates.push(date_);
             
             // Get incremental values (hours in this specific hour)
-            var pass_inc = rs_plot_data[i]['pass_time'] || 0;
-            var fail_inc = rs_plot_data[i]['fail_time'] || 0;
-            var purg_inc = rs_plot_data[i]['purg_time'] || 0;
-            var idle_inc = rs_plot_data[i]['idle_time'] || 0;
+            var pass_inc = hourly_data[i]['pass_time'] || 0;
+            var fail_inc = hourly_data[i]['fail_time'] || 0;
+            var purg_inc = hourly_data[i]['purg_time'] || 0;
+            var idle_inc = hourly_data[i]['idle_time'] || 0;
             
             pass_incremental.push(pass_inc);
             fail_incremental.push(fail_inc);
@@ -164,17 +173,17 @@
             idle_cumulative.push(cumulative_idle);
         }
 
-        // Summary - use final cumulative values
+        // Summary - use final cumulative values and run counts
         var total_pass = cumulative_pass;
         var total_fail = cumulative_fail;
         var total_purg = cumulative_purg;
         var total_idle = cumulative_idle;
         var total_phys = total_pass + total_fail + total_purg;
 
-        document.getElementById("phys_summary").innerHTML = 'Physics: ' + total_phys.toFixed(2) + ' Hours';
-        document.getElementById("pass_summary").innerHTML = 'Passed: ' + total_pass.toFixed(2) + ' Hours';
-        document.getElementById("fail_summary").innerHTML = 'Failed: ' + total_fail.toFixed(2) + ' Hours';
-        document.getElementById("purg_summary").innerHTML = 'Purgatory: ' + total_purg.toFixed(2) + ' Hours';
+        document.getElementById("phys_summary").innerHTML = 'Physics: ' + total_phys.toFixed(2) + ' Hours, ' + run_counts.phys_runs + ' Runs';
+        document.getElementById("pass_summary").innerHTML = 'Passed: ' + total_pass.toFixed(2) + ' Hours, ' + run_counts.pass_runs + ' Runs';
+        document.getElementById("fail_summary").innerHTML = 'Failed: ' + total_fail.toFixed(2) + ' Hours, ' + run_counts.fail_runs + ' Runs';
+        document.getElementById("purg_summary").innerHTML = 'Purgatory: ' + total_purg.toFixed(2) + ' Hours, ' + run_counts.purg_runs + ' Runs';
 
         // Stacked Filled Area Line Plot using Chart.js
         var ctx = document.getElementById('RunSelectionPlot').getContext('2d');

--- a/minard/templates/runselection_plots.html
+++ b/minard/templates/runselection_plots.html
@@ -174,11 +174,6 @@
         var total_purg = cumulative_purg;
         var total_phys = total_pass + total_fail + total_purg;
 
-        var pass_incremental_minutes = pass_incremental.map(x => x * 60)
-        var fail_incremental_minutes = fail_incremental.map(x => x * 60)
-        var purg_incremental_minutes = purg_incremental.map(x => x * 60)
-
-
         document.getElementById("phys_summary").innerHTML = 'Physics: ' + total_phys.toFixed(2) + ' Hours, ' + run_counts.phys_runs + ' Runs';
         document.getElementById("pass_summary").innerHTML = 'Passed: ' + total_pass.toFixed(2) + ' Hours, ' + run_counts.pass_runs + ' Runs';
         document.getElementById("fail_summary").innerHTML = 'Failed: ' + total_fail.toFixed(2) + ' Hours, ' + run_counts.fail_runs + ' Runs';
@@ -281,7 +276,7 @@
                 datasets: [
                     {
                         label: 'Passed',
-                        data: pass_incremental_minutes,
+                        data: pass_incremental,
                         backgroundColor: 'rgba(54, 162, 235, 0.5)',
                         borderColor: 'rgb(54, 162, 235)',
                         borderWidth: 1,
@@ -291,7 +286,7 @@
                     },
                     {
                         label: 'Failed',
-                        data: fail_incremental_minutes,
+                        data: fail_incremental,
                         backgroundColor: 'rgba(255, 99, 132, 0.5)',
                         borderColor: 'rgb(255, 99, 132)',
                         borderWidth: 1,
@@ -301,7 +296,7 @@
                     },
                     {
                         label: 'Purgatory',
-                        data: purg_incremental_minutes,
+                        data: purg_incremental,
                         backgroundColor: 'rgba(255, 206, 86, 0.5)',
                         borderColor: 'rgb(255, 206, 86)',
                         borderWidth: 1,
@@ -331,7 +326,7 @@
                         intersect: false,
                         callbacks: {
                             label: function(ctx) {
-                                return ctx.dataset.label + ': ' + Number(ctx.parsed.y).toFixed(3) + ' minutes';
+                                return ctx.dataset.label + ': ' + Number(ctx.parsed.y).toFixed(3) + ' hours';
                             }
                         }
                     }
@@ -345,7 +340,7 @@
                     y: { 
                         stacked: true,
                         beginAtZero: true,
-                        max: 60.0,
+                        max: 1.0,
                         title: { display: true, text: 'Incremental Datahours', font: { size: 14 } }, 
                         ticks: { 
                             font: { size: 12 }, 

--- a/minard/templates/runselection_plots.html
+++ b/minard/templates/runselection_plots.html
@@ -120,87 +120,61 @@
         var rs_plot_data = {{ rs_plot_data | safe }};
 
         var dates = [];
-        var phys = [];
-        var pass = [];
-        var fail = [];
-        var purg = [];
+        var pass_cumulative = [];
+        var fail_cumulative = [];
+        var purg_cumulative = [];
+        var idle_cumulative = [];
+        
+        var pass_incremental = [];
+        var fail_incremental = [];
+        var purg_incremental = [];
+        var idle_incremental = [];
 
-        // Track last known values for flat-lining when data is missing
-        var lastPhys = null;
-        var lastPass = null;
-        var lastFail = null;
-        var lastPurg = null;
+        // Process hourly data to build cumulative and incremental arrays
+        var cumulative_pass = 0;
+        var cumulative_fail = 0;
+        var cumulative_purg = 0;
+        var cumulative_idle = 0;
 
-        // Iterate backwards so oldest dates are first (left) and newest last (right)
-        for (var i = rs_plot_data.length - 1; i >= 0; i--)
+        for (var i = 0; i < rs_plot_data.length; i++)
         {
             var date_ = moment(rs_plot_data[i]['timestamp']).toDate();
             dates.push(date_);
             
-            // Calculate current values
-            var physVal = rs_plot_data[rs_plot_data.length - 1]['phys_total'] - rs_plot_data[i]['phys_total'];
-            var passVal = rs_plot_data[rs_plot_data.length - 1]['pass_total'] - rs_plot_data[i]['pass_total'];
-            var failVal = rs_plot_data[rs_plot_data.length - 1]['fail_total'] - rs_plot_data[i]['fail_total'];
-            var purgVal = rs_plot_data[rs_plot_data.length - 1]['purg_total'] - rs_plot_data[i]['purg_total'];
+            // Get incremental values (hours in this specific hour)
+            var pass_inc = rs_plot_data[i]['pass_time'] || 0;
+            var fail_inc = rs_plot_data[i]['fail_time'] || 0;
+            var purg_inc = rs_plot_data[i]['purg_time'] || 0;
+            var idle_inc = rs_plot_data[i]['idle_time'] || 0;
             
-            // Convert from days to hours
-            physVal = physVal * 24;
-            passVal = passVal * 24;
-            failVal = failVal * 24;
-            purgVal = purgVal * 24;
+            pass_incremental.push(pass_inc);
+            fail_incremental.push(fail_inc);
+            purg_incremental.push(purg_inc);
+            idle_incremental.push(idle_inc);
             
-            // If value is null/undefined/NaN, use last known value (flat line)
-            if (physVal == null || isNaN(physVal)) {
-                physVal = lastPhys != null ? lastPhys : 0;
-            } else {
-                lastPhys = physVal;
-            }
+            // Build cumulative values
+            cumulative_pass += pass_inc;
+            cumulative_fail += fail_inc;
+            cumulative_purg += purg_inc;
+            cumulative_idle += idle_inc;
             
-            if (passVal == null || isNaN(passVal)) {
-                passVal = lastPass != null ? lastPass : 0;
-            } else {
-                lastPass = passVal;
-            }
-            
-            if (failVal == null || isNaN(failVal)) {
-                failVal = lastFail != null ? lastFail : 0;
-            } else {
-                lastFail = failVal;
-            }
-            
-            if (purgVal == null || isNaN(purgVal)) {
-                purgVal = lastPurg != null ? lastPurg : 0;
-            } else {
-                lastPurg = purgVal;
-            }
-            
-            phys.push(physVal);
-            pass.push(passVal);
-            fail.push(failVal);
-            purg.push(purgVal);
+            pass_cumulative.push(cumulative_pass);
+            fail_cumulative.push(cumulative_fail);
+            purg_cumulative.push(cumulative_purg);
+            idle_cumulative.push(cumulative_idle);
         }
 
-        // Summary
-        var summaryTime = [
-            rs_plot_data[rs_plot_data.length - 1]['phys_total'] * 24,
-            rs_plot_data[rs_plot_data.length - 1]['pass_total'] * 24,
-            rs_plot_data[rs_plot_data.length - 1]['fail_total'] * 24,
-            rs_plot_data[rs_plot_data.length - 1]['purg_total'] * 24
-        ];
-        var summaryRuns = [
-            rs_plot_data[rs_plot_data.length - 1]['phys_runs'],
-            rs_plot_data[rs_plot_data.length - 1]['pass_runs'],
-            rs_plot_data[rs_plot_data.length - 1]['fail_runs'],
-            rs_plot_data[rs_plot_data.length - 1]['purg_runs']
-        ];
-        for (var i=0; i < summaryTime.length; i++)
-	    {
-		    summaryTime[i] = parseFloat(summaryTime[i]).toFixed(3);
-	    }
-        document.getElementById("phys_summary").innerHTML = 'Physics: ' + summaryTime[0].toString() + ' Hours, ' +summaryRuns[0].toString() + ' Runs';
-        document.getElementById("pass_summary").innerHTML = 'Passed: ' + summaryTime[1].toString() + ' Hours, ' +summaryRuns[1].toString() + ' Runs';
-        document.getElementById("fail_summary").innerHTML = 'Failed: ' + summaryTime[2].toString() + ' Hours, ' +summaryRuns[2].toString() + ' Runs';
-        document.getElementById("purg_summary").innerHTML = 'Purgatory: ' + summaryTime[3].toString()  + ' Hours, ' +summaryRuns[3].toString() + ' Runs';
+        // Summary - use final cumulative values
+        var total_pass = cumulative_pass;
+        var total_fail = cumulative_fail;
+        var total_purg = cumulative_purg;
+        var total_idle = cumulative_idle;
+        var total_phys = total_pass + total_fail + total_purg;
+
+        document.getElementById("phys_summary").innerHTML = 'Physics: ' + total_phys.toFixed(2) + ' Hours';
+        document.getElementById("pass_summary").innerHTML = 'Passed: ' + total_pass.toFixed(2) + ' Hours';
+        document.getElementById("fail_summary").innerHTML = 'Failed: ' + total_fail.toFixed(2) + ' Hours';
+        document.getElementById("purg_summary").innerHTML = 'Purgatory: ' + total_purg.toFixed(2) + ' Hours';
 
         // Stacked Filled Area Line Plot using Chart.js
         var ctx = document.getElementById('RunSelectionPlot').getContext('2d');
@@ -211,7 +185,7 @@
                 datasets: [
                     {
                         label: 'Passed',
-                        data: pass,
+                        data: pass_cumulative,
                         borderColor: 'rgb(54, 162, 235)',
                         backgroundColor: 'rgba(54, 162, 235, 0.5)',
                         borderWidth: 2,
@@ -221,7 +195,7 @@
                     },
                     {
                         label: 'Failed',
-                        data: fail,
+                        data: fail_cumulative,
                         borderColor: 'rgb(255, 99, 132)',
                         backgroundColor: 'rgba(255, 99, 132, 0.5)',
                         borderWidth: 2,
@@ -231,7 +205,7 @@
                     },
                     {
                         label: 'Purgatory',
-                        data: purg,
+                        data: purg_cumulative,
                         borderColor: 'rgb(255, 206, 86)',
                         backgroundColor: 'rgba(255, 206, 86, 0.5)',
                         borderWidth: 2,
@@ -264,7 +238,7 @@
                         intersect: false,
                         callbacks: {
                             label: function(ctx) {
-                                return ctx.dataset.label + ': ' + Number(ctx.parsed.y).toFixed(2) + ' (hours)';
+                                return ctx.dataset.label + ': ' + Number(ctx.parsed.y).toFixed(2) + ' hours';
                             }
                         }
                     }
@@ -285,45 +259,21 @@
                     },
                     x: {
                         display: false
-                        // stacked: true,
-                        // title: { display: true, text: 'Date', font: { size: 14 } },
-                        // ticks: { maxRotation: 45, minRotation: 45, font: { size: 11 } }
                     }
                 }
             }
         });
 
         // Differential (time per interval) chart
-        var ddates = [];
-        var dpass = [];
-        var dfail = [];
-        var dpurg = [];
-
-        for (var i = rs_plot_data.length - 2; i >= 0; i--)
-        {
-            var date_ = moment(rs_plot_data[i]['timestamp']).toDate();
-            ddates.push(date_);
-
-            // Calculate delta in days (time added between this timestamp and next)
-            // Since we iterate backwards, rs_plot_data[i] is older, so subtract next from current
-            var dpassVal = (rs_plot_data[i + 1]['pass_total'] - rs_plot_data[i]['pass_total']) * 24;
-            var dfailVal = (rs_plot_data[i + 1]['fail_total'] - rs_plot_data[i]['fail_total']) * 24;
-            var dpurgVal = (rs_plot_data[i + 1]['purg_total'] - rs_plot_data[i]['purg_total']) * 24;
-
-            dpass.push(dpassVal || 0);
-            dfail.push(dfailVal || 0);
-            dpurg.push(dpurgVal || 0);
-        }
-
         var ctx2 = document.getElementById('RunSelectionDiffPlot').getContext('2d');
         var diffChart = new Chart(ctx2, {
             type: 'bar',
             data: {
-                labels: ddates.map(d => moment(d).format('MM-DD HH:mm')),
+                labels: dates.map(d => moment(d).format('MM-DD HH:mm')),
                 datasets: [
                     {
                         label: 'Passed',
-                        data: dpass,
+                        data: pass_incremental,
                         backgroundColor: 'rgba(54, 162, 235, 0.5)',
                         borderColor: 'rgb(54, 162, 235)',
                         borderWidth: 1,
@@ -331,7 +281,7 @@
                     },
                     {
                         label: 'Failed',
-                        data: dfail,
+                        data: fail_incremental,
                         backgroundColor: 'rgba(255, 99, 132, 0.5)',
                         borderColor: 'rgb(255, 99, 132)',
                         borderWidth: 1,
@@ -339,9 +289,17 @@
                     },
                     {
                         label: 'Purgatory',
-                        data: dpurg,
+                        data: purg_incremental,
                         backgroundColor: 'rgba(255, 206, 86, 0.5)',
                         borderColor: 'rgb(255, 206, 86)',
+                        borderWidth: 1,
+                        stack: 'runs'
+                    },
+                    {
+                        label: 'Idle',
+                        data: idle_incremental,
+                        backgroundColor: 'rgba(200, 200, 200, 0.3)',
+                        borderColor: 'rgb(150, 150, 150)',
                         borderWidth: 1,
                         stack: 'runs'
                     }
@@ -358,14 +316,16 @@
                 interaction: { mode: 'index', intersect: false },
                 plugins: {
                     legend: {
-                        display: false
+                        display: true,
+                        position: 'top',
+                        labels: { font: { size: 14, weight: 'bold'}}
                     },
                     tooltip: {
                         mode: 'index',
                         intersect: false,
                         callbacks: {
                             label: function(ctx) {
-                                return ctx.dataset.label + ': ' + Number(ctx.parsed.y).toFixed(2) + ' hours';
+                                return ctx.dataset.label + ': ' + Number(ctx.parsed.y).toFixed(3) + ' hours';
                             }
                         }
                     }
@@ -381,7 +341,11 @@
                         beginAtZero: true,
                         max: 1.0,
                         title: { display: true, text: 'Incremental Datahours', font: { size: 14 } }, 
-                        ticks: { font: { size: 12 }, padding: 5 },
+                        ticks: { 
+                            font: { size: 12 }, 
+                            padding: 5,
+                            callback: function(v) { return Number(v).toFixed(2); }
+                        },
                         afterFit: function(scaleInstance) {
                             scaleInstance.width = 100;
                         }

--- a/minard/templates/runselection_plots.html
+++ b/minard/templates/runselection_plots.html
@@ -143,7 +143,6 @@
         var cumulative_pass = 0;
         var cumulative_fail = 0;
         var cumulative_purg = 0;
-        var cumulative_idle = 0;
 
         for (var i = 0; i < hourly_data.length; i++)
         {
@@ -154,30 +153,25 @@
             var pass_inc = hourly_data[i]['pass_time'] || 0;
             var fail_inc = hourly_data[i]['fail_time'] || 0;
             var purg_inc = hourly_data[i]['purg_time'] || 0;
-            var idle_inc = hourly_data[i]['idle_time'] || 0;
             
             pass_incremental.push(pass_inc);
             fail_incremental.push(fail_inc);
             purg_incremental.push(purg_inc);
-            idle_incremental.push(idle_inc);
             
             // Build cumulative values
             cumulative_pass += pass_inc;
             cumulative_fail += fail_inc;
             cumulative_purg += purg_inc;
-            cumulative_idle += idle_inc;
             
             pass_cumulative.push(cumulative_pass);
             fail_cumulative.push(cumulative_fail);
             purg_cumulative.push(cumulative_purg);
-            idle_cumulative.push(cumulative_idle);
         }
 
         // Summary - use final cumulative values and run counts
         var total_pass = cumulative_pass;
         var total_fail = cumulative_fail;
         var total_purg = cumulative_purg;
-        var total_idle = cumulative_idle;
         var total_phys = total_pass + total_fail + total_purg;
 
         document.getElementById("phys_summary").innerHTML = 'Physics: ' + total_phys.toFixed(2) + ' Hours, ' + run_counts.phys_runs + ' Runs';
@@ -286,7 +280,9 @@
                         backgroundColor: 'rgba(54, 162, 235, 0.5)',
                         borderColor: 'rgb(54, 162, 235)',
                         borderWidth: 1,
-                        stack: 'runs'
+                        barPercentage: 1.0,
+                        categoryPercentage: 1.0,
+                        stack: 'stack0'
                     },
                     {
                         label: 'Failed',
@@ -294,7 +290,9 @@
                         backgroundColor: 'rgba(255, 99, 132, 0.5)',
                         borderColor: 'rgb(255, 99, 132)',
                         borderWidth: 1,
-                        stack: 'runs'
+                        barPercentage: 1.0,
+                        categoryPercentage: 1.0,
+                        stack: 'stack0'
                     },
                     {
                         label: 'Purgatory',
@@ -302,15 +300,9 @@
                         backgroundColor: 'rgba(255, 206, 86, 0.5)',
                         borderColor: 'rgb(255, 206, 86)',
                         borderWidth: 1,
-                        stack: 'runs'
-                    },
-                    {
-                        label: 'Idle',
-                        data: idle_incremental,
-                        backgroundColor: 'rgba(200, 200, 200, 0.3)',
-                        borderColor: 'rgb(150, 150, 150)',
-                        borderWidth: 1,
-                        stack: 'runs'
+                        barPercentage: 1.0,
+                        categoryPercentage: 1.0,
+                        stack: 'stack0'
                     }
                 ]
             },
@@ -325,7 +317,7 @@
                 interaction: { mode: 'index', intersect: false },
                 plugins: {
                     legend: {
-                        display: true,
+                        display: false,
                         position: 'top',
                         labels: { font: { size: 14, weight: 'bold'}}
                     },
@@ -341,12 +333,12 @@
                 },
                 scales: {
                     x: { 
-                        stacked: true, 
+                        stacked: true,
                         title: { display: true, text: 'Date', font: { size: 14 } }, 
                         ticks: { maxRotation: 45, minRotation: 45, font: { size: 11 } } 
                     },
                     y: { 
-                        stacked: true, 
+                        stacked: true,
                         beginAtZero: true,
                         max: 1.0,
                         title: { display: true, text: 'Incremental Datahours', font: { size: 14 } }, 

--- a/minard/templates/runselection_plots.html
+++ b/minard/templates/runselection_plots.html
@@ -123,12 +123,10 @@
         var pass_cumulative = [];
         var fail_cumulative = [];
         var purg_cumulative = [];
-        var idle_cumulative = [];
         
         var pass_incremental = [];
         var fail_incremental = [];
         var purg_incremental = [];
-        var idle_incremental = [];
 
         // Extract hourly data and run counts
         var hourly_data = rs_plot_data.data || rs_plot_data;
@@ -167,6 +165,11 @@
             fail_cumulative.push(cumulative_fail);
             purg_cumulative.push(cumulative_purg);
         }
+
+        // Convert incremental hours to minutes for ease of understanding
+        var pass_incremental_minutes = pass_incremental.map(v => v * 60)
+        var fail_incremental_minutes = fail_incremental.map(v => v * 60)
+        var purg_incremental_minutes = purg_incremental.map(v => v * 60)
 
         // Summary - use final cumulative values and run counts
         var total_pass = cumulative_pass;
@@ -276,7 +279,7 @@
                 datasets: [
                     {
                         label: 'Passed',
-                        data: pass_incremental,
+                        data: pass_incremental_minutes,
                         backgroundColor: 'rgba(54, 162, 235, 0.5)',
                         borderColor: 'rgb(54, 162, 235)',
                         borderWidth: 1,
@@ -286,7 +289,7 @@
                     },
                     {
                         label: 'Failed',
-                        data: fail_incremental,
+                        data: fail_incremental_minutes,
                         backgroundColor: 'rgba(255, 99, 132, 0.5)',
                         borderColor: 'rgb(255, 99, 132)',
                         borderWidth: 1,
@@ -296,7 +299,7 @@
                     },
                     {
                         label: 'Purgatory',
-                        data: purg_incremental,
+                        data: purg_incremental_minutes,
                         backgroundColor: 'rgba(255, 206, 86, 0.5)',
                         borderColor: 'rgb(255, 206, 86)',
                         borderWidth: 1,
@@ -326,7 +329,7 @@
                         intersect: false,
                         callbacks: {
                             label: function(ctx) {
-                                return ctx.dataset.label + ': ' + Number(ctx.parsed.y).toFixed(3) + ' hours';
+                                return ctx.dataset.label + ': ' + Number(ctx.parsed.y).toFixed(3) + ' minutes';
                             }
                         }
                     }
@@ -340,7 +343,7 @@
                     y: { 
                         stacked: true,
                         beginAtZero: true,
-                        max: 1.0,
+                        max: 60.0,
                         title: { display: true, text: 'Incremental Datahours', font: { size: 14 } }, 
                         ticks: { 
                             font: { size: 12 }, 


### PR DESCRIPTION
Introduced a new incremental plot to the run selection plot page. This shows the status and progress of physic runs per criteria per hour. Also made the cumulative plot stacked and filled so that it is easier to parse. Note that this was accidently merged onto the main previously but the plot page changes were incomplete.

<img width="1177" height="1340" alt="image" src="https://github.com/user-attachments/assets/655a5629-447b-4286-8507-489fce5e1974" />
